### PR TITLE
fix: bcrypt 4.x非互換とHEADリクエスト405を修正

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -42,7 +42,7 @@ async def health_check():
     return {"status": "ok"}
 
 
-@app.get("/{full_path:path}")
+@app.api_route("/{full_path:path}", methods=["GET", "HEAD"])
 async def serve_frontend(full_path: str):
     if not os.path.exists(frontend_build_path):
         return {"error": "Frontend not built"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ pydantic-settings>=2.2.1
 python-multipart>=0.0.9
 python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
+bcrypt<4.0.0
 email-validator>=2.1.1
 psycopg2-binary>=2.9.9


### PR DESCRIPTION
- requirements.txt: bcrypt<4.0.0 を追加。bcrypt 4.x 以降と passlib の非互換（72バイト超パスワードでValueError）を解消。
- main.py: フロントエンド配信ルートをGETからGET/HEAD対応に変更。 Next.jsのプリフェッチ(HEAD)リクエストが405になる問題を解消。