### PR TITLE
fix: family_users.joined_at と schedules.created_at のDEFAULT不足を修正

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_fix_created_at_defaults.py
+++ b/alembic/versions/a1b2c3d4e5f6_fix_created_at_defaults.py
@@ -1,4 +1,4 @@
-"""Fix created_at column defaults
+"""Fix created_at/joined_at column defaults
 
 Revision ID: a1b2c3d4e5f6
 Revises: d91eb8885793
@@ -20,6 +20,8 @@ def upgrade() -> None:
     op.execute("ALTER TABLE users ALTER COLUMN created_at SET DEFAULT NOW()")
     op.execute("ALTER TABLE user_sessions ALTER COLUMN created_at SET DEFAULT NOW()")
     op.execute("ALTER TABLE babies ALTER COLUMN created_at SET DEFAULT NOW()")
+    op.execute("ALTER TABLE family_users ALTER COLUMN joined_at SET DEFAULT NOW()")
+    op.execute("ALTER TABLE schedules ALTER COLUMN created_at SET DEFAULT NOW()")
 
 
 def downgrade() -> None:
@@ -27,3 +29,5 @@ def downgrade() -> None:
     op.execute("ALTER TABLE users ALTER COLUMN created_at DROP DEFAULT")
     op.execute("ALTER TABLE user_sessions ALTER COLUMN created_at DROP DEFAULT")
     op.execute("ALTER TABLE babies ALTER COLUMN created_at DROP DEFAULT")
+    op.execute("ALTER TABLE family_users ALTER COLUMN joined_at DROP DEFAULT")
+    op.execute("ALTER TABLE schedules ALTER COLUMN created_at DROP DEFAULT")


### PR DESCRIPTION
Neon本番DBに直接 ALTER TABLE で DEFAULT NOW() を適用済み。
Alembicマイグレーションにも追記してコードと同期。