### PR TITLE
feat: 陣痛タイマー機能の改善と新規グラフコンポーネントの追加

### DIFF
--- a/.specify/specs/contraction_timer.md
+++ b/.specify/specs/contraction_timer.md
@@ -18,6 +18,10 @@
 - **停止ボタン**: 陣痛の終了時刻を記録し、持続時間を自動算出する
 - **リアルタイム表示**: 経過秒数を `MM:SS` 形式でリアルタイム表示する
 - **状態管理**: タイマーの状態（idle / timing）を Zustand ストアで管理する
+- **`interval_seconds` 自動計算**: 停止時に前回記録の `end_time` と今回の `start_time` の差分から算出
+  - 計算式: `(今回のstart_time - 前回のend_time) / 1000`（ミリ秒→秒、Math.round）
+  - diff > 0 の場合のみ送信（前回記録がない場合や差分が0以下の場合はフィールド自体を省略）
+- **ボタン仕様**: `h-20 w-full text-2xl rounded-2xl`（陣痛中の操作性を考慮して大型化）
 
 ### F2: 陣痛記録一覧
 - 直近の陣痛記録を一覧表示する（新しい順）
@@ -31,11 +35,24 @@
 - 直近1時間の陣痛回数
 - 平均持続時間
 - 平均間隔
-- 5-1-1ルール判定:
-  - 陣痛間隔が 5分以下
-  - 持続時間が 1分以上
-  - 上記が 1時間以上続く
+- 5-1-1ルール判定（正確なロジック）:
+  - qualifying = `interval_seconds ≤ 300` かつ `duration_seconds ≥ 60` の陣痛
+  - `shouldAlert = qualifying.length >= 3`
+    - かつ `qualifying[qualifying.length - 1].start_time <= now - 3600_000`（最古が1時間以上前）
+    - かつ `qualifying[0].start_time >= now - 1800_000`（最新が30分以内）
+  - APIは降順（新しい順）のため `qualifying[0]` が最新、`qualifying[qualifying.length - 1]` が最古
   → 条件を満たした場合、アラートバナーを表示
+
+### F4: 陣痛グラフ
+- 直近10件の陣痛を時系列順（古い→新しい）で表示するSVGバーチャート
+- 赤バー: `duration_seconds`（持続時間）
+- 青バー: `interval_seconds`（間隔）— 2件目以降から表示
+- X軸: `start_time` の HH:MM 形式
+- Y軸: 秒数（`maxValue` に応じた動的スケール、最低60秒）
+- `viewBox` ベースでレスポンシブ（`width="100%"`）
+- 外部ライブラリ不使用（純粋SVG実装）
+- レイアウト定数: `W=400, H=200, M={top:10, right:10, bottom:40, left:45}`
+- 2件以上の記録がある場合のみページで表示
 
 ## 画面構成
 
@@ -50,8 +67,11 @@
 │  ⚠️ 病院に連絡してください       │
 ├─────────────────────────────────┤
 │         ⏱ 00:45                 │
-│     [ 陣痛が終わった ]           │
+│  [ 陣痛が終わった（大型ボタン） ] │
 │     (計測中...)                  │
+├─────────────────────────────────┤
+│  [陣痛推移グラフ]                │
+│  赤=持続 青=間隔 （SVGバーチャート）│
 ├─────────────────────────────────┤
 │  陣痛記録                        │
 │  ─────────────────────          │
@@ -64,7 +84,7 @@
 
 ## バックエンド API (既存)
 以下の API は既に実装済み:
-- `GET /api/contractions/?baby_id={id}` - 陣痛記録一覧取得
+- `GET /api/contractions/?baby_id={id}` - 陣痛記録一覧取得（`order_by(start_time.desc())`で降順）
 - `POST /api/contractions/` - 陣痛記録作成
 - `DELETE /api/contractions/{id}` - 陣痛記録削除
 
@@ -110,5 +130,13 @@ interface ContractionTimerState {
 ### コンポーネント構成
 - `ContractionPage` - ページコンポーネント
 - `ContractionTimer` - タイマーUI（ストップウォッチ）
-- `ContractionStats` - 統計サマリー
+- `ContractionStats` - 統計サマリー（5-1-1ルール判定含む）
 - `ContractionHistory` - 記録一覧
+- `ContractionGraph` - 陣痛推移SVGグラフ（新規）
+
+## 改訂履歴
+
+| バージョン | 日付 | 内容 |
+|-----------|------|------|
+| 1.0 | 初版 | 基本機能仕様 |
+| 1.1 | 2026-02-13 | F1に`interval_seconds`自動計算仕様追記、ボタン大型化仕様追記、F3の5-1-1ルールロジック修正（正確な1時間継続判定）、F4「陣痛グラフ」新規追加、ContractionGraphコンポーネント追加 |

--- a/frontend/app/(dashboard)/contraction/page.tsx
+++ b/frontend/app/(dashboard)/contraction/page.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useBabies, useContractions } from "@/hooks/useData"
 import ContractionTimer from "@/components/ContractionTimer"
 import ContractionStats from "@/components/ContractionStats"
 import ContractionHistory from "@/components/ContractionHistory"
+import ContractionGraph from "@/components/ContractionGraph"
 import { Button } from "@/components/ui/button"
 import type { ContractionRecord } from "@/types/contraction"
 
@@ -12,10 +13,14 @@ export default function ContractionPage() {
     const { babies, isLoading: babiesLoading } = useBabies()
     const [selectedBabyId, setSelectedBabyId] = useState<number | null>(null)
 
-    // 最初の赤ちゃんを自動選択
-    if (babies && babies.length > 0 && selectedBabyId === null) {
-        setSelectedBabyId(babies[0].id)
-    }
+    // 最初の赤ちゃんを自動選択（React anti-patternをuseEffectで修正）
+    useEffect(() => {
+        if (babies && babies.length > 0 && selectedBabyId === null) {
+            setSelectedBabyId(babies[0].id)
+        }
+    // selectedBabyIdは意図的に除外（初回のみ実行）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [babies])
 
     const { contractions, isLoading: contractionsLoading, mutate } = useContractions(selectedBabyId)
 
@@ -35,6 +40,8 @@ export default function ContractionPage() {
     }
 
     const typedContractions: ContractionRecord[] = contractions ?? []
+    // APIは降順（新しい順）なので[0]が最新
+    const lastContraction = typedContractions[0] ?? null
 
     return (
         <div className="space-y-6">
@@ -67,7 +74,16 @@ export default function ContractionPage() {
 
             {/* タイマー */}
             {selectedBabyId && (
-                <ContractionTimer babyId={selectedBabyId} onRecorded={handleRecorded} />
+                <ContractionTimer
+                    babyId={selectedBabyId}
+                    onRecorded={handleRecorded}
+                    lastContraction={lastContraction}
+                />
+            )}
+
+            {/* グラフ（2件以上の記録がある場合のみ表示） */}
+            {typedContractions.length >= 2 && (
+                <ContractionGraph contractions={typedContractions} />
             )}
 
             {/* 履歴 */}

--- a/frontend/components/ContractionGraph.tsx
+++ b/frontend/components/ContractionGraph.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { useMemo } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { ContractionRecord } from "@/types/contraction"
+
+interface ContractionGraphProps {
+    contractions: ContractionRecord[]
+}
+
+const W = 400
+const H = 200
+const M = { top: 10, right: 10, bottom: 40, left: 45 }
+const chartW = W - M.left - M.right
+const chartH = H - M.top - M.bottom
+
+function formatHHMM(isoString: string): string {
+    const d = new Date(isoString)
+    return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`
+}
+
+function formatSeconds(s: number): string {
+    const m = Math.floor(s / 60)
+    const sec = s % 60
+    if (m > 0) return `${m}分${sec}秒`
+    return `${sec}秒`
+}
+
+export default function ContractionGraph({ contractions }: ContractionGraphProps) {
+    const data = useMemo(() => {
+        // APIは降順（新しい順）なのでreverseして時系列順にする
+        return [...contractions].reverse().slice(-10)
+    }, [contractions])
+
+    const maxValue = useMemo(() => {
+        let max = 60
+        for (const c of data) {
+            if (c.duration_seconds != null && c.duration_seconds > max) max = c.duration_seconds
+            if (c.interval_seconds != null && c.interval_seconds > max) max = c.interval_seconds
+        }
+        return max
+    }, [data])
+
+    const barGroupWidth = chartW / data.length
+    const barWidth = Math.max(4, (barGroupWidth - 8) / 2)
+
+    const scaleY = (val: number) => chartH - (val / maxValue) * chartH
+
+    // Y軸の目盛り（0, 1/4, 1/2, 3/4, max）
+    const yTicks = [0, 0.25, 0.5, 0.75, 1].map((ratio) => Math.round(maxValue * ratio))
+
+    return (
+        <Card>
+            <CardHeader className="pb-2 pt-4 px-4">
+                <CardTitle className="text-sm font-medium">陣痛推移グラフ（直近10件）</CardTitle>
+            </CardHeader>
+            <CardContent className="px-4 pb-4">
+                <div className="flex gap-4 text-xs text-muted-foreground mb-2">
+                    <span className="flex items-center gap-1">
+                        <span className="inline-block w-3 h-3 rounded-sm bg-red-400" />
+                        持続時間
+                    </span>
+                    <span className="flex items-center gap-1">
+                        <span className="inline-block w-3 h-3 rounded-sm bg-blue-400" />
+                        間隔
+                    </span>
+                </div>
+                <svg
+                    viewBox={`0 0 ${W} ${H}`}
+                    width="100%"
+                    aria-label="陣痛推移グラフ"
+                >
+                    <g transform={`translate(${M.left},${M.top})`}>
+                        {/* Y軸目盛り */}
+                        {yTicks.map((tick) => {
+                            const y = scaleY(tick)
+                            return (
+                                <g key={tick}>
+                                    <line
+                                        x1={0} y1={y}
+                                        x2={chartW} y2={y}
+                                        stroke="#e5e7eb"
+                                        strokeWidth={1}
+                                    />
+                                    <text
+                                        x={-4} y={y}
+                                        textAnchor="end"
+                                        dominantBaseline="middle"
+                                        fontSize={9}
+                                        fill="#9ca3af"
+                                    >
+                                        {tick}s
+                                    </text>
+                                </g>
+                            )
+                        })}
+
+                        {/* バーと X軸ラベル */}
+                        {data.map((c, i) => {
+                            const cx = i * barGroupWidth + barGroupWidth / 2
+                            const durationH = c.duration_seconds != null
+                                ? (c.duration_seconds / maxValue) * chartH
+                                : 0
+                            const intervalH = c.interval_seconds != null
+                                ? (c.interval_seconds / maxValue) * chartH
+                                : 0
+
+                            return (
+                                <g key={c.id}>
+                                    {/* 持続時間バー（赤） */}
+                                    {c.duration_seconds != null && (
+                                        <rect
+                                            x={cx - barWidth - 1}
+                                            y={chartH - durationH}
+                                            width={barWidth}
+                                            height={durationH}
+                                            fill="#f87171"
+                                            rx={2}
+                                        >
+                                            <title>{formatSeconds(c.duration_seconds)}</title>
+                                        </rect>
+                                    )}
+
+                                    {/* 間隔バー（青）— 2件目以降のみ */}
+                                    {i > 0 && c.interval_seconds != null && (
+                                        <rect
+                                            x={cx + 1}
+                                            y={chartH - intervalH}
+                                            width={barWidth}
+                                            height={intervalH}
+                                            fill="#60a5fa"
+                                            rx={2}
+                                        >
+                                            <title>{formatSeconds(c.interval_seconds)}</title>
+                                        </rect>
+                                    )}
+
+                                    {/* X軸ラベル */}
+                                    <text
+                                        x={cx}
+                                        y={chartH + 12}
+                                        textAnchor="middle"
+                                        fontSize={9}
+                                        fill="#9ca3af"
+                                    >
+                                        {formatHHMM(c.start_time)}
+                                    </text>
+                                </g>
+                            )
+                        })}
+
+                        {/* X軸ライン */}
+                        <line
+                            x1={0} y1={chartH}
+                            x2={chartW} y2={chartH}
+                            stroke="#d1d5db"
+                            strokeWidth={1}
+                        />
+                    </g>
+                </svg>
+            </CardContent>
+        </Card>
+    )
+}

--- a/frontend/components/ContractionStats.tsx
+++ b/frontend/components/ContractionStats.tsx
@@ -41,13 +41,19 @@ export default function ContractionStats({ contractions }: ContractionStatsProps
             ? Math.round(intervals.reduce((a, b) => a + b, 0) / intervals.length)
             : null
 
-        // 5-1-1ルール: 間隔5分以下 & 持続1分以上 & 1時間以上継続
+        // 5-1-1ルール（正確な判定）:
+        // qualifying = 間隔≤5分 かつ 持続≥1分 の陣痛（APIは降順: [0]が最新）
+        const qualifying = contractions.filter(
+            (c) => c.interval_seconds != null && c.duration_seconds != null
+                && c.interval_seconds <= 300 && c.duration_seconds >= 60
+        )
+        const now = Date.now()
         const shouldAlert =
-            avgInterval != null &&
-            avgDuration != null &&
-            avgInterval <= 300 &&
-            avgDuration >= 60 &&
-            recent.length >= 3
+            qualifying.length >= 3 &&
+            // 最古のqualifying陣痛が1時間以上前（パターンが1時間継続）
+            new Date(qualifying[qualifying.length - 1].start_time).getTime() <= now - 3600_000 &&
+            // 最新のqualifying陣痛が30分以内（まだ継続中）
+            new Date(qualifying[0].start_time).getTime() >= now - 1800_000
 
         return { count: recent.length, avgDuration, avgInterval, shouldAlert }
     }, [contractions])

--- a/frontend/components/ContractionTimer.tsx
+++ b/frontend/components/ContractionTimer.tsx
@@ -5,6 +5,7 @@ import { useContractionTimer } from "@/stores/contractionStore"
 import { api } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import type { ContractionRecord } from "@/types/contraction"
 
 function formatTime(seconds: number): string {
     const m = Math.floor(seconds / 60)
@@ -15,9 +16,10 @@ function formatTime(seconds: number): string {
 interface ContractionTimerProps {
     babyId: number
     onRecorded: () => void
+    lastContraction?: ContractionRecord | null
 }
 
-export default function ContractionTimer({ babyId, onRecorded }: ContractionTimerProps) {
+export default function ContractionTimer({ babyId, onRecorded, lastContraction }: ContractionTimerProps) {
     const { status, elapsedSeconds, start, stop, tick } = useContractionTimer()
 
     // 毎秒のtick更新
@@ -34,11 +36,19 @@ export default function ContractionTimer({ babyId, onRecorded }: ContractionTime
             const result = stop()
             if (result) {
                 try {
+                    let intervalSeconds: number | undefined = undefined
+                    if (lastContraction?.end_time) {
+                        const diff = Math.round(
+                            (result.startTime.getTime() - new Date(lastContraction.end_time).getTime()) / 1000
+                        )
+                        if (diff > 0) intervalSeconds = diff
+                    }
                     await api.post("/contractions/", {
                         baby_id: babyId,
                         start_time: result.startTime.toISOString(),
                         end_time: result.endTime.toISOString(),
                         duration_seconds: result.durationSeconds,
+                        ...(intervalSeconds !== undefined && { interval_seconds: intervalSeconds }),
                     })
                     onRecorded()
                 } catch (err) {
@@ -46,7 +56,7 @@ export default function ContractionTimer({ babyId, onRecorded }: ContractionTime
                 }
             }
         }
-    }, [status, babyId, start, stop, onRecorded])
+    }, [status, babyId, start, stop, onRecorded, lastContraction])
 
     const isTiming = status === "timing"
 
@@ -67,7 +77,7 @@ export default function ContractionTimer({ babyId, onRecorded }: ContractionTime
                 <Button
                     onClick={handleToggle}
                     size="lg"
-                    className={`h-16 w-full max-w-xs text-lg font-bold rounded-2xl transition-all duration-200 ${isTiming
+                    className={`h-20 w-full text-2xl font-bold rounded-2xl transition-all duration-200 ${isTiming
                             ? "bg-gray-700 hover:bg-gray-800 text-white"
                             : "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-200 dark:shadow-red-900/40"
                         }`}


### PR DESCRIPTION
- `interval_seconds`の自動計算機能を追加
- 陣痛推移を表示するSVGグラフコンポーネントを新規作成
- 5-1-1ルールの判定ロジックを修正
- タイマーのボタンサイズを大型化