### PR TITLE
⚡ Bolt: Add database indexes for baby_id lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-14 - Unified Record Fetching Architecture
+**Learning:** The `get_records` endpoint in `app/routers/baby.py` fetches ALL records from 4 different tables (Feeding, Sleep, Diaper, Growth), instantiates all ORM objects, sorts them in Python, and returns them all. This is a significant scalability bottleneck as the number of records grows.
+**Action:** In future optimizations, consider refactoring this to use a UNION query with pagination at the database level, or implement separate paginated endpoints for the timeline view.

--- a/alembic/versions/7556b37b9e78_add_performance_indexes.py
+++ b/alembic/versions/7556b37b9e78_add_performance_indexes.py
@@ -1,0 +1,30 @@
+"""add performance indexes
+
+Revision ID: 7556b37b9e78
+Revises: 87137ab3b509
+Create Date: 2026-02-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7556b37b9e78'
+down_revision: Union[str, Sequence[str], None] = '87137ab3b509'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index('idx_growth_baby_date', 'growths', ['baby_id', 'date'], unique=False)
+    op.create_index('idx_contraction_baby_start_time', 'contractions', ['baby_id', 'start_time'], unique=False)
+    op.create_index('idx_schedule_baby_scheduled_time', 'schedules', ['baby_id', 'scheduled_time'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('idx_schedule_baby_scheduled_time', table_name='schedules')
+    op.drop_index('idx_contraction_baby_start_time', table_name='contractions')
+    op.drop_index('idx_growth_baby_date', table_name='growths')

--- a/app/models/contraction.py
+++ b/app/models/contraction.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Index
 from .base import Base
 
 
@@ -13,3 +13,7 @@ class Contraction(Base):
     interval_seconds = Column(Integer, nullable=True)
     notes = Column(String, nullable=True)
     baby_id = Column(Integer, ForeignKey("babies.id"), nullable=False)
+
+    __table_args__ = (
+        Index("idx_contraction_baby_start_time", "baby_id", "start_time"),
+    )

--- a/app/models/growth.py
+++ b/app/models/growth.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, Date, Float
+from sqlalchemy import Column, Integer, String, ForeignKey, Date, Float, Index
 from .base import Base
 
 
@@ -13,3 +13,7 @@ class Growth(Base):
     head_circumference = Column(Float, nullable=True)  # in cm
     notes = Column(String, nullable=True)
     baby_id = Column(Integer, ForeignKey("babies.id"), nullable=False)
+
+    __table_args__ = (
+        Index("idx_growth_baby_date", "baby_id", "date"),
+    )

--- a/app/models/schedule.py
+++ b/app/models/schedule.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Boolean, func
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Boolean, func, Index
 from .base import Base
 
 
@@ -13,3 +13,7 @@ class Schedule(Base):
     is_completed = Column(Boolean, nullable=False, default=False)
     created_at = Column(DateTime, nullable=False, server_default=func.now())
     baby_id = Column(Integer, ForeignKey("babies.id"), nullable=False)
+
+    __table_args__ = (
+        Index("idx_schedule_baby_scheduled_time", "baby_id", "scheduled_time"),
+    )


### PR DESCRIPTION
💡 What:
- Added `idx_growth_baby_date` on `(baby_id, date)` to `growths` table.
- Added `idx_contraction_baby_start_time` on `(baby_id, start_time)` to `contractions` table.
- Added `idx_schedule_baby_scheduled_time` on `(baby_id, scheduled_time)` to `schedules` table.
- Created Alembic migration `7556b37b9e78_add_performance_indexes.py`.
- Updated SQLAlchemy models `Growth`, `Contraction`, `Schedule` to include these indexes.

🎯 Why:
- These tables were missing indexes on the foreign key `baby_id` used in frequent lookups (e.g., fetching records for a baby, cascade deletes).
- This prevents full table scans on these tables, especially `growths` which is fetched on the main dashboard.

📊 Impact:
- Reduces query cost for `get_records` endpoint which fetches growth records.
- Improves performance of dashboard load and baby deletion.

🔬 Measurement:
- Verify by running `EXPLAIN ANALYZE` on queries filtering by `baby_id` on these tables (requires DB access).
- Check `alembic upgrade head` applies successfully.

---
*PR created automatically by Jules for task [14996641701115903764](https://jules.google.com/task/14996641701115903764) started by @eburairu*