### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in static file serving

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Path Traversal in Static File Serving
+**Vulnerability:** The application was vulnerable to path traversal attacks via the `serve_frontend` endpoint. The `full_path` parameter was passed directly to `os.path.join`, allowing attackers to access files outside the intended directory using `..` sequences or absolute paths.
+**Learning:** Relying on web server or framework defaults to sanitize paths can be risky. Always explicitly validate that the resolved path is within the intended base directory.
+**Prevention:** Use `os.path.abspath` to resolve the target path and check if it starts with the canonical base path. Avoid trusting user-supplied path components blindly.

--- a/app/main.py
+++ b/app/main.py
@@ -50,10 +50,22 @@ async def health_check():
 async def serve_frontend(full_path: str):
     if not os.path.exists(frontend_build_path):
         return {"error": "Frontend not built"}
-    file_path = os.path.join(frontend_build_path, full_path)
-    if os.path.exists(file_path) and os.path.isfile(file_path):
-        return FileResponse(file_path)
-    html_path = file_path + ".html"
-    if os.path.exists(html_path):
+
+    # Secure path resolution to prevent traversal attacks
+    base_path = os.path.abspath(frontend_build_path)
+    # Join with base path and resolve absolute path (handles ..)
+    requested_path = os.path.abspath(os.path.join(base_path, full_path.lstrip("/")))
+
+    # Check if the resolved path starts with the base path
+    if not requested_path.startswith(base_path):
+        # Path traversal attempt - serve index.html (SPA routing handles 404)
+        return FileResponse(os.path.join(frontend_build_path, "index.html"))
+
+    if os.path.exists(requested_path) and os.path.isfile(requested_path):
+        return FileResponse(requested_path)
+
+    html_path = requested_path + ".html"
+    if os.path.exists(html_path) and os.path.isfile(html_path):
         return FileResponse(html_path)
+
     return FileResponse(os.path.join(frontend_build_path, "index.html"))

--- a/sensitive.txt
+++ b/sensitive.txt
@@ -1,0 +1,1 @@
+SECRET_DATA

--- a/test_path_traversal.py
+++ b/test_path_traversal.py
@@ -1,0 +1,13 @@
+import os
+
+frontend_build_path = "/app/frontend/out"
+full_path = "../../etc/passwd"
+
+joined_path = os.path.join(frontend_build_path, full_path)
+print(f"Joined path: {joined_path}")
+print(f"Is absolute: {os.path.isabs(joined_path)}")
+print(f"Real path: {os.path.realpath(joined_path)}")
+
+full_path_2 = "/etc/passwd"
+joined_path_2 = os.path.join(frontend_build_path, full_path_2)
+print(f"Joined path 2: {joined_path_2}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.main import app
-from app.database import Base
+from app.models.base import Base
 from app.dependencies import get_db
 
 # テスト用のインメモリ SQLite データベース

--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+from app.main import serve_frontend, frontend_build_path
+from fastapi.responses import FileResponse
+
+@pytest.mark.anyio
+async def test_path_traversal_blocked():
+    # Setup
+    os.makedirs("frontend/out", exist_ok=True)
+    with open("frontend/out/index.html", "w") as f:
+        f.write("<html>Index</html>")
+
+    # Create sensitive file outside
+    with open("sensitive.txt", "w") as f:
+        f.write("SECRET_DATA")
+
+    # Test logic directly with malicious input
+    malicious_path = "../../sensitive.txt"
+
+    response = await serve_frontend(malicious_path)
+
+    # Assert
+    assert isinstance(response, FileResponse)
+
+    # We expect it to resolve to index.html (fallback) instead of sensitive file
+    resolved_path = os.path.abspath(response.path)
+    expected_fallback_path = os.path.abspath(os.path.join(frontend_build_path, "index.html"))
+
+    assert resolved_path == expected_fallback_path, f"Expected fallback to index.html, but got {resolved_path}"
+
+    # Ensure sensitive file is NOT accessed
+    expected_sensitive_path = os.path.abspath("sensitive.txt")
+    assert resolved_path != expected_sensitive_path, "VULNERABILITY: Sensitive file was accessed!"
+
+@pytest.mark.anyio
+async def test_serve_valid_file():
+    # Setup
+    os.makedirs("frontend/out", exist_ok=True)
+    with open("frontend/out/test.js", "w") as f:
+        f.write("console.log('test')")
+
+    response = await serve_frontend("test.js")
+
+    assert isinstance(response, FileResponse)
+    resolved_path = os.path.abspath(response.path)
+    expected_path = os.path.abspath(os.path.join(frontend_build_path, "test.js"))
+
+    assert resolved_path == expected_path


### PR DESCRIPTION
🛡️ Sentinel Security Fix

🚨 Severity: CRITICAL
💡 Vulnerability: Path Traversal in `serve_frontend` endpoint allowed accessing files outside the intended directory.
🎯 Impact: Attackers could read sensitive files (e.g., config, source code) from the server.
🔧 Fix: Validated that the resolved path is within the `frontend/out` directory using `os.path.abspath` and `startswith`.
✅ Verification: Added `tests/test_security_path_traversal.py` which attempts traversal and verifies it is blocked.

---
*PR created automatically by Jules for task [17828546104607187658](https://jules.google.com/task/17828546104607187658) started by @eburairu*