### PR TITLE
🧹 Refactor duplicated data fetching hooks into a generic factory

### DIFF
--- a/frontend/hooks/useData.ts
+++ b/frontend/hooks/useData.ts
@@ -1,5 +1,10 @@
 import useSWR from 'swr';
 import { fetcher } from '@/lib/api';
+import type { ContractionRecord } from '@/types/contraction';
+import type { Feeding } from '@/types/feeding';
+import type { Diaper } from '@/types/diaper';
+import type { Sleep } from '@/types/sleep';
+import type { Growth } from '@/types/growth';
 
 export function useFamilySettings() {
     const { data, error, isLoading, mutate } = useSWR('/family/', fetcher);
@@ -31,6 +36,19 @@ export function useBabies() {
     };
 }
 
+function useBabyResource<T>(endpoint: string, babyId: string | number | null) {
+    const { data, error, isLoading, mutate } = useSWR<T[]>(
+        babyId ? `/${endpoint}/?baby_id=${babyId}` : null,
+        fetcher
+    );
+    return {
+        data,
+        isLoading,
+        isError: error,
+        mutate,
+    };
+}
+
 export function useRecords(babyId: string | null) {
     const { data, error, isLoading, mutate } = useSWR(babyId ? `/babies/${babyId}/records` : null, fetcher);
     return {
@@ -41,67 +59,52 @@ export function useRecords(babyId: string | null) {
     };
 }
 
-export function useContractions(babyId: number | null) {
-    const { data, error, isLoading, mutate } = useSWR(
-        babyId ? `/contractions/?baby_id=${babyId}` : null,
-        fetcher
-    );
+export function useContractions(babyId: string | number | null) {
+    const { data, isLoading, isError, mutate } = useBabyResource<ContractionRecord>('contractions', babyId);
     return {
         contractions: data,
         isLoading,
-        isError: error,
+        isError,
         mutate,
     };
 }
 
-export function useFeedings(babyId: string | null) {
-    const { data, error, isLoading, mutate } = useSWR(
-        babyId ? `/feedings/?baby_id=${babyId}` : null,
-        fetcher
-    );
+export function useFeedings(babyId: string | number | null) {
+    const { data, isLoading, isError, mutate } = useBabyResource<Feeding>('feedings', babyId);
     return {
-        feedings: data as any[] | undefined,
+        feedings: data,
         isLoading,
-        isError: error,
+        isError,
         mutate,
     };
 }
 
-export function useSleeps(babyId: string | null) {
-    const { data, error, isLoading, mutate } = useSWR(
-        babyId ? `/sleeps/?baby_id=${babyId}` : null,
-        fetcher
-    );
+export function useSleeps(babyId: string | number | null) {
+    const { data, isLoading, isError, mutate } = useBabyResource<Sleep>('sleeps', babyId);
     return {
-        sleeps: data as any[] | undefined,
+        sleeps: data,
         isLoading,
-        isError: error,
+        isError,
         mutate,
     };
 }
 
-export function useDiapers(babyId: string | null) {
-    const { data, error, isLoading, mutate } = useSWR(
-        babyId ? `/diapers/?baby_id=${babyId}` : null,
-        fetcher
-    );
+export function useDiapers(babyId: string | number | null) {
+    const { data, isLoading, isError, mutate } = useBabyResource<Diaper>('diapers', babyId);
     return {
-        diapers: data as any[] | undefined,
+        diapers: data,
         isLoading,
-        isError: error,
+        isError,
         mutate,
     };
 }
 
-export function useGrowths(babyId: string | null) {
-    const { data, error, isLoading, mutate } = useSWR(
-        babyId ? `/growths/?baby_id=${babyId}` : null,
-        fetcher
-    );
+export function useGrowths(babyId: string | number | null) {
+    const { data, isLoading, isError, mutate } = useBabyResource<Growth>('growths', babyId);
     return {
-        growths: data as any[] | undefined,
+        growths: data,
         isLoading,
-        isError: error,
+        isError,
         mutate,
     };
 }

--- a/frontend/types/growth.ts
+++ b/frontend/types/growth.ts
@@ -1,0 +1,19 @@
+export interface Growth {
+    id: number;
+    user_id: number;
+    baby_id: number;
+    date: string; // ISO 8601 (date)
+    weight: number | null; // in grams
+    height: number | null; // in cm
+    head_circumference: number | null; // in cm
+    notes: string | null;
+}
+
+export interface GrowthCreate {
+    baby_id: number;
+    date: string;
+    weight?: number;
+    height?: number;
+    head_circumference?: number;
+    notes?: string;
+}

--- a/frontend/types/sleep.ts
+++ b/frontend/types/sleep.ts
@@ -1,0 +1,15 @@
+export interface Sleep {
+    id: number;
+    user_id: number;
+    baby_id: number;
+    start_time: string; // ISO 8601
+    end_time: string | null; // ISO 8601
+    notes: string | null;
+}
+
+export interface SleepCreate {
+    baby_id: number;
+    start_time: string;
+    end_time?: string;
+    notes?: string;
+}


### PR DESCRIPTION
This PR improves code health by refactoring duplicated data fetching logic in `frontend/hooks/useData.ts` into a single generic helper hook `useBabyResource`.

### 🎯 What:
- Introduced `useBabyResource<T>` generic hook in `useData.ts`.
- Refactored 5 repetitive hooks to use this helper.
- Created `frontend/types/sleep.ts` and `frontend/types/growth.ts`.
- Standardized `babyId` parameter type.

### 💡 Why:
- Reduces boilerplate and improves maintainability.
- Ensures consistent fetching logic across different baby resources.
- Enhances type safety by replacing `any` with specific interfaces.

### ✅ Verification:
- Manual code review confirms the logic is preserved and API remains backward compatible.
- (Note: `npm lint`/`build` failed in this environment due to missing dependencies and network issues, but the changes were carefully verified manually).

### ✨ Result:
- Cleaner, more readable, and better-typed data fetching hooks.

---
*PR created automatically by Jules for task [3769920482984252447](https://jules.google.com/task/3769920482984252447) started by @eburairu*