### PR TITLE
🧪 [testing improvement] Add tests for ageUtils and fix calculation bugs

### DIFF
--- a/frontend/__tests__/ageUtils.test.ts
+++ b/frontend/__tests__/ageUtils.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, afterEach, setSystemTime } from "bun:test"
+import { calcAge, formatElapsed, formatDuration, isToday } from "@/lib/ageUtils"
+
+describe("ageUtils", () => {
+    afterEach(() => {
+        setSystemTime() // テストごとに時刻をリセット
+    })
+
+    describe("calcAge", () => {
+        it("今日生まれた場合は生後0日を返す", () => {
+            setSystemTime(new Date("2024-05-20T10:00:00Z"))
+            const result = calcAge("2024-05-20T00:00:00Z")
+            expect(result.months).toBe(0)
+            expect(result.days).toBe(0)
+            expect(result.label).toBe("生後 0日")
+        })
+
+        it("翌日の場合は生後1日を返す", () => {
+            setSystemTime(new Date("2024-05-21T10:00:00Z"))
+            const result = calcAge("2024-05-20T00:00:00Z")
+            expect(result.days).toBe(1)
+            expect(result.label).toBe("生後 1日")
+        })
+
+        it("ちょうど1ヶ月後の場合は生後1ヶ月を返す", () => {
+            setSystemTime(new Date("2024-06-20T10:00:00Z"))
+            const result = calcAge("2024-05-20T00:00:00Z")
+            expect(result.months).toBe(1)
+            expect(result.days).toBe(0)
+            expect(result.label).toBe("生後 1ヶ月")
+        })
+
+        it("1ヶ月と1日後の場合は生後1ヶ月1日を返す", () => {
+            setSystemTime(new Date("2024-06-21T10:00:00Z"))
+            const result = calcAge("2024-05-20T00:00:00Z")
+            expect(result.months).toBe(1)
+            expect(result.days).toBe(1)
+            expect(result.label).toBe("生後 1ヶ月1日")
+        })
+
+        it("月末生まれの境界値を正しく計算する (1月31日生まれの3月1日時点)", () => {
+            // 2024年はうるう年なので2月は29日まで。
+            // 1月31日から2月29日で1ヶ月。3月1日は1ヶ月と1日。
+            setSystemTime(new Date("2024-03-01T10:00:00Z"))
+            const result = calcAge("2024-01-31T00:00:00Z")
+            expect(result.months).toBe(1)
+            expect(result.days).toBe(1)
+            expect(result.label).toBe("生後 1ヶ月1日")
+        })
+    })
+
+    describe("formatElapsed", () => {
+        it("1分未満は 'たった今' を返す", () => {
+            setSystemTime(new Date("2024-05-20T10:00:00Z"))
+            const date = new Date("2024-05-20T09:59:30Z").toISOString()
+            expect(formatElapsed(date)).toBe("たった今")
+        })
+
+        it("1分以上60分未満は 'X分前' を返す", () => {
+            setSystemTime(new Date("2024-05-20T10:00:00Z"))
+            const date = new Date("2024-05-20T09:50:00Z").toISOString()
+            expect(formatElapsed(date)).toBe("10分前")
+        })
+
+        it("1時間以上24時間未満で端数がない場合は 'X時間前' を返す", () => {
+            setSystemTime(new Date("2024-05-20T10:00:00Z"))
+            const date = new Date("2024-05-20T08:00:00Z").toISOString()
+            expect(formatElapsed(date)).toBe("2時間前")
+        })
+
+        it("1時間以上24時間未満で端数がある場合は 'X時間Y分前' を返す", () => {
+            setSystemTime(new Date("2024-05-20T10:00:00Z"))
+            const date = new Date("2024-05-20T08:30:00Z").toISOString()
+            expect(formatElapsed(date)).toBe("1時間30分前")
+        })
+
+        it("24時間以上は 'X日前' を返す", () => {
+            setSystemTime(new Date("2024-05-21T11:00:00Z"))
+            const date = new Date("2024-05-20T10:00:00Z").toISOString()
+            expect(formatElapsed(date)).toBe("1日前")
+        })
+    })
+
+    describe("formatDuration", () => {
+        it("60分未満は 'X分' を返す", () => {
+            const start = "2024-05-20T10:00:00Z"
+            const end = "2024-05-20T10:45:00Z"
+            expect(formatDuration(start, end)).toBe("45分")
+        })
+
+        it("1時間ジャストは '1時間' を返す", () => {
+            const start = "2024-05-20T10:00:00Z"
+            const end = "2024-05-20T11:00:00Z"
+            expect(formatDuration(start, end)).toBe("1時間")
+        })
+
+        it("1時間以上で端数がある場合は 'X時間Y分' を返す", () => {
+            const start = "2024-05-20T10:00:00Z"
+            const end = "2024-05-20T11:15:00Z"
+            expect(formatDuration(start, end)).toBe("1時間15分")
+        })
+
+        it("endIso が指定されない場合は現在時刻を使用する", () => {
+            setSystemTime(new Date("2024-05-20T11:30:00Z"))
+            const start = "2024-05-20T10:00:00Z"
+            expect(formatDuration(start, null)).toBe("1時間30分")
+        })
+    })
+
+    describe("isToday", () => {
+        it("今日の日付の場合は true を返す", () => {
+            setSystemTime(new Date("2024-05-20T12:00:00Z"))
+            const date = "2024-05-20T00:00:00Z"
+            expect(isToday(date)).toBe(true)
+        })
+
+        it("昨日の日付の場合は false を返す", () => {
+            setSystemTime(new Date("2024-05-20T12:00:00Z"))
+            const date = "2024-05-19T23:59:59Z"
+            expect(isToday(date)).toBe(false)
+        })
+
+        it("明日の日付の場合は false を返す", () => {
+            setSystemTime(new Date("2024-05-20T12:00:00Z"))
+            const date = "2024-05-21T00:00:00Z"
+            expect(isToday(date)).toBe(false)
+        })
+
+        it("前年の同日の場合は false を返す", () => {
+            setSystemTime(new Date("2024-05-20T12:00:00Z"))
+            const date = "2023-05-20T12:00:00Z"
+            expect(isToday(date)).toBe(false)
+        })
+    })
+})

--- a/frontend/components/settings/BabyCard.tsx
+++ b/frontend/components/settings/BabyCard.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { Button } from "@/components/ui/button"
 import { Pencil, Trash2 } from "lucide-react"
+import { calcAge } from "@/lib/ageUtils"
 
 interface Baby {
     id: number
@@ -16,27 +17,13 @@ interface Props {
     onDelete: (baby: Baby) => void
 }
 
-function calcAge(birthday: string | null): string {
-    if (!birthday) return ""
-    const birth = new Date(birthday)
-    const now = new Date()
-    const diffMs = now.getTime() - birth.getTime()
-    if (diffMs < 0) return ""
-    const totalDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-    const months = Math.floor(totalDays / 30.4375)
-    const days = totalDays - Math.floor(months * 30.4375)
-    if (months === 0) return `生後 ${days}日`
-    if (days === 0) return `生後 ${months}ヶ月`
-    return `生後 ${months}ヶ月 ${days}日`
-}
-
 function formatDate(dateStr: string | null): string {
     if (!dateStr) return ""
     return dateStr.replace(/-/g, "/")
 }
 
 export function BabyCard({ baby, isAdmin, onEdit, onDelete }: Props) {
-    const age = calcAge(baby.birthday)
+    const age = baby.birthday ? calcAge(baby.birthday).label : ""
 
     return (
         <div className="bg-white rounded-2xl shadow-sm p-4">

--- a/frontend/lib/ageUtils.ts
+++ b/frontend/lib/ageUtils.ts
@@ -13,21 +13,26 @@ export function calcAge(birthday: string): { months: number; days: number; label
         months -= 1;
     }
 
-    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), birth.getDate());
     if (dayOfMonth < 0) {
         // 前月の日数を使う
-        const prevMonth = new Date(now.getFullYear(), now.getMonth(), 0);
-        var days = prevMonth.getDate() + dayOfMonth;
+        const prevMonthLastDay = new Date(now.getFullYear(), now.getMonth(), 0).getDate();
+        // 誕生日の日が前月の末日より大きい場合（例：1月31日生まれで前月が28日まで）、
+        // 前月の末日を基準にする
+        const referenceDay = Math.min(birth.getDate(), prevMonthLastDay);
+        let days = now.getDate() + (prevMonthLastDay - referenceDay);
+        return { months, days, label: createLabel(months, days) };
     } else {
-        var days = dayOfMonth;
+        let days = dayOfMonth;
+        return { months, days, label: createLabel(months, days) };
     }
+}
 
-    const label = months > 0
+function createLabel(months: number, days: number): string {
+    return months > 0
         ? `生後 ${months}ヶ月${days > 0 ? `${days}日` : ''}`
         : `生後 ${days}日`;
-
-    return { months, days, label };
 }
+
 
 export function formatElapsed(isoDateStr: string): string {
     const date = new Date(isoDateStr);


### PR DESCRIPTION
### 🎯 What
Missing test file for `ageUtils.ts` was addressed. In the process, a bug in age calculation for month-end dates was discovered and fixed.

### 📊 Coverage
The following scenarios are now tested:
- `calcAge`: Same day, next day, exactly 1 month later, leap year/month-end boundaries (e.g., Jan 31 to March 1).
- `formatElapsed`: Just now (<1m), minutes ago, hours and minutes ago, days ago.
- `formatDuration`: Minutes only, hours and minutes, handling of null end date (now).
- `isToday`: Today, yesterday, tomorrow, same day in previous year.

### ✨ Result
- Improved reliability of age calculation across the application.
- Removed duplicated and less accurate age calculation logic in `BabyCard.tsx`.
- Ensured consistent behavior for babies born on the 31st.

---
*PR created automatically by Jules for task [16523287173441454747](https://jules.google.com/task/16523287173441454747) started by @eburairu*