### PR TITLE
⚡ Optimize async dependency with synchronous DB I/O

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -18,7 +18,7 @@ def get_db() -> Generator[Session, None, None]:
 db_dependency = Annotated[Session, Depends(get_db)]
 
 
-async def get_current_user(request: Request, db: db_dependency):
+def get_current_user(request: Request, db: db_dependency):
     from app.models.user import User, UserSession
 
     token = request.cookies.get("access_token")


### PR DESCRIPTION
The `get_current_user` dependency was changed from `async def` to `def` to avoid blocking the main event loop during synchronous database queries. This is a critical performance optimization for FastAPI applications using synchronous SQLAlchemy ORM.

---
*PR created automatically by Jules for task [12902438113794980992](https://jules.google.com/task/12902438113794980992) started by @eburairu*