### PR TITLE
feat: 🎨 Enhance button accessibility and feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-14 - Button Accessibility and Feedback
+**Learning:** Icon-only buttons (like those using Lucide icons) are often missed by screen readers if they lack `aria-label`. Also, async actions in widgets often used `disabled={loading}` which lacks visual feedback compared to `loading={loading}` which shows a spinner.
+**Action:** Always verify icon-only buttons have `aria-label` or `title`. Prefer `loading={loading}` over `disabled={loading}` for `Button` components to provide immediate visual feedback.

--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -49,7 +49,13 @@ export function DiaperWidget({ babyId }: Props) {
                     👶 おむつ
                 </CardTitle>
                 <Link href={`/diaper?baby_id=${babyId}`}>
-                    <Button variant="ghost" size="icon" className="h-6 w-6 -mr-2 text-gray-400 hover:text-amber-500">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 -mr-2 text-gray-400 hover:text-amber-500"
+                        aria-label="おむつ詳細"
+                        title="詳細を見る"
+                    >
                         <ArrowRight className="h-4 w-4" />
                     </Button>
                 </Link>
@@ -68,19 +74,21 @@ export function DiaperWidget({ babyId }: Props) {
                 <div className="flex gap-2">
                     <Button
                         size="sm"
-                        disabled={loading}
+                        loading={loading}
                         onClick={(e) => handleQuickRecord(DiaperType.WET, e)}
                         className="flex-1 bg-amber-50 text-amber-600 hover:bg-amber-100 border-0 text-xs h-8"
                         variant="outline"
+                        aria-label="おしっこ"
                     >
                         💧
                     </Button>
                     <Button
                         size="sm"
-                        disabled={loading}
+                        loading={loading}
                         onClick={(e) => handleQuickRecord(DiaperType.DIRTY, e)}
                         className="flex-1 bg-amber-50 text-amber-600 hover:bg-amber-100 border-0 text-xs h-8"
                         variant="outline"
+                        aria-label="うんち"
                     >
                         💩
                     </Button>

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -16,9 +16,9 @@ export function FeedingWidget({ babyId }: Props) {
     const { feedings, mutate } = useFeedings(babyId)
     const [loading, setLoading] = useState(false)
 
-    const todayCount = feedings?.filter((f) => isToday(f.start_time)).length ?? 0
+    const todayCount = feedings?.filter((f) => isToday(f.feeding_time)).length ?? 0
     const lastFeeding = feedings?.[0]
-    const elapsed = lastFeeding ? formatElapsed(lastFeeding.start_time) : null
+    const elapsed = lastFeeding ? formatElapsed(lastFeeding.feeding_time) : null
 
     const handleQuickRecord = async (feedingType: string, e: React.MouseEvent) => {
         e.preventDefault()
@@ -45,7 +45,13 @@ export function FeedingWidget({ babyId }: Props) {
                     🍼 授乳
                 </CardTitle>
                 <Link href={`/feeding?baby_id=${babyId}`}>
-                    <Button variant="ghost" size="icon" className="h-6 w-6 -mr-2 text-gray-400 hover:text-rose-500">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 -mr-2 text-gray-400 hover:text-rose-500"
+                        aria-label="授乳詳細"
+                        title="詳細を見る"
+                    >
                         <ArrowRight className="h-4 w-4" />
                     </Button>
                 </Link>
@@ -62,7 +68,7 @@ export function FeedingWidget({ babyId }: Props) {
                 <div className="flex gap-2">
                     <Button
                         size="sm"
-                        disabled={loading}
+                        loading={loading}
                         onClick={(e) => handleQuickRecord("bottle", e)}
                         className="flex-1 bg-rose-50 text-rose-600 hover:bg-rose-100 border-0 text-xs h-8"
                         variant="outline"
@@ -71,7 +77,7 @@ export function FeedingWidget({ babyId }: Props) {
                     </Button>
                     <Button
                         size="sm"
-                        disabled={loading}
+                        loading={loading}
                         onClick={(e) => handleQuickRecord("breast", e)}
                         className="flex-1 bg-rose-50 text-rose-600 hover:bg-rose-100 border-0 text-xs h-8"
                         variant="outline"

--- a/frontend/components/dashboard/SleepWidget.tsx
+++ b/frontend/components/dashboard/SleepWidget.tsx
@@ -31,7 +31,7 @@ export function SleepWidget({ babyId }: Props) {
 
     const elapsed = activeSleep ? formatElapsed(activeSleep.start_time) : null
     const lastSleep = sleeps?.find((s) => s.end_time)
-    const lastElapsed = lastSleep ? formatElapsed(lastSleep.end_time) : null
+    const lastElapsed = lastSleep ? formatElapsed(lastSleep.end_time!) : null
 
     const handleStart = async () => {
         setLoading(true)
@@ -73,7 +73,13 @@ export function SleepWidget({ babyId }: Props) {
                     )}
                 </CardTitle>
                 <Link href={`/sleep?baby_id=${babyId}`}>
-                    <Button variant="ghost" size="icon" className="h-6 w-6 -mr-2 text-gray-400 hover:text-indigo-500">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 -mr-2 text-gray-400 hover:text-indigo-500"
+                        aria-label="睡眠詳細"
+                        title="詳細を見る"
+                    >
                         <ArrowRight className="h-4 w-4" />
                     </Button>
                 </Link>
@@ -96,7 +102,7 @@ export function SleepWidget({ babyId }: Props) {
                 </div>
                 <Button
                     size="sm"
-                    disabled={loading}
+                    loading={loading}
                     onClick={isSleeping ? handleEnd : handleStart}
                     className={`w-full text-xs h-8 border-0 ${isSleeping
                             ? "bg-indigo-500 text-white hover:bg-indigo-600"

--- a/frontend/components/settings/InviteCodeCard.tsx
+++ b/frontend/components/settings/InviteCodeCard.tsx
@@ -52,16 +52,22 @@ export function InviteCodeCard({ inviteCode, isAdmin, onRegenerated }: Props) {
                 <div className="flex-1 bg-violet-50 rounded-lg px-4 py-2 font-mono text-gray-800 text-sm">
                     {inviteCode}
                 </div>
-                <Button variant="outline" size="icon" onClick={handleCopy}>
+                <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={handleCopy}
+                    aria-label={copied ? "コピー完了" : "招待コードをコピー"}
+                    title="招待コードをコピー"
+                >
                     {copied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
                 </Button>
             </div>
-            {copied && <p className="text-green-600 text-xs mt-1">コピーしました ✓</p>}
+            {copied && <p className="text-green-600 text-xs mt-1" role="status">コピーしました ✓</p>}
             {isAdmin && (
                 <div className="mt-3">
                     <AlertDialog>
                         <AlertDialogTrigger asChild>
-                            <Button variant="outline" size="sm" disabled={regenerating}>
+                            <Button variant="outline" size="sm" loading={regenerating}>
                                 <RefreshCw className="h-4 w-4 mr-1" />
                                 再生成
                             </Button>


### PR DESCRIPTION
This PR enhances the accessibility and feedback of several dashboard widgets and settings cards.

**Changes:**
1.  **InviteCodeCard.tsx**:
    -   Added `aria-label` and `title` to the copy button.
    -   Added `role="status"` to the "Copied" success message.
    -   Changed the regenerate button to use `loading={regenerating}` for better feedback.
2.  **DiaperWidget.tsx**:
    -   Added `aria-label` to "Wet" and "Dirty" icon buttons.
    -   Changed `disabled={loading}` to `loading={loading}`.
    -   Added `aria-label` to the detail link button.
3.  **FeedingWidget.tsx**:
    -   Changed `disabled={loading}` to `loading={loading}`.
    -   Added `aria-label` to the detail link button.
    -   **Fix:** Changed `start_time` to `feeding_time` to match `Feeding` type definition and fix build error.
4.  **SleepWidget.tsx**:
    -   Changed `disabled={loading}` to `loading={loading}`.
    -   Added `aria-label` to the detail link button.
    -   **Fix:** Added non-null assertion to `end_time` usage to fix build error.
5.  **Documentation**:
    -   Created `.jules/palette.md` with learnings about icon-only buttons and loading states.

**Verification:**
-   Ran `npm run lint` (fixed what I could, ignored existing errors).
-   Ran `npm run build` and it passed successfully.

---
*PR created automatically by Jules for task [82911637023963945](https://jules.google.com/task/82911637023963945) started by @eburairu*