### PR TITLE
🔒 [security fix] Change COOKIE_SECURE default to True

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cp .env.example .env
 
 - `DATABASE_URL`（必須）
 - `CORS_ORIGINS`（任意。例: `http://localhost:3000,http://localhost:8000`）
-- `COOKIE_SECURE`（任意。ローカルでは通常 `false`）
+- `COOKIE_SECURE`（任意。デフォルトは `true`。ローカル開発で HTTP を使用する場合は `false` に設定してください）
 
 ### 3. Backend セットアップ
 

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -17,7 +17,7 @@ from app.services.auth import verify_password, get_password_hash
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 SESSION_EXPIRE_DAYS = 7
-COOKIE_SECURE = os.getenv("COOKIE_SECURE", "false").lower() == "true"
+COOKIE_SECURE = os.getenv("COOKIE_SECURE", "true").lower() == "true"
 
 
 def _create_session(db: Session, user_id: int) -> str:

--- a/tests/test_security_cookie.py
+++ b/tests/test_security_cookie.py
@@ -1,0 +1,54 @@
+import os
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+
+def test_cookie_secure_default_is_true():
+    # Ensure COOKIE_SECURE is not set in environment
+    if "COOKIE_SECURE" in os.environ:
+        del os.environ["COOKIE_SECURE"]
+
+    # Reload the module to pick up the default value
+    import app.routers.auth
+    importlib.reload(app.routers.auth)
+
+    from app.routers.auth import COOKIE_SECURE
+    # Now it should be True by default
+    assert COOKIE_SECURE is True
+
+def test_cookie_secure_can_be_false():
+    # Set COOKIE_SECURE to "false" in environment
+    os.environ["COOKIE_SECURE"] = "false"
+
+    # Reload the module
+    import app.routers.auth
+    importlib.reload(app.routers.auth)
+
+    from app.routers.auth import COOKIE_SECURE
+    assert COOKIE_SECURE is False
+
+    # Cleanup
+    del os.environ["COOKIE_SECURE"]
+
+def test_cookie_secure_header_is_present(client):
+    # We need to make sure the app uses the updated COOKIE_SECURE
+    # Since 'client' might have already initialized the app, we might need to reload.
+    # But in a typical pytest setup, the client is created per test or session.
+
+    # Let's ensure COOKIE_SECURE is True for this test
+    if "COOKIE_SECURE" in os.environ:
+        del os.environ["COOKIE_SECURE"]
+    import app.routers.auth
+    importlib.reload(app.routers.auth)
+
+    response = client.post(
+        "/api/auth/register/family",
+        json={
+            "name": "Security Family",
+            "username": "security_user_2",
+            "password": "password123"
+        }
+    )
+    assert response.status_code == 200
+    set_cookie = response.headers.get("set-cookie")
+    assert "secure" in set_cookie.lower()


### PR DESCRIPTION
This PR addresses a security vulnerability where session cookies were not marked as 'Secure' by default. By changing the default value of `COOKIE_SECURE` to `True`, the application now follows the 'secure by default' principle. Developers working in local environments without HTTPS can still override this setting by setting `COOKIE_SECURE=false` in their environment variables, as now documented in the `README.md`. A new test suite has been added to ensure this behavior is preserved.

---
*PR created automatically by Jules for task [11379888373107209314](https://jules.google.com/task/11379888373107209314) started by @eburairu*