### PR TITLE
Fix Next.js build error: Property 'length' does not exist on type '{}'

### DIFF
--- a/frontend/hooks/useData.ts
+++ b/frontend/hooks/useData.ts
@@ -5,6 +5,7 @@ import type { Feeding } from '@/types/feeding';
 import type { Diaper } from '@/types/diaper';
 import type { Sleep } from '@/types/sleep';
 import type { Growth } from '@/types/growth';
+import type { Baby } from '@/types/baby';
 
 export function useFamilySettings() {
     const { data, error, isLoading, mutate } = useSWR('/family/', fetcher);
@@ -27,7 +28,7 @@ export function useFamilyMembers() {
 }
 
 export function useBabies() {
-    const { data, error, isLoading, mutate } = useSWR('/babies/', fetcher);
+    const { data, error, isLoading, mutate } = useSWR<Baby[]>('/babies/', fetcher);
     return {
         babies: data,
         isLoading,

--- a/frontend/types/baby.ts
+++ b/frontend/types/baby.ts
@@ -1,0 +1,7 @@
+export interface Baby {
+    id: number
+    name: string
+    birthday: string | null
+    due_date: string | null
+    gender?: string | null
+}


### PR DESCRIPTION
- Created `frontend/types/baby.ts` with `Baby` interface to prevent inference issues.
- Updated `frontend/hooks/useData.ts` to explicitly type `useBabies` return value as `Baby[]`.
- This resolves the `Property 'length' does not exist on type '{}'` error during build.

---
*PR created automatically by Jules for task [1084665810912801286](https://jules.google.com/task/1084665810912801286) started by @eburairu*