### PR TITLE
🧹 Remove unnecessary any cast in baby settings

### DIFF
--- a/frontend/app/(dashboard)/settings/babies/page.tsx
+++ b/frontend/app/(dashboard)/settings/babies/page.tsx
@@ -37,7 +37,7 @@ export default function BabySettingsPage() {
 
     if (!user) return null
 
-    const currentMember = members?.find((m: any) => m.username === user.username)
+    const currentMember = members?.find((m) => m.username === user.username)
     const isAdmin = currentMember?.role === "admin"
 
     return (


### PR DESCRIPTION
🎯 **What:** Removed the explicit `any` cast on the member parameter in `frontend/app/(dashboard)/settings/babies/page.tsx`.
💡 **Why:** The `members` array is already typed by `useFamilyMembers`, so TypeScript can correctly infer the type of `m`. Removing `any` improves type safety and code readability.
✅ **Verification:** Verified that `members` is typed as `{ user_id: number; username: string; role: string; joined_at: string }[]`. Ran `npm run lint` with no errors in the file. `bun test` passed for utility functions.
✨ **Result:** Cleaner code with better type inference.

---
*PR created automatically by Jules for task [5000418118100390680](https://jules.google.com/task/5000418118100390680) started by @eburairu*