### PR TITLE
🧹 Replace print with logging in ai_summary.py

### DIFF
--- a/app/services/ai_summary.py
+++ b/app/services/ai_summary.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from datetime import date, datetime, timedelta, timezone
 from typing import Tuple
 from sqlalchemy.orm import Session
@@ -8,6 +9,8 @@ from app.models.feeding import Feeding
 from app.models.sleep import Sleep
 from app.models.diaper import Diaper
 from app.models.growth import Growth
+
+logger = logging.getLogger(__name__)
 
 
 def get_llm_client() -> Tuple[OpenAI, str]:
@@ -211,7 +214,7 @@ def update_baby_characteristics(
             update_baby(db, baby, {"characteristics": new_characteristics})
 
     except Exception as e:
-        print(f"Failed to update characteristics: {e}")
+        logger.error(f"Failed to update characteristics: {e}")
         # 特徴更新の失敗は日誌生成自体を失敗させない（ログ出力のみ）
 
 


### PR DESCRIPTION
The `print` statement used for error logging in `app/services/ai_summary.py` was replaced with `logging.error` to improve maintainability and follow better logging practices.

Changes:
- Added `import logging` to `app/services/ai_summary.py`.
- Initialized `logger = logging.getLogger(__name__)` at the module level.
- Replaced `print(f"Failed to update characteristics: {e}")` with `logger.error(f"Failed to update characteristics: {e}")` in the `update_baby_characteristics` function.

Verification:
- Syntax validated with `python3 -m py_compile`.
- Manual inspection of code and indentation.
- Code review performed and approved.

---
*PR created automatically by Jules for task [2752530859030452051](https://jules.google.com/task/2752530859030452051) started by @eburairu*