### PR TITLE
🎨 Palette: Navigation improvements with sidebar menu

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-02-14 - Button Accessibility and Feedback
 **Learning:** Icon-only buttons (like those using Lucide icons) are often missed by screen readers if they lack `aria-label`. Also, async actions in widgets often used `disabled={loading}` which lacks visual feedback compared to `loading={loading}` which shows a spinner.
 **Action:** Always verify icon-only buttons have `aria-label` or `title`. Prefer `loading={loading}` over `disabled={loading}` for `Button` components to provide immediate visual feedback.
+
+## 2026-02-14 - Navigation Context Awareness
+**Learning:** Users may have different mental models for "Back" vs "Menu" depending on the context. In deep hierarchies like Settings, a "Back" button is expected, while in flat feature areas (Dashboard, Feeding, etc.), a "Menu" button is preferred for lateral navigation.
+**Action:** Implement dynamic navigation headers that switch between "Back" and "Hamburger Menu" based on the current path depth and context, rather than forcing a single pattern globally.

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -6,10 +6,30 @@ import { useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { api } from "@/lib/api"
-import { ChevronLeft, Settings } from "lucide-react"
+import { ChevronLeft, Settings, Menu } from "lucide-react"
 import { useBabies } from "@/hooks/useData"
 import { useBabyStore } from "@/stores/babyStore"
 import { getDisplayName } from "@/lib/utils"
+import {
+    Sheet,
+    SheetContent,
+    SheetTrigger,
+    SheetHeader,
+    SheetTitle,
+    SheetDescription,
+    SheetClose,
+} from "@/components/ui/sheet"
+
+const NAV_ITEMS = [
+    { label: "ホーム", href: "/", icon: "🏠" },
+    { label: "授乳", href: "/feeding", icon: "🍼" },
+    { label: "おむつ", href: "/diaper", icon: "👶" },
+    { label: "睡眠", href: "/sleep", icon: "💤" },
+    { label: "成長", href: "/growth", icon: "📏" },
+    { label: "陣痛", href: "/contraction", icon: "⏱️" },
+    { label: "日記", href: "/diary", icon: "📝" },
+    { label: "設定", href: "/settings", icon: "⚙️" },
+]
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
     const { user, isLoading, mutate } = useUser()
@@ -40,19 +60,47 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         }
     }
 
-    const isRoot = pathname === "/"
+    const isSettingsSubPage = pathname.startsWith("/settings/") && pathname !== "/settings"
 
     return (
         <div className="min-h-screen bg-gray-100 font-sans">
             <header className="bg-white/80 backdrop-blur-md sticky top-0 z-50 shadow-sm">
                 <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8 flex justify-between items-center">
                     <div className="flex items-center gap-2">
-                        {!isRoot && (
-                            <Link href="/">
-                                <Button variant="ghost" size="icon" className="mr-1">
+                        {isSettingsSubPage ? (
+                            <Link href="/settings">
+                                <Button variant="ghost" size="icon" className="mr-1" aria-label="設定に戻る">
                                     <ChevronLeft className="h-5 w-5" />
                                 </Button>
                             </Link>
+                        ) : (
+                            <Sheet>
+                                <SheetTrigger asChild>
+                                    <Button variant="ghost" size="icon" className="mr-1" aria-label="メニューを開く">
+                                        <Menu className="h-5 w-5" />
+                                    </Button>
+                                </SheetTrigger>
+                                <SheetContent side="left">
+                                    <SheetHeader>
+                                        <SheetTitle>メニュー</SheetTitle>
+                                        <SheetDescription>
+                                            機能を選択してください
+                                        </SheetDescription>
+                                    </SheetHeader>
+                                    <nav className="mt-6 flex flex-col gap-2">
+                                        {NAV_ITEMS.map((item) => (
+                                            <SheetClose asChild key={item.href}>
+                                                <Link href={item.href} className="w-full">
+                                                    <Button variant="ghost" className="w-full justify-start text-lg h-12" aria-label={item.label}>
+                                                        <span className="mr-3 text-xl">{item.icon}</span>
+                                                        {item.label}
+                                                    </Button>
+                                                </Link>
+                                            </SheetClose>
+                                        ))}
+                                    </nav>
+                                </SheetContent>
+                            </Sheet>
                         )}
                         <Link href="/">
                             <h1 className="text-xl font-bold tracking-tight text-gray-900">Baby App</h1>
@@ -68,11 +116,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                             Welcome, {user && getDisplayName(user)}
                         </span>
                         <Link href="/settings">
-                            <Button variant="ghost" size="icon" className="text-gray-500">
+                            <Button variant="ghost" size="icon" className="text-gray-500" aria-label="設定">
                                 <Settings className="h-5 w-5" />
                             </Button>
                         </Link>
-                        <Button variant="ghost" size="sm" onClick={handleLogout} className="text-gray-500">Logout</Button>
+                        <Button variant="ghost" size="sm" onClick={handleLogout} className="text-gray-500" aria-label="ログアウト">Logout</Button>
                     </div>
                 </div>
             </header>

--- a/frontend/components/ui/sheet.tsx
+++ b/frontend/components/ui/sheet.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/frontend/lib/ageUtils.ts
+++ b/frontend/lib/ageUtils.ts
@@ -19,10 +19,10 @@ export function calcAge(birthday: string): { months: number; days: number; label
         // 誕生日の日が前月の末日より大きい場合（例：1月31日生まれで前月が28日まで）、
         // 前月の末日を基準にする
         const referenceDay = Math.min(birth.getDate(), prevMonthLastDay);
-        let days = now.getDate() + (prevMonthLastDay - referenceDay);
+        const days = now.getDate() + (prevMonthLastDay - referenceDay);
         return { months, days, label: createLabel(months, days) };
     } else {
-        let days = dayOfMonth;
+        const days = dayOfMonth;
         return { months, days, label: createLabel(months, days) };
     }
 }


### PR DESCRIPTION
💡 What:
- Added a `Sheet` component for a sidebar drawer navigation.
- Replaced the global "Back to Dashboard" button with a hamburger menu in the layout.
- Implemented context-aware navigation: shows "Back" button only in Settings subpages, otherwise shows the menu.

🎯 Why:
- Users found it tedious to go back to the dashboard to switch features.
- Deep navigation in Settings requires a specific "Back" context, while feature pages benefit from lateral navigation.

📸 Before/After:
- Before: Always back to dashboard.
- After: Hamburger menu for quick access to all features, Back button for deep hierarchy in settings.

♿ Accessibility:
- Added ARIA labels for menu and back buttons.
- Ensure keyboard focus management within the drawer using Radix UI primitives.

---
*PR created automatically by Jules for task [9514847375961944309](https://jules.google.com/task/9514847375961944309) started by @eburairu*