### PR TITLE
⚡ [performance] Optimize N+1 query in get_baby_permissions

### DIFF
--- a/app/routers/baby_permissions.py
+++ b/app/routers/baby_permissions.py
@@ -39,14 +39,23 @@ def get_baby_permissions(
 
     record_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule"]
     
+    # 3. 全メンバーの BabyPermission を一括取得（N+1 の解消）
+    member_user_ids = [u.id for _, u in members]
+    all_perms = db.query(BabyPermission).filter(
+        BabyPermission.baby_id == baby_id,
+        BabyPermission.user_id.in_(member_user_ids)
+    ).all()
+
+    # ユーザーごとの権限マップを作成 {user_id: {record_type: can_view}}
+    perms_by_user = {}
+    for p in all_perms:
+        if p.user_id not in perms_by_user:
+            perms_by_user[p.user_id] = {}
+        perms_by_user[p.user_id][p.record_type] = p.can_view
+
     response_members = []
     for fu, u in members:
-        # 3. 各ユーザーについて BabyPermission を検索
-        perms = db.query(BabyPermission).filter(
-            BabyPermission.baby_id == baby_id,
-            BabyPermission.user_id == u.id
-        ).all()
-        perm_dict = {p.record_type: p.can_view for p in perms}
+        perm_dict = perms_by_user.get(u.id, {})
         
         user_perms = []
         for rt in record_types:


### PR DESCRIPTION
The `get_baby_permissions` endpoint previously executed a separate database query for each member of a family to fetch their permissions for a specific baby. This led to an N+1 query problem, where the number of queries increased linearly with the number of family members.

This PR optimizes the data retrieval by:
1. Identifying all involved user IDs upfront.
2. Executing a single bulk query to fetch all relevant `BabyPermission` records.
3. Mapping these records in memory using a dictionary for constant-time lookup within the results loop.

This change reduces the number of database roundtrips and improves the overall responsiveness of the permission management feature.

---
*PR created automatically by Jules for task [5240795778604182188](https://jules.google.com/task/5240795778604182188) started by @eburairu*