### PR TITLE
🧹 [code health] Use strict Growth[] type in GrowthChart

### DIFF
--- a/frontend/components/growth/GrowthChart.tsx
+++ b/frontend/components/growth/GrowthChart.tsx
@@ -12,9 +12,10 @@ import {
 } from "recharts"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { Growth } from "@/types/growth"
 
 interface GrowthChartProps {
-    records: any[]
+    records: Growth[]
 }
 
 export function GrowthChart({ records }: GrowthChartProps) {


### PR DESCRIPTION
**What:**
Replaced `any[]` with strict `Growth[]` type in `frontend/components/growth/GrowthChart.tsx`.

**Why:**
Using `any[]` bypasses TypeScript's type checking. By using the `Growth` interface defined in `frontend/types/growth.ts`, we ensure that the component receives and uses the correct data structure, improving maintainability and reducing the risk of bugs.

**Verification:**
- Verified that `frontend/types/growth.ts` defines the `Growth` interface correctly matching the data used in the component.
- Confirmed that `useGrowths` hook in `frontend/hooks/useData.ts` returns `Growth[]`, ensuring compatibility with the updated component props.
- Ran `npm run lint` and `npm run build` in the `frontend` directory. The build succeeded.
- Reviewed `GrowthChart` implementation to ensure it only accesses properties present in the `Growth` interface (`date`, `height`, `weight`, `head_circumference`).

**Result:**
The `GrowthChart` component now has strong typing for its props. The change is purely a type-level refactor and preserves all existing functionality.

---
*PR created automatically by Jules for task [8696893189463343561](https://jules.google.com/task/8696893189463343561) started by @eburairu*