### PR TITLE
🧪 Test getDisplayName Utility

### DIFF
--- a/frontend/__tests__/utils.test.ts
+++ b/frontend/__tests__/utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import { getDisplayName, cn } from "@/lib/utils"
+
+describe("utils", () => {
+  describe("getDisplayName", () => {
+    it("should return trimmed display_name when it exists", () => {
+      const user = { username: "johndoe", display_name: " John Doe " }
+      expect(getDisplayName(user)).toBe("John Doe")
+    })
+
+    it("should return username when display_name is null", () => {
+      const user = { username: "johndoe", display_name: null }
+      expect(getDisplayName(user)).toBe("johndoe")
+    })
+
+    it("should return username when display_name is undefined", () => {
+      const user = { username: "johndoe" }
+      expect(getDisplayName(user)).toBe("johndoe")
+    })
+
+    it("should return username when display_name is an empty string", () => {
+      const user = { username: "johndoe", display_name: "" }
+      expect(getDisplayName(user)).toBe("johndoe")
+    })
+
+    it("should return username when display_name is only whitespace", () => {
+      const user = { username: "johndoe", display_name: "   " }
+      expect(getDisplayName(user)).toBe("johndoe")
+    })
+  })
+
+  describe("cn", () => {
+    it("should merge class names", () => {
+      expect(cn("foo", "bar")).toBe("foo bar")
+    })
+
+    it("should handle conditional classes", () => {
+      expect(cn("foo", true && "bar", false && "baz")).toBe("foo bar")
+    })
+
+    it("should resolve tailwind class conflicts", () => {
+      expect(cn("px-2 py-2", "p-4")).toBe("p-4")
+    })
+
+    it("should handle undefined and null", () => {
+      expect(cn("foo", undefined, null, "bar")).toBe("foo bar")
+    })
+  })
+})


### PR DESCRIPTION
Implemented unit tests for the `getDisplayName` and `cn` utility functions in `frontend/lib/utils.ts`. 

The new tests are located in `frontend/__tests__/utils.test.ts` and cover various edge cases including null, undefined, empty strings, and whitespace for the display name. Additionally, tests for the `cn` utility were added to ensure proper class name merging and Tailwind conflict resolution.

Logic was verified using a standalone Bun script to confirm the correctness of the implementation despite environment-specific issues with the test runner.

---
*PR created automatically by Jules for task [6808790865717812960](https://jules.google.com/task/6808790865717812960) started by @eburairu*