### PR TITLE
Refactor: Centralize config constants to fix local import and duplication

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,4 @@
+import os
+
+SESSION_EXPIRE_DAYS = 7
+COOKIE_SECURE = os.getenv("COOKIE_SECURE", "true").lower() == "true"

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,10 +1,11 @@
 from typing import Generator, Annotated
 from fastapi import Depends, HTTPException, status, Request
 from sqlalchemy.orm import Session
-from datetime import datetime
+from datetime import datetime, timedelta
 from app.database import SessionLocal
 from app.models.baby import Baby, BabyPermission
 from app.models.family import FamilyUser
+from app.config import SESSION_EXPIRE_DAYS
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -33,14 +34,7 @@ def get_current_user(request: Request, db: db_dependency):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired session")
 
     # Sliding session: extend expiration
-    from datetime import timedelta
-    # Assuming SESSION_EXPIRE_DAYS is defined somewhere common or I can import it, 
-    # but strictly following the file content I might need to redefine or import it.
-    # Let's import it from auth router if possible, or just use 7 as per spec.
-    # To avoid circular import, I'll use a constant or hardcode 7 for now as it's defined in auth.py
-    # Better yet, I will define it here or use a config.
-    # For now, I will use 7 days as per spec.
-    session.expires_at = datetime.now() + timedelta(days=7)
+    session.expires_at = datetime.now() + timedelta(days=SESSION_EXPIRE_DAYS)
     db.commit()
 
     user = db.query(User).filter(User.id == session.user_id).first()

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,4 +1,4 @@
-import os
+
 import secrets
 from datetime import datetime, timedelta
 
@@ -13,11 +13,10 @@ from app.schemas.user import UserCreate, UserResponse, UserProfileUpdate
 from app.models.user import User, UserSession
 from app.models.family import Family, FamilyUser
 from app.services.auth import verify_password, get_password_hash
+from app.config import SESSION_EXPIRE_DAYS, COOKIE_SECURE
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
-SESSION_EXPIRE_DAYS = 7
-COOKIE_SECURE = os.getenv("COOKIE_SECURE", "true").lower() == "true"
 
 
 def _create_session(db: Session, user_id: int) -> str:


### PR DESCRIPTION
- **What:** Moved `SESSION_EXPIRE_DAYS` and `COOKIE_SECURE` to a new `app/config.py` file.
- **Why:** Resolved a code health issue in `app/dependencies.py` involving a local import of `timedelta` and duplicated/hardcoded session expiration logic. This also prevents potential circular dependencies between `dependencies.py` and `auth.py`.
- **Verification:** Verified by running `pytest tests/test_auth_session.py` and `tests/test_auth.py`, which passed successfully.
- **Result:** The codebase is cleaner, with centralized configuration and no local imports for standard library types in dependencies.

---
*PR created automatically by Jules for task [953581464149505214](https://jules.google.com/task/953581464149505214) started by @eburairu*