### PR TITLE
🔒 Fix Exposed Default Credentials in Frontend Bundle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,6 @@
 DATABASE_URL=postgresql://neondb_owner:<password>@<endpoint>.ap-southeast-1.aws.neon.tech/neondb?sslmode=require
 TZ=Asia/Tokyo
 
-# Test User Info (for development)
-NEXT_PUBLIC_TEST_USER_USERNAME=testuser
-NEXT_PUBLIC_TEST_USER_PASSWORD=password123
 TEST_USER_USERNAME=testuser
 TEST_USER_PASSWORD=password123
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was vulnerable to path traversal attacks via the `serve_frontend` endpoint. The `full_path` parameter was passed directly to `os.path.join`, allowing attackers to access files outside the intended directory using `..` sequences or absolute paths.
 **Learning:** Relying on web server or framework defaults to sanitize paths can be risky. Always explicitly validate that the resolved path is within the intended base directory.
 **Prevention:** Use `os.path.abspath` to resolve the target path and check if it starts with the canonical base path. Avoid trusting user-supplied path components blindly.
+
+## 2026-02-14 - Exposed Default Credentials in Frontend Bundle
+**Vulnerability:** Default test credentials (username and password) were exposed in the frontend bundle because they were assigned to `NEXT_PUBLIC_` environment variables. In Next.js, variables prefixed with `NEXT_PUBLIC_` are embedded in the client-side JavaScript during build time, making them visible to anyone inspecting the source code.
+**Learning:** Never use `NEXT_PUBLIC_` for sensitive information, even for "test" or "default" credentials. Anything prefixed with `NEXT_PUBLIC_` is public by design.
+**Prevention:** Use empty strings for default values in frontend forms. If default credentials are needed for automated testing, they should be handled by the testing framework (e.g., Playwright) or server-side scripts, never hardcoded or bundled into the client-side application.

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -33,8 +33,8 @@ export default function LoginPage() {
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema),
         defaultValues: {
-            username: process.env.NEXT_PUBLIC_TEST_USER_USERNAME || "",
-            password: process.env.NEXT_PUBLIC_TEST_USER_PASSWORD || "",
+            username: "",
+            password: "",
         },
     })
 


### PR DESCRIPTION
### 🎯 What:
Fixed a security vulnerability where default test credentials were exposed in the frontend bundle.

### ⚠️ Risk:
Variables prefixed with `NEXT_PUBLIC_` in Next.js are embedded in the browser-side JavaScript. Using them for credentials (even defaults) exposes them to anyone who views the source, potentially allowing unauthorized access if these credentials work on any environment.

### 🛡️ Solution:
- Removed `process.env.NEXT_PUBLIC_TEST_USER_USERNAME` and `process.env.NEXT_PUBLIC_TEST_USER_PASSWORD` usage in `frontend/app/(auth)/login/page.tsx`.
- Changed form `defaultValues` to empty strings.
- Removed the problematic variables from `.env.example`.
- Documented the fix in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9527495268465598783](https://jules.google.com/task/9527495268465598783) started by @eburairu*