### PR TITLE
chore: replace any with Growth type in GrowthPage and components

### DIFF
--- a/frontend/app/(dashboard)/growth/page.tsx
+++ b/frontend/app/(dashboard)/growth/page.tsx
@@ -14,6 +14,7 @@ import { PageLoading } from "@/components/ui/page-loading"
 import { AccessDenied } from "@/components/ui/access-denied"
 import { ChevronLeft, TrendingUp } from "lucide-react"
 import Link from "next/link"
+import type { Growth } from "@/types/growth"
 
 export default function GrowthPage() {
     const searchParams = useSearchParams()
@@ -26,9 +27,9 @@ export default function GrowthPage() {
     const { growths, isLoading, isError: growthError, mutate } = useGrowths(babyId)
 
     const [isFormOpen, setIsFormOpen] = useState(false)
-    const [editingRecord, setEditingRecord] = useState<any>(null)
+    const [editingRecord, setEditingRecord] = useState<Growth | null>(null)
 
-    const handleEdit = (record: any) => {
+    const handleEdit = (record: Growth) => {
         setEditingRecord(record)
         setIsFormOpen(true)
     }

--- a/frontend/components/growth/GrowthHistoryList.tsx
+++ b/frontend/components/growth/GrowthHistoryList.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState } from "react"
-import { format } from "date-fns"
 import { Edit2, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { api } from "@/lib/api"
@@ -15,10 +14,11 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import type { Growth } from "@/types/growth"
 
 interface GrowthHistoryListProps {
-    records: any[]
-    onEdit: (record: any) => void
+    records: Growth[]
+    onEdit: (record: Growth) => void
     onDeleteSuccess: () => void
 }
 

--- a/frontend/components/growth/GrowthRecordForm.tsx
+++ b/frontend/components/growth/GrowthRecordForm.tsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
 import { format } from "date-fns"
-import { CalendarIcon, Loader2 } from "lucide-react"
+import { Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
     Dialog,
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { api } from "@/lib/api"
+import type { Growth } from "@/types/growth"
 
 const growthSchema = z.object({
     date: z.string().min(1, "日付を選択してください"),
@@ -33,7 +34,7 @@ type GrowthFormValues = z.infer<typeof growthSchema>
 
 interface GrowthRecordFormProps {
     babyId: number
-    record?: any
+    record?: Growth | null
     isOpen: boolean
     onClose: () => void
     onSuccess: () => void


### PR DESCRIPTION
🎯 **What:**
Code health improvement to replace usage of `any` with strict `Growth` types in the Growth tracking feature.

💡 **Why:**
Using `any` undermines TypeScript's type safety and can lead to runtime errors. By introducing strict types, we ensure that:
- `GrowthPage` correctly manages the editing record state.
- `GrowthHistoryList` and `GrowthRecordForm` components receive and handle data with the correct structure.
- The codebase becomes more maintainable and readable.

✅ **Verification:**
- Ran `npm run lint` to confirm that the `any` usage errors related to Growth components are resolved.
- Ran `npm run build` to ensure the project builds successfully.
- Ran `npm run test` to verify no regressions in existing tests.

✨ **Result:**
The `handleEdit` function and `editingRecord` state in `GrowthPage`, as well as props in `GrowthHistoryList` and `GrowthRecordForm`, now use the `Growth` interface, eliminating `any` types in this module.

---
*PR created automatically by Jules for task [4881729278094933869](https://jules.google.com/task/4881729278094933869) started by @eburairu*