### PR TITLE
Fix dataKey for head circumference and weight units in GrowthChart

### DIFF
--- a/frontend/__tests__/growthUtils.test.ts
+++ b/frontend/__tests__/growthUtils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest"
+import { mergeData } from "../utils/growthUtils"
+
+describe("growthUtils", () => {
+    describe("mergeData", () => {
+        const mockRecords = [
+            {
+                date: "2023-01-01",
+                weight: 3000,
+                height: 50,
+                head_circumference: 34
+            }
+        ];
+
+        it("should convert weight from grams to kilograms", () => {
+            const merged = mergeData(mockRecords, [], 'weight');
+            expect(merged[0].weight).toBe(3);
+        });
+
+        it("should use 'head' key for head circumference", () => {
+            const merged = mergeData(mockRecords, [], 'head');
+            expect(merged[0].head).toBe(34);
+        });
+
+        it("should use 'height' key for height", () => {
+            const merged = mergeData(mockRecords, [], 'height');
+            expect(merged[0].height).toBe(50);
+        });
+
+        it("should include WHO data with correct keys for head", () => {
+            const whoData = [
+                { date: new Date("2023-01-01").getTime(), p3: 31, p50: 34, p97: 37, month: 0 }
+            ];
+            const merged = mergeData([], whoData, 'head');
+            expect(merged[0].who_head_p3).toBe(31);
+            expect(merged[0].who_head_p50).toBe(34);
+            expect(merged[0].who_head_p97).toBe(37);
+        });
+
+        it("should include WHO data with correct keys for weight", () => {
+            const whoData = [
+                { date: new Date("2023-01-01").getTime(), p3: 2.5, p50: 3.3, p97: 4.3, month: 0 }
+            ];
+            const merged = mergeData([], whoData, 'weight');
+            expect(merged[0].who_weight_p3).toBe(2.5);
+            expect(merged[0].who_weight_p50).toBe(3.3);
+            expect(merged[0].who_weight_p97).toBe(4.3);
+        });
+    });
+});

--- a/frontend/components/growth/GrowthChart.tsx
+++ b/frontend/components/growth/GrowthChart.tsx
@@ -154,17 +154,7 @@ export function GrowthChart({ records, babyBirthday, babyGender }: GrowthChartPr
                     </TabsContent>
 
                     <TabsContent value="head" className="h-[300px]">
-                        {renderChart(chartData.head, "head_circumference_cm", "cm", "#ff7300")}
-                        {/* Note: dataKey in chartData logic uses 'head' but the record has 'head_circumference_cm'.
-                             In mergeData, I used [type]: ... 
-                             If type is 'head', I mapped it to r.head_circumference.
-                             But in `renderChart(..., "head_circumference_cm"...)`
-                             The data point key must match dataKey.
-                             In mergeData: `[type]: ...` -> `head: ...`
-                             So dataKey should be `head` not `head_circumference_cm`. 
-                             I need to correct the renderChart call or mergeType logic.
-                             I'll fix dataKey in renderChart call.
-                         */}
+                        {renderChart(chartData.head, "head", "cm", "#ff7300")}
                     </TabsContent>
                 </Tabs>
             </CardContent>

--- a/frontend/utils/growthUtils.ts
+++ b/frontend/utils/growthUtils.ts
@@ -77,10 +77,19 @@ export function mergeData(records: any[], whoData: WhoDataPoint[], type: 'height
     // Add User Records
     for (const r of records) {
         const d = new Date(r.date);
+        let value = null;
+        if (type === 'weight') {
+            value = r.weight ? r.weight / 1000 : null;
+        } else if (type === 'height') {
+            value = r.height;
+        } else if (type === 'head') {
+            value = r.head_circumference;
+        }
+
         allPoints.push({
             date: d.getTime(),
             originalDate: r.date,
-            [type]: type === 'weight' ? r.weight : (type === 'height' ? r.height : r.head_circumference),
+            [type]: value,
             // User data does NOT have WHO values initially
         });
     }


### PR DESCRIPTION
The growth chart had a dataKey mismatch for head circumference, where the chart was looking for 'head_circumference_cm' but the data utility was providing 'head'. I corrected this in GrowthChart.tsx. Additionally, I updated the mergeData utility to convert weight from grams (stored in DB) to kilograms (used in chart/WHO standards) and added a test suite to ensure the mapping logic is correct.

---
*PR created automatically by Jules for task [4945190997099953252](https://jules.google.com/task/4945190997099953252) started by @eburairu*