### PR TITLE
🔒 [security fix] Add input validation to user schemas

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Default test credentials (username and password) were exposed in the frontend bundle because they were assigned to `NEXT_PUBLIC_` environment variables. In Next.js, variables prefixed with `NEXT_PUBLIC_` are embedded in the client-side JavaScript during build time, making them visible to anyone inspecting the source code.
 **Learning:** Never use `NEXT_PUBLIC_` for sensitive information, even for "test" or "default" credentials. Anything prefixed with `NEXT_PUBLIC_` is public by design.
 **Prevention:** Use empty strings for default values in frontend forms. If default credentials are needed for automated testing, they should be handled by the testing framework (e.g., Playwright) or server-side scripts, never hardcoded or bundled into the client-side application.
+
+## 2026-02-15 - Missing Input Validation in User Schemas
+**Vulnerability:** User-related schemas (`UserCreate`, `FamilyCreate`, `LoginRequest`) lacked input validation for length and complexity. This could allow attackers to perform DoS attacks by sending massive payloads (e.g., extremely long passwords that take significant time to hash) or bypass expected security standards for passwords.
+**Learning:** Pydantic models should always include reasonable `min_length`, `max_length`, and `pattern` constraints for user-supplied data to prevent resource exhaustion and ensure data integrity.
+**Prevention:** Use Pydantic's `Field` with `min_length`, `max_length`, and `pattern` (regex) to enforce constraints. For login schemas, prioritize `max_length` for DoS protection while ensuring compatibility with existing users.

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class LoginRequest(BaseModel):
-    username: str
-    password: str
+    username: str = Field(..., max_length=50)
+    password: str = Field(..., max_length=128)

--- a/app/schemas/family.py
+++ b/app/schemas/family.py
@@ -1,12 +1,12 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime
 from typing import Optional
 
 
 class FamilyCreate(BaseModel):
-    name: str
-    username: str
-    password: str
+    name: str = Field(..., min_length=1, max_length=100)
+    username: str = Field(..., min_length=3, max_length=50, pattern=r"^[a-zA-Z0-9_-]+$")
+    password: str = Field(..., min_length=8, max_length=128, pattern=r"^(?=.*[a-zA-Z])(?=.*\d).+$")
 
 
 class FamilyResponse(BaseModel):
@@ -20,7 +20,7 @@ class FamilyResponse(BaseModel):
 
 
 class FamilyUpdate(BaseModel):
-    name: str
+    name: str = Field(..., min_length=1, max_length=100)
 
 
 class FamilyMemberResponse(BaseModel):

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -4,8 +4,8 @@ from datetime import datetime
 
 
 class UserCreate(BaseModel):
-    username: str
-    password: str
+    username: str = Field(..., min_length=3, max_length=50, pattern=r"^[a-zA-Z0-9_-]+$")
+    password: str = Field(..., min_length=8, max_length=128, pattern=r"^(?=.*[a-zA-Z])(?=.*\d).+$")
 
 
 class UserProfileUpdate(BaseModel):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -51,10 +51,10 @@ def test_login_failure(client):
     assert response.status_code == 401
 
 def test_get_me(auth_client):
-    client = auth_client(username="me", password="password123")
+    client = auth_client(username="meuser", password="password123")
     response = client.get("/api/auth/me")
     assert response.status_code == 200
-    assert response.json()["username"] == "me"
+    assert response.json()["username"] == "meuser"
 
 def test_logout(auth_client):
     client = auth_client()
@@ -68,7 +68,7 @@ def test_join_family(client):
     # 家族作成
     res = client.post(
         "/api/auth/register/family",
-        json={"name": "Existing Family", "username": "admin", "password": "password"}
+        json={"name": "Existing Family", "username": "admin", "password": "password123"}
     )
     invite_code = res.json()["invite_code"]
     client.cookies.clear()


### PR DESCRIPTION
This PR addresses a security vulnerability where user-related schemas lacked input validation.

### 🎯 What: The vulnerability fixed
Missing input validation (length and complexity) in `UserCreate`, `FamilyCreate`, and `LoginRequest` Pydantic models.

### ⚠️ Risk: The potential impact if left unfixed
- **Denial of Service (DoS):** Attackers could send massive payloads (e.g., extremely long passwords) that consume excessive CPU during hashing or memory in database buffers.
- **Security Standards:** Users could create weak passwords or usernames with potentially dangerous characters.

### 🛡️ Solution: How the fix addresses the vulnerability
- Implemented `min_length` and `max_length` using Pydantic `Field`.
- Added regex `pattern` to ensure usernames use safe characters and passwords contain at least one letter and one digit.
- `LoginRequest` only uses `max_length` to prevent DoS while maintaining backward compatibility for existing users' logins.
- Updated `tests/test_auth.py` to satisfy the new constraints.
- Verified changes using `py_compile` (syntax check) due to environment limitations for running full tests.

---
*PR created automatically by Jules for task [1593543530620486344](https://jules.google.com/task/1593543530620486344) started by @eburairu*