### PR TITLE
🧹 chore: remove unused import Any in app/routers/baby.py

### DIFF
--- a/app/routers/baby.py
+++ b/app/routers/baby.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from typing import List, Any
+from typing import List
 from datetime import datetime
 from pydantic import BaseModel
 


### PR DESCRIPTION
### 🎯 What
Removed the unused `Any` import from `app/routers/baby.py`.

### 💡 Why
To improve code cleanliness and maintainability by removing dead code.

### ✅ Verification
- Checked for any usage of `Any` in the file using `grep`.
- Verified the syntax of the modified file using `python3 -m py_compile`.
- Requested and received a positive code review.

### ✨ Result
Cleaner code with no unused imports in `app/routers/baby.py`.

---
*PR created automatically by Jules for task [11997678311355968618](https://jules.google.com/task/11997678311355968618) started by @eburairu*