### PR TITLE
⚡ Add pagination to diaper records endpoint

### DIFF
--- a/app/routers/diaper.py
+++ b/app/routers/diaper.py
@@ -11,9 +11,15 @@ router = APIRouter(prefix="/api/diapers", tags=["diapers"])
 
 
 @router.get("/", response_model=List[DiaperResponse])
-def get_diapers(baby_id: int, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+def get_diapers(
+    baby_id: int,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
     verify_baby_access(db, baby_id, current_user.id, record_type="diaper")
-    return db.query(Diaper).filter(Diaper.baby_id == baby_id).order_by(Diaper.change_time.desc()).all()
+    return db.query(Diaper).filter(Diaper.baby_id == baby_id).order_by(Diaper.change_time.desc()).offset(skip).limit(limit).all()
 
 
 @router.post("/", response_model=DiaperResponse)


### PR DESCRIPTION
Implemented pagination for diaper records to optimize performance. Added `skip` and `limit` parameters to the backend API.

---
*PR created automatically by Jules for task [1702369622266216136](https://jules.google.com/task/1702369622266216136) started by @eburairu*