### PR TITLE
🧪 Add tests for Sleep API and fix Pydantic validation issues

### DIFF
--- a/app/schemas/family.py
+++ b/app/schemas/family.py
@@ -1,12 +1,20 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
 from typing import Optional
+import re
 
 
 class FamilyCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     username: str = Field(..., min_length=3, max_length=50, pattern=r"^[a-zA-Z0-9_-]+$")
-    password: str = Field(..., min_length=8, max_length=128, pattern=r"^(?=.*[a-zA-Z])(?=.*\d).+$")
+    password: str = Field(..., min_length=8, max_length=128)
+
+    @field_validator('password')
+    @classmethod
+    def password_complexity(cls, v: str) -> str:
+        if not (re.search(r'[a-zA-Z]', v) and re.search(r'\d', v)):
+            raise ValueError('Password must contain at least one letter and one number')
+        return v
 
 
 class FamilyResponse(BaseModel):

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,11 +1,19 @@
 from typing import Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
+import re
 
 
 class UserCreate(BaseModel):
     username: str = Field(..., min_length=3, max_length=50, pattern=r"^[a-zA-Z0-9_-]+$")
-    password: str = Field(..., min_length=8, max_length=128, pattern=r"^(?=.*[a-zA-Z])(?=.*\d).+$")
+    password: str = Field(..., min_length=8, max_length=128)
+
+    @field_validator('password')
+    @classmethod
+    def password_complexity(cls, v: str) -> str:
+        if not (re.search(r'[a-zA-Z]', v) and re.search(r'\d', v)):
+            raise ValueError('Password must contain at least one letter and one number')
+        return v
 
 
 class UserProfileUpdate(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def client(db):
 @pytest.fixture
 def auth_client(client):
     """認証済みクライアントを作成するためのヘルパー"""
-    def _auth(username="testuser", password="testpassword", family_name="Test Family"):
+    def _auth(username="testuser", password="testpassword1", family_name="Test Family"):
         # 家族とユーザーを登録
         res = client.post(
             "/api/auth/register/family",

--- a/tests/test_baby_characteristics.py
+++ b/tests/test_baby_characteristics.py
@@ -38,7 +38,7 @@ def test_create_baby_with_characteristics(auth_client):
     assert target["characteristics"] == "Updated text"
     
 def test_update_characteristics_partial(auth_client):
-    client = auth_client(username="user2", password="pw", family_name="Fam2")
+    client = auth_client(username="user2", password="password1", family_name="Fam2")
     
     # Create baby without characteristics
     res = client.post(

--- a/tests/test_baby_permissions.py
+++ b/tests/test_baby_permissions.py
@@ -1,6 +1,8 @@
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 from app.main import app
 from app.database import SessionLocal, engine
 from app.models.base import Base
@@ -9,6 +11,15 @@ from app.models.family import Family, FamilyUser
 from app.models.baby import Baby, BabyPermission
 from app.dependencies import get_current_user, get_db
 import uuid
+
+# Setup SQLite engine for this test file
+sqlite_engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=sqlite_engine)
+
 
 # Global mock states
 _mock_user = None
@@ -23,9 +34,9 @@ def mock_get_current_user():
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_db():
-    Base.metadata.create_all(bind=engine)
+    Base.metadata.create_all(bind=sqlite_engine)
     yield
-    Base.metadata.drop_all(bind=engine)
+    Base.metadata.drop_all(bind=sqlite_engine)
 
 @pytest.fixture(autouse=True)
 def overrides():
@@ -37,9 +48,9 @@ def overrides():
 @pytest.fixture
 def db():
     global _test_db
-    connection = engine.connect()
+    connection = sqlite_engine.connect()
     transaction = connection.begin()
-    _test_db = SessionLocal(bind=connection)
+    _test_db = TestingSessionLocal(bind=connection)
     yield _test_db
     _test_db.close()
     transaction.rollback()

--- a/tests/test_security_cookie.py
+++ b/tests/test_security_cookie.py
@@ -9,6 +9,9 @@ def test_cookie_secure_default_is_true():
         del os.environ["COOKIE_SECURE"]
 
     # Reload the module to pick up the default value
+    import app.config
+    importlib.reload(app.config)
+
     import app.routers.auth
     importlib.reload(app.routers.auth)
 
@@ -21,6 +24,9 @@ def test_cookie_secure_can_be_false():
     os.environ["COOKIE_SECURE"] = "false"
 
     # Reload the module
+    import app.config
+    importlib.reload(app.config)
+
     import app.routers.auth
     importlib.reload(app.routers.auth)
 
@@ -31,13 +37,15 @@ def test_cookie_secure_can_be_false():
     del os.environ["COOKIE_SECURE"]
 
 def test_cookie_secure_header_is_present(client):
-    # We need to make sure the app uses the updated COOKIE_SECURE
-    # Since 'client' might have already initialized the app, we might need to reload.
-    # But in a typical pytest setup, the client is created per test or session.
-
-    # Let's ensure COOKIE_SECURE is True for this test
+    # Ensure COOKIE_SECURE is True for this test
     if "COOKIE_SECURE" in os.environ:
         del os.environ["COOKIE_SECURE"]
+
+    # Reload config to pick up environment change
+    import app.config
+    importlib.reload(app.config)
+
+    # Reload auth router so it picks up the new config
     import app.routers.auth
     importlib.reload(app.routers.auth)
 

--- a/tests/test_sleep_api.py
+++ b/tests/test_sleep_api.py
@@ -1,0 +1,191 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+
+@pytest.fixture
+def baby(auth_client):
+    client = auth_client()
+    res = client.post("/api/babies/", json={"name": "Test Baby", "birthday": "2024-01-01", "gender": "boy"})
+    assert res.status_code == 200
+    return client, res.json()["id"]
+
+def test_create_sleep(baby):
+    client, baby_id = baby
+    start_time = datetime.now(timezone.utc)
+    end_time = start_time + timedelta(hours=2)
+
+    response = client.post(
+        "/api/sleeps/",
+        json={
+            "baby_id": baby_id,
+            "start_time": start_time.isoformat(),
+            "end_time": end_time.isoformat(),
+            "notes": "Nap time"
+        }
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["baby_id"] == baby_id
+    assert data["notes"] == "Nap time"
+    # ISO format check might be tricky with timezone, checking existence
+    assert "start_time" in data
+    assert "end_time" in data
+
+def test_create_sleep_no_end_time(baby):
+    client, baby_id = baby
+    start_time = datetime.now(timezone.utc)
+
+    response = client.post(
+        "/api/sleeps/",
+        json={
+            "baby_id": baby_id,
+            "start_time": start_time.isoformat(),
+            "notes": "Ongoing sleep"
+        }
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["baby_id"] == baby_id
+    assert data["end_time"] is None
+
+def test_get_sleeps(baby):
+    client, baby_id = baby
+
+    # Create two sleep records
+    now = datetime.now(timezone.utc)
+
+    # Record 1: 2 hours ago
+    start1 = now - timedelta(hours=2)
+    client.post(
+        "/api/sleeps/",
+        json={
+            "baby_id": baby_id,
+            "start_time": start1.isoformat(),
+            "notes": "First nap"
+        }
+    )
+
+    # Record 2: 1 hour ago (should come first in list as it's more recent)
+    start2 = now - timedelta(hours=1)
+    client.post(
+        "/api/sleeps/",
+        json={
+            "baby_id": baby_id,
+            "start_time": start2.isoformat(),
+            "notes": "Second nap"
+        }
+    )
+
+    response = client.get(f"/api/sleeps/?baby_id={baby_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["notes"] == "Second nap"
+    assert data[1]["notes"] == "First nap"
+
+def test_update_sleep(baby):
+    client, baby_id = baby
+    start_time = datetime.now(timezone.utc)
+
+    # Create
+    create_res = client.post(
+        "/api/sleeps/",
+        json={
+            "baby_id": baby_id,
+            "start_time": start_time.isoformat(),
+            "notes": "Original note"
+        }
+    )
+    sleep_id = create_res.json()["id"]
+
+    # Update
+    end_time = start_time + timedelta(hours=1)
+    response = client.patch(
+        f"/api/sleeps/{sleep_id}",
+        json={
+            "end_time": end_time.isoformat(),
+            "notes": "Updated note"
+        }
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["notes"] == "Updated note"
+    assert data["end_time"] is not None
+
+def test_delete_sleep(baby):
+    client, baby_id = baby
+    start_time = datetime.now(timezone.utc)
+
+    # Create
+    create_res = client.post(
+        "/api/sleeps/",
+        json={
+            "baby_id": baby_id,
+            "start_time": start_time.isoformat()
+        }
+    )
+    sleep_id = create_res.json()["id"]
+
+    # Delete
+    response = client.delete(f"/api/sleeps/{sleep_id}")
+    assert response.status_code == 200
+
+    # Verify deletion (API behavior is usually not to return deleted items)
+    get_res = client.get(f"/api/sleeps/?baby_id={baby_id}")
+    assert len(get_res.json()) == 0
+
+    # Verify 404 on update/delete of deleted item
+    update_res = client.patch(f"/api/sleeps/{sleep_id}", json={"notes": "Try update"})
+    assert update_res.status_code == 404
+
+def test_access_control(auth_client):
+    # User A setup
+    client_a = auth_client(username="user_a", family_name="Family A")
+    res_a = client_a.post("/api/babies/", json={"name": "Baby A", "birthday": "2024-01-01", "gender": "boy"})
+    baby_a_id = res_a.json()["id"]
+
+    # Create sleep record for Baby A
+    sleep_res = client_a.post(
+        "/api/sleeps/",
+        json={
+            "baby_id": baby_a_id,
+            "start_time": datetime.now(timezone.utc).isoformat(),
+            "notes": "Baby A sleep"
+        }
+    )
+    sleep_a_id = sleep_res.json()["id"]
+
+    # User B setup
+    client_b = auth_client(username="user_b", family_name="Family B")
+
+    # User B tries to access Baby A's sleep records
+    get_res = client_b.get(f"/api/sleeps/?baby_id={baby_a_id}")
+    assert get_res.status_code == 403
+
+    # User B tries to update Baby A's sleep record
+    update_res = client_b.patch(
+        f"/api/sleeps/{sleep_a_id}",
+        json={"notes": "Hacked"}
+    )
+    # Depending on implementation, this might be 404 (not found in user's scope) or 403 (forbidden access)
+    # Looking at code:
+    # sleep = db.query(Sleep).filter(Sleep.id == sleep_id).first()
+    # verify_baby_access(db, sleep.baby_id, ...)
+    # If standard verify_baby_access raises 403, then it should be 403.
+    # However, create_sleep checks access BEFORE creation.
+    # update_sleep finds sleep by ID (global lookup), then checks access.
+    assert update_res.status_code == 403
+
+    # User B tries to delete Baby A's sleep record
+    delete_res = client_b.delete(f"/api/sleeps/{sleep_a_id}")
+    assert delete_res.status_code == 403
+
+def test_invalid_operations(baby):
+    client, baby_id = baby
+
+    # Update non-existent
+    response = client.patch("/api/sleeps/99999", json={"notes": "Ghost"})
+    assert response.status_code == 404
+
+    # Delete non-existent
+    response = client.delete("/api/sleeps/99999")
+    assert response.status_code == 404

--- a/tests/test_viewer_role.py
+++ b/tests/test_viewer_role.py
@@ -6,7 +6,7 @@ def test_viewer_default_on_join(client):
     client.post("/api/auth/register/family", json={
         "name": "Admin Family",
         "username": "admin_user",
-        "password": "password"
+        "password": "password1"
     })
     res = client.get("/api/family/")
     invite_code = res.json()["invite_code"]
@@ -15,7 +15,7 @@ def test_viewer_default_on_join(client):
     # 2. 新規ユーザーが参加
     res = client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
         "username": "viewer_user",
-        "password": "password"
+        "password": "password1"
     })
     assert res.status_code == 200
     assert res.json()["role"] == UserRole.VIEWER
@@ -29,7 +29,7 @@ def test_viewer_read_only_access(client):
     client.post("/api/auth/register/family", json={
         "name": "Test Family",
         "username": "admin_user",
-        "password": "password"
+        "password": "password1"
     })
     res = client.post("/api/babies/", json={"name": "Baby", "gender": "boy"})
     baby_id = res.json()["id"]
@@ -39,7 +39,7 @@ def test_viewer_read_only_access(client):
     # 2. VIEWERが参加
     client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
         "username": "viewer_user",
-        "password": "password"
+        "password": "password1"
     })
 
     # 3. 閲覧は可能
@@ -58,7 +58,7 @@ def test_viewer_read_only_access(client):
     # 5. 削除も拒否 (403)
     # まずADMINとして記録作成
     client.cookies.clear()
-    client.post("/api/auth/login", json={"username": "admin_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password1"})
     res = client.post("/api/feedings/", json={
         "baby_id": baby_id,
         "feeding_time": "2024-01-01T10:00:00",
@@ -68,7 +68,7 @@ def test_viewer_read_only_access(client):
     client.cookies.clear()
 
     # 再度VIEWERとしてログイン
-    client.post("/api/auth/login", json={"username": "viewer_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "viewer_user", "password": "password1"})
     res = client.delete(f"/api/feedings/{feeding_id}")
     assert res.status_code == 403
 
@@ -77,7 +77,7 @@ def test_admin_can_change_role(client):
     client.post("/api/auth/register/family", json={
         "name": "Role Family",
         "username": "admin_user",
-        "password": "password"
+        "password": "password1"
     })
     invite_code = client.get("/api/family/").json()["invite_code"]
     client.cookies.clear()
@@ -85,20 +85,20 @@ def test_admin_can_change_role(client):
     # 2. ユーザーが参加 (最初はVIEWER)
     res = client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
         "username": "target_user",
-        "password": "password"
+        "password": "password1"
     })
     user_id = res.json()["id"]
     client.cookies.clear()
 
     # 3. ADMINがロールをMEMBERに変更
-    client.post("/api/auth/login", json={"username": "admin_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password1"})
     res = client.patch(f"/api/family/members/{user_id}/role", json={"role": UserRole.MEMBER})
     assert res.status_code == 200
     assert res.json()["role"] == UserRole.MEMBER
 
     # 4. MEMBERなら作成できることを確認
     client.cookies.clear()
-    client.post("/api/auth/login", json={"username": "target_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "target_user", "password": "password1"})
     res = client.post("/api/babies/", json={"name": "Another Baby", "gender": "girl"})
     # MEMBERは赤ちゃん作成権限はない(ADMINのみ)が、ここでは権限不足で403になるはず
     # 代わりに授乳記録などでテスト
@@ -108,13 +108,13 @@ def test_admin_can_change_role(client):
     # 授乳記録ならMEMBERもOKなはず
     # まずADMINとして赤ちゃん作成
     client.cookies.clear()
-    client.post("/api/auth/login", json={"username": "admin_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password1"})
     res = client.post("/api/babies/", json={"name": "Real Baby", "gender": "boy"})
     baby_id = res.json()["id"]
     client.cookies.clear()
     
     # MEMBERとしてログイン
-    client.post("/api/auth/login", json={"username": "target_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "target_user", "password": "password1"})
     res = client.post("/api/feedings/", json={
         "baby_id": baby_id,
         "feeding_time": "2024-01-01T10:00:00",


### PR DESCRIPTION
I have implemented comprehensive tests for the Sleep API (`app/routers/sleep.py`), covering Create, Read, Update, and Delete (CRUD) operations, as well as access control and error handling.

During the process, I encountered and fixed several issues:
1.  **Pydantic V2 Regex Compatibility**: The existing regex patterns for password validation in `app/schemas/family.py` and `app/schemas/user.py` were using look-arounds, which are not supported by the default `pydantic-core` regex engine. I replaced the `pattern` argument in `Field` with a `@field_validator` using Python's standard `re` module.
2.  **Test Data Weakness**: Existing tests were using weak passwords (e.g., "password") which failed the new (working) validation. I updated `tests/conftest.py`, `tests/test_baby_characteristics.py`, and `tests/test_viewer_role.py` to use stronger passwords (e.g., "password1").
3.  **Test Database Configuration**: `tests/test_baby_permissions.py` was incorrectly importing the production `engine` from `app.database`, causing it to attempt connections to a non-existent Postgres database. I updated it to use a local in-memory SQLite engine, consistent with other tests.
4.  **Configuration Reloading**: `tests/test_security_cookie.py` was flaky because it wasn't reloading `app.config` when mocking environment variables. I added the necessary reloads.

**Coverage:**
- `test_create_sleep`: Valid creation.
- `test_get_sleeps`: Filtering by baby and ordering.
- `test_update_sleep`: Valid update.
- `test_delete_sleep`: Valid deletion.
- `test_access_control`: Ensuring cross-family access is forbidden.
- `test_invalid_operations`: 404 handling.

**Result:**
- 100% test pass rate for `tests/test_sleep_api.py`.
- Regressions in existing tests fixed.
- Improved code reliability with working password validation.


---
*PR created automatically by Jules for task [4013324665813169640](https://jules.google.com/task/4013324665813169640) started by @eburairu*