### PR TITLE
🧪 Add tests for ai_summary.py:build_daily_prompt

### DIFF
--- a/app/schemas/family.py
+++ b/app/schemas/family.py
@@ -1,12 +1,22 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
 from typing import Optional
+import re
 
 
 class FamilyCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     username: str = Field(..., min_length=3, max_length=50, pattern=r"^[a-zA-Z0-9_-]+$")
-    password: str = Field(..., min_length=8, max_length=128, pattern=r"^(?=.*[a-zA-Z])(?=.*\d).+$")
+    password: str = Field(..., min_length=8, max_length=128)
+
+    @field_validator('password')
+    @classmethod
+    def validate_password(cls, v):
+        if not re.search(r"[a-zA-Z]", v):
+            raise ValueError('Password must contain at least one letter')
+        if not re.search(r"\d", v):
+            raise ValueError('Password must contain at least one digit')
+        return v
 
 
 class FamilyResponse(BaseModel):

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,11 +1,21 @@
 from typing import Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
+import re
 
 
 class UserCreate(BaseModel):
     username: str = Field(..., min_length=3, max_length=50, pattern=r"^[a-zA-Z0-9_-]+$")
-    password: str = Field(..., min_length=8, max_length=128, pattern=r"^(?=.*[a-zA-Z])(?=.*\d).+$")
+    password: str = Field(..., min_length=8, max_length=128)
+
+    @field_validator('password')
+    @classmethod
+    def validate_password(cls, v):
+        if not re.search(r"[a-zA-Z]", v):
+            raise ValueError('Password must contain at least one letter')
+        if not re.search(r"\d", v):
+            raise ValueError('Password must contain at least one digit')
+        return v
 
 
 class UserProfileUpdate(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def client(db):
 @pytest.fixture
 def auth_client(client):
     """認証済みクライアントを作成するためのヘルパー"""
-    def _auth(username="testuser", password="testpassword", family_name="Test Family"):
+    def _auth(username="testuser", password="testpassword1", family_name="Test Family"):
         # 家族とユーザーを登録
         res = client.post(
             "/api/auth/register/family",

--- a/tests/test_ai_summary_service.py
+++ b/tests/test_ai_summary_service.py
@@ -1,0 +1,183 @@
+import pytest
+from datetime import datetime, date, timedelta, timezone
+from sqlalchemy.orm import Session
+
+from app.services.ai_summary import build_daily_prompt
+from app.models.baby import Baby
+from app.models.family import Family
+from app.models.user import User
+from app.models.feeding import Feeding, FeedingType
+from app.models.sleep import Sleep
+from app.models.diaper import Diaper, DiaperType
+from app.models.growth import Growth
+
+# JST timezone definition
+JST = timezone(timedelta(hours=9))
+
+@pytest.fixture
+def test_data(db: Session):
+    # Setup Family, User, Baby
+    family = Family(name="Test Family", invite_code="testcode123")
+    db.add(family)
+    db.commit()
+    db.refresh(family)
+
+    user = User(username="testuser", hashed_password="hashed_password", display_name="Test User")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    baby = Baby(family_id=family.id, name="Test Baby", birthday=date(2023, 1, 1), gender="boy")
+    db.add(baby)
+    db.commit()
+    db.refresh(baby)
+
+    return {"family": family, "user": user, "baby": baby}
+
+def test_build_daily_prompt_with_records(db: Session, test_data):
+    baby = test_data["baby"]
+    user = test_data["user"]
+    target_date = date(2024, 1, 15)
+
+    # 1. Feeding Record (10:00 JST)
+    feeding_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=JST)
+    feeding = Feeding(
+        user_id=user.id,
+        baby_id=baby.id,
+        feeding_time=feeding_time,
+        feeding_type=FeedingType.BOTTLE,
+        amount_ml=120,
+        notes="Drank well"
+    )
+    db.add(feeding)
+
+    # 2. Sleep Record (13:00 - 15:00 JST)
+    sleep_start = datetime(2024, 1, 15, 13, 0, 0, tzinfo=JST)
+    sleep_end = datetime(2024, 1, 15, 15, 0, 0, tzinfo=JST)
+    sleep = Sleep(
+        user_id=user.id,
+        baby_id=baby.id,
+        start_time=sleep_start,
+        end_time=sleep_end,
+        notes="Nap"
+    )
+    db.add(sleep)
+
+    # 3. Diaper Record (16:00 JST)
+    change_time = datetime(2024, 1, 15, 16, 0, 0, tzinfo=JST)
+    diaper = Diaper(
+        user_id=user.id,
+        baby_id=baby.id,
+        change_time=change_time,
+        diaper_type=DiaperType.WET,
+        notes="Heavy"
+    )
+    db.add(diaper)
+
+    # 4. Growth Record (Same Date)
+    growth = Growth(
+        user_id=user.id,
+        baby_id=baby.id,
+        date=target_date,
+        weight=8000,
+        height=70.5,
+        head_circumference=45.0,
+        notes="Checkup"
+    )
+    db.add(growth)
+
+    db.commit()
+
+    # Execute
+    prompt, total_records, records_text = build_daily_prompt(db, baby.id, baby.name, target_date)
+
+    # Assertions
+    assert total_records == 4
+
+    # Check if records_text contains key information
+    assert "Test Babyちゃんの2024年01月15日の育児記録です。" in records_text
+
+    # Feeding check
+    assert "【授乳】1回" in records_text
+    assert "10:00 ミルク 120ml" in records_text
+    assert "メモ: Drank well" in records_text
+
+    # Sleep check
+    assert "【睡眠】1回" in records_text
+    assert "13:00〜15:00（120分）" in records_text
+    assert "メモ: Nap" in records_text
+
+    # Diaper check
+    assert "【おむつ】1回" in records_text
+    assert "16:00 おしっこ" in records_text
+    assert "メモ: Heavy" in records_text
+
+    # Growth check
+    assert "【成長記録】" in records_text
+    assert "体重 8.000kg" in records_text
+    assert "身長 70.5cm" in records_text
+    assert "頭囲 45.0cm" in records_text
+
+    # Prompt wrapper check
+    assert "以下は赤ちゃんの育児記録です。" in prompt
+    assert records_text in prompt
+
+def test_build_daily_prompt_no_records(db: Session, test_data):
+    baby = test_data["baby"]
+    target_date = date(2024, 2, 20) # A date with no records
+
+    # Execute
+    prompt, total_records, records_text = build_daily_prompt(db, baby.id, baby.name, target_date)
+
+    # Assertions
+    assert total_records == 0
+    assert "Test Babyちゃんの2024年02月20日の育児記録です。" in records_text
+    assert "【授乳】" not in records_text
+    assert "【睡眠】" not in records_text
+    assert "【おむつ】" not in records_text
+    assert "【成長記録】" not in records_text
+
+def test_build_daily_prompt_timezone(db: Session, test_data):
+    baby = test_data["baby"]
+    user = test_data["user"]
+    target_date = date(2024, 3, 10)
+
+    # Records that SHOULD be included
+
+    # Start of day (00:00:00 JST)
+    t1 = datetime(2024, 3, 10, 0, 0, 0, tzinfo=JST)
+    db.add(Feeding(
+        user_id=user.id, baby_id=baby.id, feeding_time=t1,
+        feeding_type=FeedingType.BREAST, amount_ml=None
+    ))
+
+    # End of day (23:59:59 JST)
+    t2 = datetime(2024, 3, 10, 23, 59, 59, tzinfo=JST)
+    db.add(Feeding(
+        user_id=user.id, baby_id=baby.id, feeding_time=t2,
+        feeding_type=FeedingType.BREAST, amount_ml=None
+    ))
+
+    # Records that SHOULD NOT be included
+
+    # Previous day end (23:59:59 JST of previous day)
+    t_prev = datetime(2024, 3, 9, 23, 59, 59, tzinfo=JST)
+    db.add(Feeding(
+        user_id=user.id, baby_id=baby.id, feeding_time=t_prev,
+        feeding_type=FeedingType.BREAST, amount_ml=None
+    ))
+
+    # Next day start (00:00:00 JST of next day)
+    t_next = datetime(2024, 3, 11, 0, 0, 0, tzinfo=JST)
+    db.add(Feeding(
+        user_id=user.id, baby_id=baby.id, feeding_time=t_next,
+        feeding_type=FeedingType.BREAST, amount_ml=None
+    ))
+
+    db.commit()
+
+    # Execute
+    prompt, total_records, records_text = build_daily_prompt(db, baby.id, baby.name, target_date)
+
+    # Assertions
+    assert total_records == 2

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -45,7 +45,7 @@ def test_login_failure(client):
         "/api/auth/login",
         json={
             "username": "wronguser",
-            "password": "wrongpassword"
+            "password": "wrongpassword1"
         }
     )
     assert response.status_code == 401

--- a/tests/test_auth_session.py
+++ b/tests/test_auth_session.py
@@ -8,7 +8,7 @@ from app.services.auth import get_password_hash
 @pytest.fixture
 def test_user(db):
     # Create a test user
-    password = "testpassword"
+    password = "testpassword1"
     hashed_password = get_password_hash(password)
     user = User(username="test_auth_user", hashed_password=hashed_password)
     db.add(user)
@@ -17,7 +17,7 @@ def test_user(db):
     return user
 
 def test_login_cookie_attributes(client, test_user):
-    response = client.post("/api/auth/login", json={"username": test_user.username, "password": "testpassword"})
+    response = client.post("/api/auth/login", json={"username": test_user.username, "password": "testpassword1"})
     assert response.status_code == 200
     
     # Check cookie attributes
@@ -35,7 +35,7 @@ def test_login_cookie_attributes(client, test_user):
     
 def test_sliding_session(client, test_user, db):
     # 1. Login
-    response = client.post("/api/auth/login", json={"username": test_user.username, "password": "testpassword"})
+    response = client.post("/api/auth/login", json={"username": test_user.username, "password": "testpassword1"})
     assert response.status_code == 200
     token = response.cookies["access_token"]
     

--- a/tests/test_baby_characteristics.py
+++ b/tests/test_baby_characteristics.py
@@ -38,7 +38,7 @@ def test_create_baby_with_characteristics(auth_client):
     assert target["characteristics"] == "Updated text"
     
 def test_update_characteristics_partial(auth_client):
-    client = auth_client(username="user2", password="pw", family_name="Fam2")
+    client = auth_client(username="user2", password="password123", family_name="Fam2")
     
     # Create baby without characteristics
     res = client.post(

--- a/tests/test_baby_permissions.py
+++ b/tests/test_baby_permissions.py
@@ -1,8 +1,9 @@
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.pool import StaticPool
 from app.main import app
-from app.database import SessionLocal, engine
 from app.models.base import Base
 from app.models.user import User
 from app.models.family import Family, FamilyUser
@@ -10,40 +11,43 @@ from app.models.baby import Baby, BabyPermission
 from app.dependencies import get_current_user, get_db
 import uuid
 
+# Use in-memory SQLite for this test file too
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+test_engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
+
 # Global mock states
 _mock_user = None
-_test_db = None
-
-def mock_get_db():
-    yield _test_db
 
 def mock_get_current_user():
-    global _mock_user
     return _mock_user
 
-@pytest.fixture(scope="session", autouse=True)
-def setup_db():
-    Base.metadata.create_all(bind=engine)
+@pytest.fixture(scope="module", autouse=True)
+def setup_module_db():
+    Base.metadata.create_all(bind=test_engine)
     yield
-    Base.metadata.drop_all(bind=engine)
-
-@pytest.fixture(autouse=True)
-def overrides():
-    app.dependency_overrides[get_current_user] = mock_get_current_user
-    app.dependency_overrides[get_db] = mock_get_db
-    yield
-    app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=test_engine)
 
 @pytest.fixture
 def db():
-    global _test_db
-    connection = engine.connect()
+    connection = test_engine.connect()
     transaction = connection.begin()
-    _test_db = SessionLocal(bind=connection)
-    yield _test_db
-    _test_db.close()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
     transaction.rollback()
     connection.close()
+
+@pytest.fixture(autouse=True)
+def overrides(db):
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    app.dependency_overrides[get_db] = lambda: db
+    yield
+    app.dependency_overrides.clear()
 
 @pytest.fixture
 def setup_data(db: Session):
@@ -52,21 +56,24 @@ def setup_data(db: Session):
     db.add(family)
     db.flush()
 
-    admin_user = User(id=2001, username=f"admin-{suffix}", hashed_password="hashed")
+    admin_user = User(username=f"admin-{suffix}", hashed_password="hashed")
     db.add(admin_user)
     db.flush()
     db.add(FamilyUser(family_id=family.id, user_id=admin_user.id, role="admin"))
 
-    member_user = User(id=2002, username=f"member-{suffix}", hashed_password="hashed")
+    member_user = User(username=f"member-{suffix}", hashed_password="hashed")
     db.add(member_user)
     db.flush()
     db.add(FamilyUser(family_id=family.id, user_id=member_user.id, role="member"))
 
-    baby = Baby(id=3001, family_id=family.id, name="Test Baby")
+    baby = Baby(family_id=family.id, name="Test Baby")
     db.add(baby)
     db.flush()
 
     db.commit()
+    db.refresh(admin_user)
+    db.refresh(member_user)
+    db.refresh(baby)
     return {"admin": admin_user, "member": member_user, "baby": baby}
 
 def test_get_permissions_as_admin(setup_data):

--- a/tests/test_security_cookie.py
+++ b/tests/test_security_cookie.py
@@ -2,14 +2,17 @@ import os
 import importlib
 import pytest
 from fastapi.testclient import TestClient
+import app.config
+import app.routers.auth
 
 def test_cookie_secure_default_is_true():
     # Ensure COOKIE_SECURE is not set in environment
     if "COOKIE_SECURE" in os.environ:
         del os.environ["COOKIE_SECURE"]
 
-    # Reload the module to pick up the default value
-    import app.routers.auth
+    # Reload config first
+    importlib.reload(app.config)
+    # Then reload the module that uses it
     importlib.reload(app.routers.auth)
 
     from app.routers.auth import COOKIE_SECURE
@@ -20,8 +23,9 @@ def test_cookie_secure_can_be_false():
     # Set COOKIE_SECURE to "false" in environment
     os.environ["COOKIE_SECURE"] = "false"
 
-    # Reload the module
-    import app.routers.auth
+    # Reload config first
+    importlib.reload(app.config)
+    # Then reload the module
     importlib.reload(app.routers.auth)
 
     from app.routers.auth import COOKIE_SECURE
@@ -29,6 +33,9 @@ def test_cookie_secure_can_be_false():
 
     # Cleanup
     del os.environ["COOKIE_SECURE"]
+    # Reset config
+    importlib.reload(app.config)
+    importlib.reload(app.routers.auth)
 
 def test_cookie_secure_header_is_present(client):
     # We need to make sure the app uses the updated COOKIE_SECURE
@@ -38,7 +45,8 @@ def test_cookie_secure_header_is_present(client):
     # Let's ensure COOKIE_SECURE is True for this test
     if "COOKIE_SECURE" in os.environ:
         del os.environ["COOKIE_SECURE"]
-    import app.routers.auth
+
+    importlib.reload(app.config)
     importlib.reload(app.routers.auth)
 
     response = client.post(

--- a/tests/test_viewer_role.py
+++ b/tests/test_viewer_role.py
@@ -6,7 +6,7 @@ def test_viewer_default_on_join(client):
     client.post("/api/auth/register/family", json={
         "name": "Admin Family",
         "username": "admin_user",
-        "password": "password"
+        "password": "password1"
     })
     res = client.get("/api/family/")
     invite_code = res.json()["invite_code"]
@@ -15,7 +15,7 @@ def test_viewer_default_on_join(client):
     # 2. 新規ユーザーが参加
     res = client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
         "username": "viewer_user",
-        "password": "password"
+        "password": "password1"
     })
     assert res.status_code == 200
     assert res.json()["role"] == UserRole.VIEWER
@@ -29,7 +29,7 @@ def test_viewer_read_only_access(client):
     client.post("/api/auth/register/family", json={
         "name": "Test Family",
         "username": "admin_user",
-        "password": "password"
+        "password": "password1"
     })
     res = client.post("/api/babies/", json={"name": "Baby", "gender": "boy"})
     baby_id = res.json()["id"]
@@ -39,7 +39,7 @@ def test_viewer_read_only_access(client):
     # 2. VIEWERが参加
     client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
         "username": "viewer_user",
-        "password": "password"
+        "password": "password1"
     })
 
     # 3. 閲覧は可能
@@ -58,7 +58,7 @@ def test_viewer_read_only_access(client):
     # 5. 削除も拒否 (403)
     # まずADMINとして記録作成
     client.cookies.clear()
-    client.post("/api/auth/login", json={"username": "admin_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password1"})
     res = client.post("/api/feedings/", json={
         "baby_id": baby_id,
         "feeding_time": "2024-01-01T10:00:00",
@@ -68,7 +68,7 @@ def test_viewer_read_only_access(client):
     client.cookies.clear()
 
     # 再度VIEWERとしてログイン
-    client.post("/api/auth/login", json={"username": "viewer_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "viewer_user", "password": "password1"})
     res = client.delete(f"/api/feedings/{feeding_id}")
     assert res.status_code == 403
 
@@ -77,7 +77,7 @@ def test_admin_can_change_role(client):
     client.post("/api/auth/register/family", json={
         "name": "Role Family",
         "username": "admin_user",
-        "password": "password"
+        "password": "password1"
     })
     invite_code = client.get("/api/family/").json()["invite_code"]
     client.cookies.clear()
@@ -85,20 +85,20 @@ def test_admin_can_change_role(client):
     # 2. ユーザーが参加 (最初はVIEWER)
     res = client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
         "username": "target_user",
-        "password": "password"
+        "password": "password1"
     })
     user_id = res.json()["id"]
     client.cookies.clear()
 
     # 3. ADMINがロールをMEMBERに変更
-    client.post("/api/auth/login", json={"username": "admin_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password1"})
     res = client.patch(f"/api/family/members/{user_id}/role", json={"role": UserRole.MEMBER})
     assert res.status_code == 200
     assert res.json()["role"] == UserRole.MEMBER
 
     # 4. MEMBERなら作成できることを確認
     client.cookies.clear()
-    client.post("/api/auth/login", json={"username": "target_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "target_user", "password": "password1"})
     res = client.post("/api/babies/", json={"name": "Another Baby", "gender": "girl"})
     # MEMBERは赤ちゃん作成権限はない(ADMINのみ)が、ここでは権限不足で403になるはず
     # 代わりに授乳記録などでテスト
@@ -108,13 +108,13 @@ def test_admin_can_change_role(client):
     # 授乳記録ならMEMBERもOKなはず
     # まずADMINとして赤ちゃん作成
     client.cookies.clear()
-    client.post("/api/auth/login", json={"username": "admin_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password1"})
     res = client.post("/api/babies/", json={"name": "Real Baby", "gender": "boy"})
     baby_id = res.json()["id"]
     client.cookies.clear()
     
     # MEMBERとしてログイン
-    client.post("/api/auth/login", json={"username": "target_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "target_user", "password": "password1"})
     res = client.post("/api/feedings/", json={
         "baby_id": baby_id,
         "feeding_time": "2024-01-01T10:00:00",


### PR DESCRIPTION
This PR introduces comprehensive unit tests for the `build_daily_prompt` function in `app/services/ai_summary.py` to ensure reliable prompt generation for the AI diary feature.

**Key Changes:**
*   **New Test File:** Added `tests/test_ai_summary_service.py` with tests for:
    *   Prompt generation with various record types (Feeding, Sleep, Diaper, Growth).
    *   Handling of dates with no records.
    *   Correct timezone handling (JST) to ensure records are filtered by day boundaries accurately.
*   **Schema Fixes:** Updated `app/schemas/family.py` and `app/schemas/user.py` to replace Pydantic `Field(pattern=...)` with `@field_validator` for password complexity checks. This resolves `SchemaError` issues caused by `rust-regex` limitations with look-arounds.
*   **Test Suite Stability:**
    *   Updated test data in `conftest.py` and other test files to use passwords that meet the complexity requirements (e.g., "password1").
    *   Fixed `tests/test_baby_permissions.py` to use the in-memory SQLite engine instead of connecting to a real Postgres database, resolving `IntegrityError`.
    *   Fixed `tests/test_security_cookie.py` to correctly reload `app.config` before `app.routers.auth` when testing environment variable changes.

**Coverage:**
*   `build_daily_prompt` is now fully tested.
*   The entire backend test suite (`pytest`) passes.

---
*PR created automatically by Jules for task [5367982548043689905](https://jules.google.com/task/5367982548043689905) started by @eburairu*