### PR TITLE
🧪 Add tests for Diaper API and fix pydantic schema validation

### DIFF
--- a/app/schemas/family.py
+++ b/app/schemas/family.py
@@ -1,12 +1,20 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
 from typing import Optional
+import re
 
 
 class FamilyCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     username: str = Field(..., min_length=3, max_length=50, pattern=r"^[a-zA-Z0-9_-]+$")
-    password: str = Field(..., min_length=8, max_length=128, pattern=r"^(?=.*[a-zA-Z])(?=.*\d).+$")
+    password: str = Field(..., min_length=8, max_length=128)
+
+    @field_validator('password')
+    @classmethod
+    def password_complexity(cls, v):
+        if not re.search(r'[a-zA-Z]', v) or not re.search(r'\d', v):
+            raise ValueError('Password must contain at least one letter and one number')
+        return v
 
 
 class FamilyResponse(BaseModel):

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,11 +1,19 @@
 from typing import Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
+import re
 
 
 class UserCreate(BaseModel):
     username: str = Field(..., min_length=3, max_length=50, pattern=r"^[a-zA-Z0-9_-]+$")
-    password: str = Field(..., min_length=8, max_length=128, pattern=r"^(?=.*[a-zA-Z])(?=.*\d).+$")
+    password: str = Field(..., min_length=8, max_length=128)
+
+    @field_validator('password')
+    @classmethod
+    def password_complexity(cls, v):
+        if not re.search(r'[a-zA-Z]', v) or not re.search(r'\d', v):
+            raise ValueError('Password must contain at least one letter and one number')
+        return v
 
 
 class UserProfileUpdate(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def client(db):
 @pytest.fixture
 def auth_client(client):
     """認証済みクライアントを作成するためのヘルパー"""
-    def _auth(username="testuser", password="testpassword", family_name="Test Family"):
+    def _auth(username="testuser", password="testpassword1", family_name="Test Family"):
         # 家族とユーザーを登録
         res = client.post(
             "/api/auth/register/family",

--- a/tests/test_baby_characteristics.py
+++ b/tests/test_baby_characteristics.py
@@ -38,7 +38,7 @@ def test_create_baby_with_characteristics(auth_client):
     assert target["characteristics"] == "Updated text"
     
 def test_update_characteristics_partial(auth_client):
-    client = auth_client(username="user2", password="pw", family_name="Fam2")
+    client = auth_client(username="user2", password="password1", family_name="Fam2")
     
     # Create baby without characteristics
     res = client.post(

--- a/tests/test_diaper_records.py
+++ b/tests/test_diaper_records.py
@@ -1,0 +1,143 @@
+from datetime import datetime, timedelta
+import pytest
+from app.models.diaper import DiaperType
+
+def test_diaper_crud(auth_client):
+    client = auth_client()
+    # 1. Create a baby first
+    res = client.post("/api/babies/", json={"name": "Baby Diaper", "birthday": "2024-01-01", "gender": "boy"})
+    assert res.status_code == 200
+    baby_id = res.json()["id"]
+
+    # 2. Create Diaper Record
+    change_time = datetime.now().isoformat()
+    diaper_data = {
+        "baby_id": baby_id,
+        "change_time": change_time,
+        "diaper_type": "WET",
+        "notes": "First change"
+    }
+    res = client.post("/api/diapers/", json=diaper_data)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["baby_id"] == baby_id
+    assert data["diaper_type"] == "WET"
+    assert data["notes"] == "First change"
+    diaper_id = data["id"]
+
+    # 3. Get Diaper Records
+    res = client.get(f"/api/diapers/?baby_id={baby_id}")
+    assert res.status_code == 200
+    records = res.json()
+    assert len(records) == 1
+    assert records[0]["id"] == diaper_id
+    assert records[0]["diaper_type"] == "WET"
+
+    # 4. Update Diaper Record
+    update_data = {
+        "diaper_type": "DIRTY",
+        "notes": "Updated note"
+    }
+    res = client.put(f"/api/diapers/{diaper_id}", json=update_data)
+    assert res.status_code == 200
+    updated_data = res.json()
+    assert updated_data["diaper_type"] == "DIRTY"
+    assert updated_data["notes"] == "Updated note"
+
+    # Verify update via GET
+    res = client.get(f"/api/diapers/?baby_id={baby_id}")
+    assert res.status_code == 200
+    records = res.json()
+    assert records[0]["diaper_type"] == "DIRTY"
+    assert records[0]["notes"] == "Updated note"
+
+    # 5. Delete Diaper Record
+    res = client.delete(f"/api/diapers/{diaper_id}")
+    assert res.status_code == 200
+
+    # Verify deletion
+    res = client.get(f"/api/diapers/?baby_id={baby_id}")
+    assert res.status_code == 200
+    assert len(res.json()) == 0
+
+def test_diaper_list_ordering(auth_client):
+    client = auth_client()
+    res = client.post("/api/babies/", json={"name": "Baby Order", "birthday": "2024-01-01"})
+    baby_id = res.json()["id"]
+
+    # Create 3 records with different times
+    base_time = datetime.now()
+    times = [
+        base_time - timedelta(hours=1),
+        base_time,
+        base_time - timedelta(hours=2)
+    ]
+
+    for t in times:
+        client.post("/api/diapers/", json={
+            "baby_id": baby_id,
+            "change_time": t.isoformat(),
+            "diaper_type": "WET"
+        })
+
+    res = client.get(f"/api/diapers/?baby_id={baby_id}")
+    assert res.status_code == 200
+    records = res.json()
+    assert len(records) == 3
+
+    # Should be ordered by change_time descending (newest first)
+    # base_time (index 1 in times) > base_time - 1h (index 0) > base_time - 2h (index 2)
+    # Expected order in response: times[1], times[0], times[2]
+
+    t0 = datetime.fromisoformat(records[0]["change_time"])
+    t1 = datetime.fromisoformat(records[1]["change_time"])
+    t2 = datetime.fromisoformat(records[2]["change_time"])
+
+    assert t0 > t1
+    assert t1 > t2
+
+def test_diaper_access_control(auth_client):
+    # User A
+    client_a = auth_client(username="user_a_diaper", family_name="Family A")
+    res = client_a.post("/api/babies/", json={"name": "Baby A"})
+    baby_a_id = res.json()["id"]
+
+    # Create a diaper record for Baby A
+    res = client_a.post("/api/diapers/", json={
+        "baby_id": baby_a_id,
+        "change_time": datetime.now().isoformat(),
+        "diaper_type": "WET"
+    })
+    diaper_a_id = res.json()["id"]
+
+    # Clear cookies to simulate logout
+    client_a.cookies.clear()
+
+    # User B (different family)
+    client_b = auth_client(username="user_b_diaper", family_name="Family B")
+
+    # 1. Try to GET diapers for Baby A
+    res = client_b.get(f"/api/diapers/?baby_id={baby_a_id}")
+    assert res.status_code == 403
+
+    # 2. Try to POST diaper for Baby A
+    res = client_b.post("/api/diapers/", json={
+        "baby_id": baby_a_id,
+        "change_time": datetime.now().isoformat(),
+        "diaper_type": "WET"
+    })
+    assert res.status_code == 403
+
+    # 3. Try to PUT diaper for Baby A
+    res = client_b.put(f"/api/diapers/{diaper_a_id}", json={"notes": "Hacked"})
+    # The current implementation might return 404 if it checks ownership before existence,
+    # or 403 if it checks existence then ownership.
+    # Let's check the implementation:
+    # diaper = db.query(Diaper).filter(Diaper.id == diaper_id).first()
+    # verify_baby_access(db, diaper.baby_id, ...)
+    # So it should find it, then raise 403.
+    assert res.status_code == 403
+
+    # 4. Try to DELETE diaper for Baby A
+    res = client_b.delete(f"/api/diapers/{diaper_a_id}")
+    assert res.status_code == 403

--- a/tests/test_security_cookie.py
+++ b/tests/test_security_cookie.py
@@ -9,6 +9,8 @@ def test_cookie_secure_default_is_true():
         del os.environ["COOKIE_SECURE"]
 
     # Reload the module to pick up the default value
+    import app.config
+    importlib.reload(app.config)
     import app.routers.auth
     importlib.reload(app.routers.auth)
 
@@ -21,6 +23,8 @@ def test_cookie_secure_can_be_false():
     os.environ["COOKIE_SECURE"] = "false"
 
     # Reload the module
+    import app.config
+    importlib.reload(app.config)
     import app.routers.auth
     importlib.reload(app.routers.auth)
 
@@ -38,6 +42,8 @@ def test_cookie_secure_header_is_present(client):
     # Let's ensure COOKIE_SECURE is True for this test
     if "COOKIE_SECURE" in os.environ:
         del os.environ["COOKIE_SECURE"]
+    import app.config
+    importlib.reload(app.config)
     import app.routers.auth
     importlib.reload(app.routers.auth)
 

--- a/tests/test_viewer_role.py
+++ b/tests/test_viewer_role.py
@@ -6,7 +6,7 @@ def test_viewer_default_on_join(client):
     client.post("/api/auth/register/family", json={
         "name": "Admin Family",
         "username": "admin_user",
-        "password": "password"
+        "password": "password1"
     })
     res = client.get("/api/family/")
     invite_code = res.json()["invite_code"]
@@ -15,7 +15,7 @@ def test_viewer_default_on_join(client):
     # 2. 新規ユーザーが参加
     res = client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
         "username": "viewer_user",
-        "password": "password"
+        "password": "password1"
     })
     assert res.status_code == 200
     assert res.json()["role"] == UserRole.VIEWER
@@ -29,7 +29,7 @@ def test_viewer_read_only_access(client):
     client.post("/api/auth/register/family", json={
         "name": "Test Family",
         "username": "admin_user",
-        "password": "password"
+        "password": "password1"
     })
     res = client.post("/api/babies/", json={"name": "Baby", "gender": "boy"})
     baby_id = res.json()["id"]
@@ -39,7 +39,7 @@ def test_viewer_read_only_access(client):
     # 2. VIEWERが参加
     client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
         "username": "viewer_user",
-        "password": "password"
+        "password": "password1"
     })
 
     # 3. 閲覧は可能
@@ -58,7 +58,7 @@ def test_viewer_read_only_access(client):
     # 5. 削除も拒否 (403)
     # まずADMINとして記録作成
     client.cookies.clear()
-    client.post("/api/auth/login", json={"username": "admin_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password1"})
     res = client.post("/api/feedings/", json={
         "baby_id": baby_id,
         "feeding_time": "2024-01-01T10:00:00",
@@ -68,7 +68,7 @@ def test_viewer_read_only_access(client):
     client.cookies.clear()
 
     # 再度VIEWERとしてログイン
-    client.post("/api/auth/login", json={"username": "viewer_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "viewer_user", "password": "password1"})
     res = client.delete(f"/api/feedings/{feeding_id}")
     assert res.status_code == 403
 
@@ -77,7 +77,7 @@ def test_admin_can_change_role(client):
     client.post("/api/auth/register/family", json={
         "name": "Role Family",
         "username": "admin_user",
-        "password": "password"
+        "password": "password1"
     })
     invite_code = client.get("/api/family/").json()["invite_code"]
     client.cookies.clear()
@@ -85,20 +85,20 @@ def test_admin_can_change_role(client):
     # 2. ユーザーが参加 (最初はVIEWER)
     res = client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
         "username": "target_user",
-        "password": "password"
+        "password": "password1"
     })
     user_id = res.json()["id"]
     client.cookies.clear()
 
     # 3. ADMINがロールをMEMBERに変更
-    client.post("/api/auth/login", json={"username": "admin_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password1"})
     res = client.patch(f"/api/family/members/{user_id}/role", json={"role": UserRole.MEMBER})
     assert res.status_code == 200
     assert res.json()["role"] == UserRole.MEMBER
 
     # 4. MEMBERなら作成できることを確認
     client.cookies.clear()
-    client.post("/api/auth/login", json={"username": "target_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "target_user", "password": "password1"})
     res = client.post("/api/babies/", json={"name": "Another Baby", "gender": "girl"})
     # MEMBERは赤ちゃん作成権限はない(ADMINのみ)が、ここでは権限不足で403になるはず
     # 代わりに授乳記録などでテスト
@@ -108,13 +108,13 @@ def test_admin_can_change_role(client):
     # 授乳記録ならMEMBERもOKなはず
     # まずADMINとして赤ちゃん作成
     client.cookies.clear()
-    client.post("/api/auth/login", json={"username": "admin_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password1"})
     res = client.post("/api/babies/", json={"name": "Real Baby", "gender": "boy"})
     baby_id = res.json()["id"]
     client.cookies.clear()
     
     # MEMBERとしてログイン
-    client.post("/api/auth/login", json={"username": "target_user", "password": "password"})
+    client.post("/api/auth/login", json={"username": "target_user", "password": "password1"})
     res = client.post("/api/feedings/", json={
         "baby_id": baby_id,
         "feeding_time": "2024-01-01T10:00:00",


### PR DESCRIPTION
- Added `tests/test_diaper_records.py` covering CRUD operations and access control for Diaper records.
- Fixed Pydantic `Field` regex pattern issue in `app/schemas/family.py` and `app/schemas/user.py` by replacing look-around regexes with `field_validator`.
- Updated test data in `tests/conftest.py`, `tests/test_baby_characteristics.py`, and `tests/test_viewer_role.py` to meet new password complexity requirements (at least one letter and one digit).
- Fixed `tests/test_security_cookie.py` to properly reload `app.config` during tests.

---
*PR created automatically by Jules for task [2683464106237256207](https://jules.google.com/task/2683464106237256207) started by @eburairu*