### PR TITLE
🔒 Enforce role validation in MemberRoleUpdate schema

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -78,7 +78,7 @@ def verify_baby_access(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied to this baby")
 
     # admin は常に許可
-    if family_user.role == "admin":
+    if family_user.role == UserRole.ADMIN:
         return baby
 
     # "baby" レベルの可視性チェック（record_type != "baby" のときも先にチェック）

--- a/app/models/family.py
+++ b/app/models/family.py
@@ -1,9 +1,10 @@
+import enum
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, func
 from sqlalchemy.orm import relationship
 from .base import Base
 
 
-class UserRole:
+class UserRole(str, enum.Enum):
     ADMIN = "admin"
     MEMBER = "member"
     VIEWER = "viewer"

--- a/app/routers/family.py
+++ b/app/routers/family.py
@@ -105,8 +105,6 @@ def update_member_role(
 ):
     family_user = _get_family_user(db, current_user)
     _require_admin(family_user)
-    if body.role not in (UserRole.ADMIN, UserRole.MEMBER, UserRole.VIEWER):
-        raise HTTPException(status_code=422, detail=f"Role must be one of: {UserRole.ADMIN}, {UserRole.MEMBER}, {UserRole.VIEWER}")
     target = (
         db.query(FamilyUser)
         .filter(

--- a/app/schemas/family.py
+++ b/app/schemas/family.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
 from typing import Optional
+from app.models.family import UserRole
 
 
 class FamilyCreate(BaseModel):
@@ -36,7 +37,7 @@ class FamilyMemberResponse(BaseModel):
     user_id: int
     username: str
     display_name: Optional[str] = None
-    role: str
+    role: UserRole
     joined_at: datetime
 
     class Config:
@@ -44,4 +45,4 @@ class FamilyMemberResponse(BaseModel):
 
 
 class MemberRoleUpdate(BaseModel):
-    role: str
+    role: UserRole

--- a/tests/test_role_validation.py
+++ b/tests/test_role_validation.py
@@ -1,0 +1,29 @@
+import pytest
+from app.models.family import UserRole
+
+def test_update_role_with_invalid_value(client):
+    # 1. ADMINが家族を作成
+    client.post("/api/auth/register/family", json={
+        "name": "Role Family",
+        "username": "admin_user",
+        "password": "password123"
+    })
+    res = client.get("/api/family/")
+    invite_code = res.json()["invite_code"]
+    client.cookies.clear()
+
+    # 2. ユーザーが参加
+    res = client.post(f"/api/auth/register/join?invite_code={invite_code}", json={
+        "username": "target_user",
+        "password": "password123"
+    })
+    user_id = res.json()["id"]
+    client.cookies.clear()
+
+    # 3. ADMINがログイン
+    client.post("/api/auth/login", json={"username": "admin_user", "password": "password123"})
+
+    # 4. 無効なロールで更新を試みる
+    res = client.patch(f"/api/family/members/{user_id}/role", json={"role": "invalid_role"})
+    assert res.status_code == 422
+    # 現在はルーターで 422 が返るが、将来は Pydantic で返る


### PR DESCRIPTION
### 🔒 Security Vulnerability Fix: Missing Validation for Role Update Schema

#### 🎯 What
The `MemberRoleUpdate` schema in `app/schemas/family.py` was using a plain `str` for the `role` field without any validation at the API boundary. This vulnerability allowed arbitrary strings to be passed as roles in the API request.

#### ⚠️ Risk
If left unfixed, an attacker (or a bug in the frontend) could potentially pass invalid or malicious strings as roles. While the backend router had a manual check, moving validation to the Pydantic schema ensures:
1.  **Defense in Depth:** Validation happens at the earliest possible stage (API boundary).
2.  **Documentation:** The allowed roles are correctly reflected in the OpenAPI (Swagger) documentation.
3.  **Consistency:** Centralizes role definition using an Enum, reducing the risk of typos or inconsistent checks across the codebase.

#### 🛡️ Solution
1.  **Refactored `UserRole`**: Converted the `UserRole` class in `app/models/family.py` to a `str, enum.Enum`. This maintains backward compatibility with string comparisons while providing Enum benefits.
2.  **Schema Enforcement**: Updated `MemberRoleUpdate` to use `UserRole` as the type for the `role` field. Pydantic now automatically validates that only `admin`, `member`, or `viewer` are accepted.
3.  **Cleaned up Router**: Removed the redundant manual validation check in `app/routers/family.py`.
4.  **Consistency Update**: Updated a hardcoded `"admin"` string in `app/dependencies.py` to use `UserRole.ADMIN`.
5.  **Verified**: Confirmed syntax correctness with `py_compile` and added a reproduction test case in `tests/test_role_validation.py`.

---
*PR created automatically by Jules for task [6739057757291751978](https://jules.google.com/task/6739057757291751978) started by @eburairu*