### PR TITLE
🧪 [testing improvement] Add edge case tests and fix logic gaps in ageUtils

### DIFF
--- a/frontend/__tests__/ageUtils.test.ts
+++ b/frontend/__tests__/ageUtils.test.ts
@@ -39,13 +39,52 @@ describe("ageUtils", () => {
         })
 
         it("月末生まれの境界値を正しく計算する (1月31日生まれの3月1日時点)", () => {
-            // 2024年はうるう年なので2月は29日まで。
-            // 1月31日から2月29日で1ヶ月。3月1日は1ヶ月と1日。
             vi.setSystemTime(new Date("2024-03-01T10:00:00Z"))
             const result = calcAge("2024-01-31T00:00:00Z")
             expect(result.months).toBe(1)
             expect(result.days).toBe(1)
             expect(result.label).toBe("生後 1ヶ月1日")
+        })
+
+        // Edge Cases
+        it("ちょうど1年後の場合は生後 12ヶ月 を返す", () => {
+            vi.setSystemTime(new Date("2025-05-20T10:00:00Z"))
+            const result = calcAge("2024-05-20T00:00:00Z")
+            expect(result.months).toBe(12)
+            expect(result.days).toBe(0)
+            expect(result.label).toBe("生後 12ヶ月")
+        })
+
+        it("月末生まれの境界値: 1月31日生まれの2月28日時点 (非うるう年)", () => {
+            vi.setSystemTime(new Date("2023-02-28T10:00:00Z"))
+            const result = calcAge("2023-01-31T00:00:00Z")
+            expect(result.months).toBe(1)
+            expect(result.days).toBe(0)
+            expect(result.label).toBe("生後 1ヶ月")
+        })
+
+        it("月末生まれの境界値: 1月31日生まれの2月29日時点 (うるう年)", () => {
+            vi.setSystemTime(new Date("2024-02-29T10:00:00Z"))
+            const result = calcAge("2024-01-31T00:00:00Z")
+            expect(result.months).toBe(1)
+            expect(result.days).toBe(0)
+            expect(result.label).toBe("生後 1ヶ月")
+        })
+
+        it("うるう年生まれ: 2月29日生まれの翌年2月28日時点", () => {
+            vi.setSystemTime(new Date("2025-02-28T10:00:00Z"))
+            const result = calcAge("2024-02-29T00:00:00Z")
+            expect(result.months).toBe(12)
+            expect(result.days).toBe(0)
+            expect(result.label).toBe("生後 12ヶ月")
+        })
+
+        it("未来の誕生日を指定した場合は 0ヶ月0日 を返す", () => {
+            vi.setSystemTime(new Date("2024-05-20T10:00:00Z"))
+            const result = calcAge("2024-05-21T00:00:00Z")
+            expect(result.months).toBe(0)
+            expect(result.days).toBe(0)
+            expect(result.label).toBe("生後 0日")
         })
     })
 
@@ -79,6 +118,25 @@ describe("ageUtils", () => {
             const date = new Date("2024-05-20T10:00:00Z").toISOString()
             expect(formatElapsed(date)).toBe("1日前")
         })
+
+        // Edge Cases
+        it("ちょうど60分前は '1時間前' を返す", () => {
+            vi.setSystemTime(new Date("2024-05-20T10:00:00Z"))
+            const date = new Date("2024-05-20T09:00:00Z").toISOString()
+            expect(formatElapsed(date)).toBe("1時間前")
+        })
+
+        it("ちょうど24時間前は '1日前' を返す", () => {
+            vi.setSystemTime(new Date("2024-05-21T10:00:00Z"))
+            const date = new Date("2024-05-20T10:00:00Z").toISOString()
+            expect(formatElapsed(date)).toBe("1日前")
+        })
+
+        it("未来の時刻は 'たった今' を返す", () => {
+            vi.setSystemTime(new Date("2024-05-20T10:00:00Z"))
+            const date = new Date("2024-05-20T10:05:00Z").toISOString()
+            expect(formatElapsed(date)).toBe("たった今")
+        })
     })
 
     describe("formatDuration", () => {
@@ -104,6 +162,13 @@ describe("ageUtils", () => {
             vi.setSystemTime(new Date("2024-05-20T11:30:00Z"))
             const start = "2024-05-20T10:00:00Z"
             expect(formatDuration(start, null)).toBe("1時間30分")
+        })
+
+        // Edge Case
+        it("マイナスの期間は '0分' を返す", () => {
+            const start = "2024-05-20T11:00:00Z"
+            const end = "2024-05-20T10:00:00Z"
+            expect(formatDuration(start, end)).toBe("0分")
         })
     })
 

--- a/frontend/lib/ageUtils.ts
+++ b/frontend/lib/ageUtils.ts
@@ -6,14 +6,23 @@ export function calcAge(birthday: string): { months: number; days: number; label
     const birth = new Date(birthday);
     const now = new Date();
 
-    let months = (now.getFullYear() - birth.getFullYear()) * 12 + (now.getMonth() - birth.getMonth());
-    const dayOfMonth = now.getDate() - birth.getDate();
+    if (now < birth) {
+        return { months: 0, days: 0, label: createLabel(0, 0) };
+    }
 
-    if (dayOfMonth < 0) {
-        months -= 1;
+    let months = (now.getFullYear() - birth.getFullYear()) * 12 + (now.getMonth() - birth.getMonth());
+    let dayOfMonth = now.getDate() - birth.getDate();
+
+    // 月末の処理
+    const lastDayOfNowMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    const isLastDayOfNowMonth = now.getDate() === lastDayOfNowMonth;
+
+    if (dayOfMonth < 0 && isLastDayOfNowMonth && birth.getDate() >= lastDayOfNowMonth) {
+        dayOfMonth = 0;
     }
 
     if (dayOfMonth < 0) {
+        months -= 1;
         // 前月の日数を使う
         const prevMonthLastDay = new Date(now.getFullYear(), now.getMonth(), 0).getDate();
         // 誕生日の日が前月の末日より大きい場合（例：1月31日生まれで前月が28日まで）、
@@ -55,7 +64,7 @@ export function formatDuration(startIso: string, endIso?: string | null): string
     const start = new Date(startIso);
     const end = endIso ? new Date(endIso) : new Date();
     const diffMs = end.getTime() - start.getTime();
-    const diffMin = Math.floor(diffMs / 60000);
+    const diffMin = Math.max(0, Math.floor(diffMs / 60000));
     if (diffMin < 60) return `${diffMin}分`;
     const h = Math.floor(diffMin / 60);
     const m = diffMin % 60;


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
- Identified and addressed missing edge case tests for age calculation and duration formatting in `frontend/lib/ageUtils.ts`.
- Fixed logic bugs where month-end boundaries were incorrectly calculated (e.g., skipping "1ヶ月" for Jan 31st born babies on Feb 28th).
- Improved robustness for future dates and negative time differences.

### 📊 Coverage: What scenarios are now tested
- `calcAge`: Birth on 31st (transitioning to 28/29/30 day months), leap years (Feb 29), exactly 1 year later, and future birthdays.
- `formatElapsed`: Exactly 60 minutes, exactly 24 hours, and future timestamps.
- `formatDuration`: Exactly 60 minutes and negative durations.

### ✨ Result: The improvement in test coverage
- Increased the number of tests in `ageUtils.test.ts` from 18 to 27.
- Improved the accuracy of age calculation for babies born on the 31st.
- Ensured the utility functions return sensible values for future or negative time inputs.

---
*PR created automatically by Jules for task [13676148187996353076](https://jules.google.com/task/13676148187996353076) started by @eburairu*