### PR TITLE
Verify GrowthChart dataKey usage with new test

### DIFF
--- a/frontend/__tests__/growthUtils.test.ts
+++ b/frontend/__tests__/growthUtils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest"
+import { mergeData } from "@/utils/growthUtils"
+
+describe("growthUtils", () => {
+    describe("mergeData", () => {
+        it("should use 'head' as key for head circumference data", () => {
+            const records = [
+                {
+                    date: "2023-01-01",
+                    weight: 3000,
+                    height: 50,
+                    head_circumference: 35
+                }
+            ]
+            const result = mergeData(records, [], "head")
+
+            expect(result).toHaveLength(1)
+            expect(result[0]).toHaveProperty("head", 35)
+            expect(result[0]).not.toHaveProperty("head_circumference")
+            expect(result[0]).not.toHaveProperty("head_circumference_cm")
+        })
+
+        it("should handle missing head circumference data", () => {
+            const records = [
+                {
+                    date: "2023-01-01",
+                    weight: 3000,
+                    height: 50,
+                    head_circumference: null
+                }
+            ]
+            const result = mergeData(records, [], "head")
+
+            expect(result).toHaveLength(1)
+            expect(result[0]).toHaveProperty("head", null)
+        })
+    })
+})


### PR DESCRIPTION
The task was to fix a mismatch between dataKey='head_circumference_cm' and the 'head' key from mergeData.
Investigation revealed that GrowthChart.tsx already correctly uses dataKey='head' and mergeData correctly produces 'head' keys.
Added frontend/__tests__/growthUtils.test.ts to verify mergeData behavior and prevent regression.

---
*PR created automatically by Jules for task [1744700454731214440](https://jules.google.com/task/1744700454731214440) started by @eburairu*