### PR TITLE
Add test for upload API error handling and fix auth in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,9 @@ def mock_cookie_secure(monkeypatch):
     """テスト環境ではSecure Cookieを無効化する"""
     monkeypatch.setenv("COOKIE_SECURE", "false")
     import app.routers.auth
+    import app.dependencies
     monkeypatch.setattr(app.routers.auth, "COOKIE_SECURE", False)
+    monkeypatch.setattr(app.dependencies, "COOKIE_SECURE", False)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,29 @@
+import pytest
+from botocore.exceptions import ClientError
+from unittest.mock import MagicMock, patch
+
+def test_upload_image_r2_failure(auth_client):
+    """
+    R2アップロードが失敗した場合、500エラーが返されることをテストする
+    """
+    # Create a mock client that raises ClientError
+    mock_s3_client = MagicMock()
+    error_response = {'Error': {'Code': 'InternalError', 'Message': 'Something went wrong'}}
+    mock_s3_client.put_object.side_effect = ClientError(error_response, 'PutObject')
+
+    # Mock _get_r2_client to return the mock client
+    # Note: We patch where it is defined since it is imported and used there
+    with patch("app.routers.upload._get_r2_client", return_value=mock_s3_client):
+        client = auth_client()
+
+        # Prepare a dummy file for upload
+        # Simulating a file upload
+        files = {'file': ('test_image.jpg', b'fake image content', 'image/jpeg')}
+
+        response = client.post("/api/upload/image", files=files)
+
+        assert response.status_code == 500
+        data = response.json()
+        # Verify the error details are propagated
+        assert "InternalError" in data["detail"]
+        assert "Something went wrong" in data["detail"]


### PR DESCRIPTION
- Created `tests/test_upload.py` to cover `ClientError` during image upload.
- Implemented `test_upload_image_r2_failure` mocking `botocore.exceptions.ClientError`.
- Updated `tests/conftest.py` to correctly patch `COOKIE_SECURE` in `app.dependencies` in addition to `app.routers.auth`, resolving test authentication failures (401 Unauthorized) across the suite.
- Verified all backend tests pass (49 passed).

---
*PR created automatically by Jules for task [2647006688770627183](https://jules.google.com/task/2647006688770627183) started by @eburairu*