### PR TITLE
fix: only trigger Render deploy when new release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,32 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get latest tag before release
+        id: pre_release
+        run: |
+          git fetch --tags
+          echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo 'none')" >> $GITHUB_OUTPUT
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
 
+      - name: Check if new release was published
+        id: check_release
+        run: |
+          git fetch --tags
+          NEW_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo 'none')
+          if [ "$NEW_TAG" != "${{ steps.pre_release.outputs.tag }}" ]; then
+            echo "published=true" >> $GITHUB_OUTPUT
+            echo "New release published: $NEW_TAG"
+          else
+            echo "published=false" >> $GITHUB_OUTPUT
+            echo "No new release. Skipping deploy."
+          fi
+
       - name: Trigger Render Deploy
-        if: success()
+        if: steps.check_release.outputs.published == 'true'
         env:
           DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
         run: |


### PR DESCRIPTION
## 問題

`Trigger Render Deploy` ステップが `if: success()` 条件になっていたため、semantic-release が新リリースを作成しない場合（関連コミットなし等）でも Deploy Hook が呼ばれ、二重デプロイが発生していた。

## 修正内容

semantic-release 実行の前後で git tag を比較し、新しいタグが作成された場合のみ Deploy Hook を呼び出すよう変更。

**フロー:**
1. `Get latest tag before release` — 現在の最新タグを記録
2. `Release` — semantic-release を実行
3. `Check if new release was published` — タグが変化したか確認
4. `Trigger Render Deploy` — タグが新しくなった場合のみ実行

## Test plan

- [ ] PR マージ後に GitHub Actions ログで「No new release. Skipping deploy.」または「New release published: vX.Y.Z」が出ることを確認
- [ ] リリースが作成された場合のみ Render デプロイが1回だけ起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)