### PR TITLE
fix(notifications): prevent double mailto: prefix in VAPID claims

### DIFF
--- a/app/utils/notifications.py
+++ b/app/utils/notifications.py
@@ -50,7 +50,7 @@ def send_push_notification(subscription: PushSubscription, title: str, body: str
             data=json.dumps(payload),
             vapid_private_key=VAPID_PRIVATE_KEY,
             vapid_claims={
-                "sub": f"mailto:{VAPID_CLAIM_EMAIL}"
+                "sub": VAPID_CLAIM_EMAIL if VAPID_CLAIM_EMAIL.startswith("mailto:") else f"mailto:{VAPID_CLAIM_EMAIL}"
             }
         )
         return True


### PR DESCRIPTION
## Summary

- `VAPID_CLAIM_EMAIL` 環境変数に `mailto:` プレフィックスが含まれている場合、二重になって VAPID 認証が失敗するバグを修正
- Render の環境変数に `mailto:ry1e@ebuchi.net` と設定されている場合でも正しく動作するよう対応

## Root cause

```python
# 修正前: sub が "mailto:mailto:ry1e@ebuchi.net" になっていた
"sub": f"mailto:{VAPID_CLAIM_EMAIL}"

# 修正後: 既に mailto: が含まれている場合はそのまま使用
"sub": VAPID_CLAIM_EMAIL if VAPID_CLAIM_EMAIL.startswith("mailto:") else f"mailto:{VAPID_CLAIM_EMAIL}"
```

## Test plan

- [ ] Render にデプロイ後、通知設定ページで購読を登録
- [ ] 家族の別アカウントで記録を追加し、プッシュ通知が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)