### PR TITLE
fix(notifications): surface detailed error message on subscribe failure

### DIFF
--- a/frontend/app/(dashboard)/settings/notifications/page.tsx
+++ b/frontend/app/(dashboard)/settings/notifications/page.tsx
@@ -73,12 +73,17 @@ export default function NotificationsPage() {
         return;
       }
       
-      const sub = await subscribeUser(vapidPublicKey);
-      if (sub) {
-        await sendSubscriptionToBackend(sub);
-        toast.success("通知が有効になりました");
-      } else {
-        toast.error("通知の購読に失敗しました。時間をおいて再度お試しください。");
+      try {
+        const sub = await subscribeUser(vapidPublicKey);
+        if (sub) {
+          await sendSubscriptionToBackend(sub);
+          toast.success("通知が有効になりました");
+        } else {
+          toast.error("通知の購読に失敗しました。時間をおいて再度お試しください。");
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : "不明なエラー";
+        toast.error(`購読エラー: ${msg}`);
       }
     } else if (status === "denied") {
       toast.error("通知がブロックされています。ブラウザの設定から通知を許可してください。");

--- a/frontend/hooks/usePushNotification.ts
+++ b/frontend/hooks/usePushNotification.ts
@@ -61,8 +61,9 @@ export function usePushNotification() {
       setSubscription(newSubscription);
       return newSubscription;
     } catch (error) {
-      console.error("Failed to subscribe user:", error);
-      return null;
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error("Failed to subscribe user:", msg);
+      throw new Error(msg);
     }
   };
 


### PR DESCRIPTION
## Summary

- 購読失敗時のエラーメッセージを詳細化し、原因特定をしやすくする
- `subscribeUser` で発生した例外のメッセージをトーストに表示する

🤖 Generated with [Claude Code](https://claude.com/claude-code)