### PR TITLE
fix(notifications): add timeout and pushManager check to subscribeUser

### DIFF
--- a/frontend/hooks/usePushNotification.ts
+++ b/frontend/hooks/usePushNotification.ts
@@ -46,7 +46,16 @@ export function usePushNotification() {
     if (!("serviceWorker" in navigator)) return null;
 
     try {
-      const registration = await navigator.serviceWorker.ready;
+      // Service Worker が active になるまで最大 60 秒待機
+      const registration = await Promise.race([
+        navigator.serviceWorker.ready,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("Service Worker の準備がタイムアウトしました。ページを再読み込みして再試行してください。")), 60000)
+        ),
+      ]);
+      if (!registration.pushManager) {
+        throw new Error("プッシュ通知はこのブラウザ/環境では使用できません（PushManager が見つかりません）。");
+      }
       const existingSubscription = await registration.pushManager.getSubscription();
 
       if (existingSubscription) {


### PR DESCRIPTION
## Summary

- `serviceWorker.ready` に 60 秒タイムアウトを追加（Service Worker がインストール中に停止した場合に無限待機しないようにする）
- `pushManager` が存在しない環境（古いブラウザ等）に明示的なエラーメッセージを追加
- これによりトーストに具体的な失敗理由が表示される

## Background

Playwright によるデバッグで Service Worker のインストールに最大 30 秒かかることを確認。`serviceWorker.ready` のタイムアウトがなかったため、遅い環境では無限待機していた可能性がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)