### PR TITLE
fix: auto-create notification settings for users without settings

### DIFF
--- a/app/utils/notifications.py
+++ b/app/utils/notifications.py
@@ -88,9 +88,16 @@ def notify_user(db: Session, user_id: int, title: str, body: str, url: str = "/"
     """ユーザーの全デバイスに通知を送信する（設定を確認した上で）"""
     settings = db.query(NotificationSetting).filter(NotificationSetting.user_id == user_id).first()
     if not settings:
-        # 設定がない場合はデフォルト（システム通知のみON等）
-        if category != "system":
-            logger.info(f"Skipping {category} notification for user {user_id}: no settings found and category is not system")
+        # 設定がない場合はデフォルト設定を自動作成（family_record_enabled=True がデフォルト）
+        logger.info(f"No notification settings for user {user_id}, creating defaults")
+        settings = NotificationSetting(user_id=user_id)
+        db.add(settings)
+        try:
+            db.commit()
+            db.refresh(settings)
+        except Exception as ex:
+            logger.error(f"Failed to create default notification settings for user {user_id}: {ex}")
+            db.rollback()
             return
     else:
         # カテゴリごとのON/OFF確認

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -95,14 +95,15 @@ class TestSendPushNotification:
 
 
 class TestNotifyUser:
-    def test_skip_non_system_without_settings(self):
-        """設定がないユーザーへのsystem以外の通知はスキップ"""
+    def test_auto_creates_settings_for_new_user(self):
+        """設定がないユーザーにはデフォルト設定を自動作成する"""
         db = MagicMock()
         db.query.return_value.filter.return_value.first.return_value = None
+        db.query.return_value.filter.return_value.all.return_value = []  # no subscriptions
         
         notify_user(db, 1, "Test", "Body", category="family_record")
-        # PushSubscriptionのクエリが呼ばれないことを確認
-        # (最初のqueryはNotificationSettingのため)
+        # デフォルト設定が作成されることを確認
+        db.add.assert_called_once()
 
     def test_skip_disabled_category(self):
         """無効なカテゴリの通知はスキップ"""


### PR DESCRIPTION
Previously, users who never visited the notification settings page had no NotificationSetting row, causing all non-system notifications (including family_record) to be silently skipped. Now defaults are auto-created (family_record_enabled=True) so notifications work immediately.