### PR TITLE
feat: add recorded_by_display_name to note records

### DIFF
--- a/app/routers/note.py
+++ b/app/routers/note.py
@@ -14,6 +14,11 @@ from app.models.baby import Baby
 
 router = APIRouter(prefix="/api", tags=["notes"])
 
+def _build_note_response(note: Note, user_map: dict) -> NoteResponse:
+    r = NoteResponse.model_validate(note)
+    r.recorded_by_display_name = user_map.get(note.user_id)
+    return r
+
 @router.get("/babies/{baby_id}/notes", response_model=List[NoteResponse])
 def get_notes(
     baby_id: int,
@@ -22,7 +27,11 @@ def get_notes(
 ):
     """メモ一覧取得（履歴）"""
     verify_baby_access(db, baby_id, current_user.id, record_type="note")
-    return db.query(Note).filter(Note.baby_id == baby_id).order_by(Note.note_time.desc()).all()
+    records = db.query(Note).filter(Note.baby_id == baby_id).order_by(Note.note_time.desc()).all()
+    user_ids = {r.user_id for r in records if r.user_id is not None}
+    users = db.query(User).filter(User.id.in_(user_ids)).all() if user_ids else []
+    user_map = {u.id: u.display_name or u.username for u in users}
+    return [_build_note_response(r, user_map) for r in records]
 
 @router.post("/babies/{baby_id}/notes", response_model=NoteResponse, status_code=status.HTTP_201_CREATED)
 def create_note(
@@ -53,22 +62,24 @@ def create_note(
     db.add(db_note)
     db.commit()
     db.refresh(db_note)
-    
+
     # 家族に通知
     baby = db.query(Baby).filter(Baby.id == baby_id).first()
     if baby:
         display_name = current_user.display_name or current_user.username
         notify_family_members(
-            db, 
-            baby.family_id, 
-            current_user.id, 
-            title="メモの投稿", 
+            db,
+            baby.family_id,
+            current_user.id,
+            title="メモの投稿",
             body=f"{display_name}さんが新しいメモを投稿しました。",
             url=f"/note",
             category="family_record"
         )
-        
-    return db_note
+
+    response = NoteResponse.model_validate(db_note)
+    response.recorded_by_display_name = current_user.display_name or current_user.username
+    return response
 
 @router.patch("/notes/{note_id}", response_model=NoteResponse)
 def update_note(
@@ -103,7 +114,10 @@ def update_note(
 
     db.commit()
     db.refresh(db_note)
-    return db_note
+    recorder = db.query(User).filter(User.id == db_note.user_id).first() if db_note.user_id else None
+    response = NoteResponse.model_validate(db_note)
+    response.recorded_by_display_name = (recorder.display_name or recorder.username) if recorder else None
+    return response
 
 @router.delete("/notes/{note_id}")
 def delete_note(

--- a/app/schemas/note.py
+++ b/app/schemas/note.py
@@ -19,5 +19,6 @@ class NoteResponse(NoteBase):
     user_id: Optional[int]
     created_at: datetime
     updated_at: datetime
+    recorded_by_display_name: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/frontend/components/note/NoteHistory.tsx
+++ b/frontend/components/note/NoteHistory.tsx
@@ -7,7 +7,7 @@ import * as z from "zod"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Note, deleteNote, updateNote } from "@/hooks/useNotes"
 import { Button } from "@/components/ui/button"
-import { Trash2, Pencil, Calendar, Save } from "lucide-react"
+import { Trash2, Pencil, Calendar, Save, User } from "lucide-react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import {
@@ -127,9 +127,17 @@ export function NoteHistory({ notes, onRefresh, canWrite = true }: Props) {
                             className="p-4 rounded-xl border border-gray-100 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-sm space-y-2"
                         >
                             <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-zinc-400 font-medium">
-                                    <Calendar className="h-3.5 w-3.5" />
-                                    {format(new Date(note.note_time), "yyyy/MM/dd HH:mm", { locale: ja })}
+                                <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-zinc-400 font-medium">
+                                    <span className="flex items-center gap-1.5">
+                                        <Calendar className="h-3.5 w-3.5" />
+                                        {format(new Date(note.note_time), "yyyy/MM/dd HH:mm", { locale: ja })}
+                                    </span>
+                                    {note.recorded_by_display_name && (
+                                        <span className="flex items-center gap-1 text-gray-400 dark:text-zinc-500">
+                                            <User className="h-3 w-3" />
+                                            {note.recorded_by_display_name}
+                                        </span>
+                                    )}
                                 </div>
                                 {canWrite && (
                                     <div className="flex gap-1">

--- a/frontend/hooks/useNotes.ts
+++ b/frontend/hooks/useNotes.ts
@@ -9,6 +9,7 @@ export type Note = {
   note_time: string;
   created_at: string;
   updated_at: string;
+  recorded_by_display_name?: string | null;
 };
 
 export function useNotes(babyId: number | null) {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1627,6 +1627,17 @@
             "title": "Note Time",
             "type": "string"
           },
+          "recorded_by_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recorded By Display Name"
+          },
           "updated_at": {
             "format": "date-time",
             "title": "Updated At",

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -1207,6 +1207,8 @@ export interface components {
              * Format: date-time
              */
             note_time: string;
+            /** Recorded By Display Name */
+            recorded_by_display_name?: string | null;
             /**
              * Updated At
              * Format: date-time


### PR DESCRIPTION
## Summary
- メモ（note）の GET/POST/PATCH エンドポイントで記録者名（`recorded_by_display_name`）を返すよう対応
- `NoteResponse` スキーマにフィールド追加
- `NoteHistory` コンポーネントにカレンダーアイコン横で記録者名を表示
- `openapi.json` と `api.d.ts` を更新

## Test plan
- [ ] メモ一覧でユーザー名が表示されることを確認
- [ ] メモ新規作成後、作成者名が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)