### PR TITLE
fix(ci): remove @semantic-release/git to avoid branch protection conf…

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,14 +5,6 @@
     "plugins": [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",
-        "@semantic-release/changelog",
-        [
-            "@semantic-release/npm",
-            {
-                "npmPublish": false
-            }
-        ],
-        "@semantic-release/git",
         "@semantic-release/github"
     ]
 }


### PR DESCRIPTION
…lict

@semantic-release/git tries to push CHANGELOG.md back to main, but main requires 3 status checks to pass before any push, causing the release job to fail. Remove the git and npm plugins so release notes are only published as GitHub Releases via @semantic-release/github.