### PR TITLE
feat: Sentry Session Replay プライバシー設定を追加

### DIFF
--- a/.specify/specs/infrastructure/sentry_monitoring.md
+++ b/.specify/specs/infrastructure/sentry_monitoring.md
@@ -109,3 +109,100 @@ export default withSentryConfig(withPWA(nextConfig), {
 - `tracesSampleRate` を本番では `0.2`（20%）程度に下げてコスト・負荷を削減する。
 - ユーザーのメールアドレスを `Sentry.setUser()` でセットし、エラー発生ユーザーを特定可能にする。
 - アラートルールを設定し、エラー急増時に Slack 通知を受け取る。
+
+## 10. Session Replay プライバシー設定
+
+### 10.1. 設計方針
+
+**「デフォルト全マスク・安全な要素のみ明示的にアンマスク」** を採用する。
+
+- Sentry のデフォルト `maskAllText: true` を維持し、安全側を優先する
+- `data-sentry-unmask` 属性を付与した要素のみ Session Replay に表示する
+- 属性を持たないすべての要素は自動的にマスクされる
+
+### 10.2. マスク対象 / 非マスク対象の分類
+
+| カテゴリ | 具体例 | 方針 |
+| :--- | :--- | :--- |
+| ナビゲーションラベル | ホーム、授乳、おむつ、睡眠、成長、陣痛、日記、設定 | **アンマスク** |
+| ボタン・アクションラベル | 保存、キャンセル、削除、編集、記録する | **アンマスク** |
+| 静的ページ見出し | "Baby App"、"授乳記録"、"おむつ記録" など | **アンマスク** |
+| 記録タイプラベル | 授乳、睡眠、おむつ、成長、メモ | **アンマスク** |
+| ユーザー入力フィールド | ユーザー名、パスワード、表示名、家族名 | **マスク（デフォルト）** |
+| 赤ちゃんの名前 | ユーザーが登録した任意の名前 | **マスク（デフォルト）** |
+| 育児記録の数値 | 授乳量（ml）、睡眠時間、体重、身長、頭囲 | **マスク（デフォルト）** |
+| フリーテキストメモ | 授乳メモ、睡眠メモ、育児日誌テキスト | **マスク（デフォルト）** |
+| 招待コード | 家族の招待コード | **マスク（デフォルト）** |
+
+### 10.3. 実装方法
+
+#### replayIntegration のオプション設定
+
+```typescript
+// frontend/instrumentation-client.ts
+Sentry.init({
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,                              // デフォルト全マスク（安全側を維持）
+      blockAllMedia: true,                            // 画像・メディアもデフォルトでブロック
+      unmask: ["[data-sentry-unmask]"],               // この属性の要素のみ表示する
+    }),
+  ],
+  // ...
+});
+```
+
+#### コンポーネントでの `data-sentry-unmask` 属性の付与
+
+静的な UI 文字列（ナビゲーション、ボタン、ページタイトルなど）には
+`data-sentry-unmask` 属性を付与する。
+
+```tsx
+// ナビゲーションアイテム
+<span data-sentry-unmask>ホーム</span>
+<span data-sentry-unmask>授乳</span>
+
+// ボタン
+<Button data-sentry-unmask>記録する</Button>
+<Button data-sentry-unmask>保存</Button>
+
+// ページ見出し（静的テキストのみ）
+<h1 data-sentry-unmask>授乳記録</h1>
+```
+
+ユーザー入力・動的データには属性を付与しない（マスクのまま）。
+
+```tsx
+// マスクされる（属性なし）
+<Input value={username} />             // ユーザー名入力
+<span>{baby.name}</span>               // 赤ちゃんの名前（動的データ）
+<span>{feeding.amount_ml} ml</span>    // 授乳量
+<Textarea value={notes} />             // メモ
+```
+
+### 10.4. 対象コンポーネント一覧
+
+`data-sentry-unmask` を追加する主なファイルと対象要素。
+
+| ファイル | 対象要素 |
+| :--- | :--- |
+| `frontend/app/(dashboard)/layout.tsx` | ナビゲーションラベル（ホーム、授乳、おむつ…） |
+| `frontend/components/dashboard/*Widget.tsx` | ウィジェットのタイトル（🍼 授乳、💤 睡眠…） |
+| `frontend/components/*/` 各フォーム | ボタン（保存、キャンセル、記録する、削除） |
+| `frontend/app/(auth)/login/page.tsx` | ページ見出し（"Baby App にログイン"） |
+| `frontend/app/(auth)/register/page.tsx` | ページ見出し（"家族を新規作成"、"家族に参加"） |
+
+### 10.5. 実装チェックリスト
+
+- [ ] `frontend/instrumentation-client.ts`: `replayIntegration` にオプション追加
+- [ ] `frontend/app/(dashboard)/layout.tsx`: ナビゲーションに `data-sentry-unmask` 追加
+- [ ] `frontend/components/dashboard/FeedingWidget.tsx`: タイトルに追加
+- [ ] `frontend/components/dashboard/SleepWidget.tsx`: タイトルに追加
+- [ ] `frontend/components/dashboard/DiaperWidget.tsx`: タイトルに追加
+- [ ] `frontend/components/dashboard/GrowthWidget.tsx`: タイトルに追加
+- [ ] `frontend/components/feeding/feeding-form.tsx`: ボタンに追加
+- [ ] `frontend/components/sleep/sleep-form.tsx`: ボタンに追加
+- [ ] `frontend/components/diaper/DiaperForm.tsx`: ボタンに追加
+- [ ] `frontend/components/growth/GrowthRecordForm.tsx`: ボタンに追加
+- [ ] `frontend/app/(auth)/login/page.tsx`: ページ見出しに追加
+- [ ] `frontend/app/(auth)/register/page.tsx`: ページ見出しに追加

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -58,8 +58,8 @@ export default function LoginPage() {
     return (
         <Card className="rounded-2xl shadow-sm border-0">
             <CardHeader>
-                <CardTitle>Baby App にログイン</CardTitle>
-                <CardDescription>ユーザー名を入力してログインしてください</CardDescription>
+                <CardTitle data-sentry-unmask>Baby App にログイン</CardTitle>
+                <CardDescription data-sentry-unmask>ユーザー名を入力してログインしてください</CardDescription>
             </CardHeader>
             <CardContent className="pt-6">
                 <Form {...form}>
@@ -91,10 +91,11 @@ export default function LoginPage() {
                                 </FormItem>
                             )}
                         />
-                        <Button 
-                            type="submit" 
-                            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl h-11" 
+                        <Button
+                            type="submit"
+                            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl h-11"
                             loading={form.formState.isSubmitting}
+                            data-sentry-unmask
                         >
                             ログイン
                         </Button>

--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -93,15 +93,15 @@ export default function RegisterPage() {
     return (
         <Tabs defaultValue="create" className="w-full">
             <TabsList className="grid w-full grid-cols-2 mb-4 p-1 rounded-xl">
-                <TabsTrigger value="create" className="rounded-lg">家族を新規作成</TabsTrigger>
-                <TabsTrigger value="join" className="rounded-lg">家族に参加</TabsTrigger>
+                <TabsTrigger value="create" className="rounded-lg" data-sentry-unmask>家族を新規作成</TabsTrigger>
+                <TabsTrigger value="join" className="rounded-lg" data-sentry-unmask>家族に参加</TabsTrigger>
             </TabsList>
 
             <TabsContent value="create">
                 <Card className="rounded-2xl shadow-sm border-0">
                     <CardHeader>
-                        <CardTitle>家族の新規作成</CardTitle>
-                        <CardDescription>家族で赤ちゃんの記録を共有しましょう。</CardDescription>
+                        <CardTitle data-sentry-unmask>家族の新規作成</CardTitle>
+                        <CardDescription data-sentry-unmask>家族で赤ちゃんの記録を共有しましょう。</CardDescription>
                     </CardHeader>
                     <CardContent className="pt-6">
                         <Form {...createForm}>
@@ -146,10 +146,11 @@ export default function RegisterPage() {
                                         </FormItem>
                                     )}
                                 />
-                                <Button 
-                                    type="submit" 
-                                    className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl h-11" 
+                                <Button
+                                    type="submit"
+                                    className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl h-11"
                                     loading={createForm.formState.isSubmitting}
+                                    data-sentry-unmask
                                 >
                                     家族を作成して登録
                                 </Button>
@@ -170,8 +171,8 @@ export default function RegisterPage() {
             <TabsContent value="join">
                 <Card className="rounded-2xl shadow-sm border-0">
                     <CardHeader>
-                        <CardTitle>既存の家族に参加</CardTitle>
-                        <CardDescription>家族から共有された招待コードを入力してください。</CardDescription>
+                        <CardTitle data-sentry-unmask>既存の家族に参加</CardTitle>
+                        <CardDescription data-sentry-unmask>家族から共有された招待コードを入力してください。</CardDescription>
                     </CardHeader>
                     <CardContent className="pt-6">
                         <Form {...joinForm}>
@@ -216,10 +217,11 @@ export default function RegisterPage() {
                                         </FormItem>
                                     )}
                                 />
-                                <Button 
-                                    type="submit" 
-                                    className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl h-11" 
+                                <Button
+                                    type="submit"
+                                    className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl h-11"
                                     loading={joinForm.formState.isSubmitting}
+                                    data-sentry-unmask
                                 >
                                     家族に参加して登録
                                 </Button>

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -123,12 +123,12 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                                 </SheetTrigger>
                                 <SheetContent side="left" className="dark:bg-zinc-900 dark:border-zinc-800">
                                     <SheetHeader>
-                                        <SheetTitle className="dark:text-zinc-100">メニュー</SheetTitle>
+                                        <SheetTitle className="dark:text-zinc-100" data-sentry-unmask>メニュー</SheetTitle>
                                         <SheetDescription className="dark:text-zinc-400">
                                             機能を選択してください
                                         </SheetDescription>
                                     </SheetHeader>
-                                    <nav className="mt-6 flex flex-col gap-2">
+                                    <nav className="mt-6 flex flex-col gap-2" data-sentry-unmask>
                                         {ALL_NAV_ITEMS
                                             .filter(item => {
                                                 const born = selectedBaby ? isBorn(selectedBaby.birthday) : true
@@ -149,7 +149,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                             </Sheet>
                         )}
                         <Link href="/">
-                            <h1 className="text-xl font-bold tracking-tight text-gray-900 dark:text-zinc-100">Baby App</h1>
+                            <h1 className="text-xl font-bold tracking-tight text-gray-900 dark:text-zinc-100" data-sentry-unmask>Baby App</h1>
                         </Link>
                     </div>
                     <div className="flex items-center gap-4">

--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -37,13 +37,13 @@ export function DiaperWidget({ babyId, records, isError, mutate }: Props) {
         return (
             <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 opacity-60 transition-colors">
                 <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
-                    <CardTitle className="text-sm font-medium text-gray-400 dark:text-zinc-500 flex items-center gap-1">
+                    <CardTitle className="text-sm font-medium text-gray-400 dark:text-zinc-500 flex items-center gap-1" data-sentry-unmask>
                         👶 おむつ
                     </CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-col items-center justify-center py-6">
                     <ShieldOff className="h-6 w-6 text-gray-300 dark:text-zinc-700 mb-1" />
-                    <p className="text-[10px] text-gray-400 dark:text-zinc-600">閲覧制限中</p>
+                    <p className="text-[10px] text-gray-400 dark:text-zinc-600" data-sentry-unmask>閲覧制限中</p>
                 </CardContent>
             </Card>
         )
@@ -72,7 +72,7 @@ export function DiaperWidget({ babyId, records, isError, mutate }: Props) {
     return (
         <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 transition-colors">
             <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
-                <CardTitle className="text-sm font-medium text-amber-500 dark:text-amber-400 flex items-center gap-1">
+                <CardTitle className="text-sm font-medium text-amber-500 dark:text-amber-400 flex items-center gap-1" data-sentry-unmask>
                     👶 おむつ
                 </CardTitle>
                 <Link href={`/diaper?baby_id=${babyId}`}>
@@ -92,7 +92,7 @@ export function DiaperWidget({ babyId, records, isError, mutate }: Props) {
                     {elapsed ? (
                         <p className="text-2xl font-bold text-gray-800 dark:text-zinc-100">{elapsed}</p>
                     ) : (
-                        <p className="text-sm text-gray-400 dark:text-zinc-600">記録なし</p>
+                        <p className="text-sm text-gray-400 dark:text-zinc-600" data-sentry-unmask>記録なし</p>
                     )}
                     <p className="text-xs text-gray-500 dark:text-zinc-400 mt-1">
                         今日: 💧{wetCount} / 💩{dirtyCount}
@@ -107,6 +107,7 @@ export function DiaperWidget({ babyId, records, isError, mutate }: Props) {
                             className="flex-1 bg-amber-50 dark:bg-amber-950/30 text-amber-600 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-900/50 border-0 text-xs h-8"
                             variant="outline"
                             aria-label="おしっこ"
+                            data-sentry-unmask
                         >
                             💧
                         </Button>
@@ -117,6 +118,7 @@ export function DiaperWidget({ babyId, records, isError, mutate }: Props) {
                             className="flex-1 bg-amber-50 dark:bg-amber-950/30 text-amber-600 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-900/50 border-0 text-xs h-8"
                             variant="outline"
                             aria-label="うんち"
+                            data-sentry-unmask
                         >
                             💩
                         </Button>

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -35,13 +35,13 @@ export function FeedingWidget({ babyId, records, isError, mutate }: Props) {
         return (
             <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 opacity-60 transition-colors">
                 <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
-                    <CardTitle className="text-sm font-medium text-gray-400 dark:text-zinc-500 flex items-center gap-1">
+                    <CardTitle className="text-sm font-medium text-gray-400 dark:text-zinc-500 flex items-center gap-1" data-sentry-unmask>
                         🍼 授乳
                     </CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-col items-center justify-center py-6">
                     <ShieldOff className="h-6 w-6 text-gray-300 dark:text-zinc-700 mb-1" />
-                    <p className="text-[10px] text-gray-400 dark:text-zinc-600">閲覧制限中</p>
+                    <p className="text-[10px] text-gray-400 dark:text-zinc-600" data-sentry-unmask>閲覧制限中</p>
                 </CardContent>
             </Card>
         )
@@ -70,7 +70,7 @@ export function FeedingWidget({ babyId, records, isError, mutate }: Props) {
     return (
         <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 transition-colors">
             <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
-                <CardTitle className="text-sm font-medium text-rose-500 dark:text-rose-400 flex items-center gap-1">
+                <CardTitle className="text-sm font-medium text-rose-500 dark:text-rose-400 flex items-center gap-1" data-sentry-unmask>
                     🍼 授乳
                 </CardTitle>
                 <Link href={`/feeding?baby_id=${babyId}`}>
@@ -90,7 +90,7 @@ export function FeedingWidget({ babyId, records, isError, mutate }: Props) {
                     {elapsed ? (
                         <p className="text-2xl font-bold text-gray-800 dark:text-zinc-100">{elapsed}</p>
                     ) : (
-                        <p className="text-sm text-gray-400 dark:text-zinc-600">記録なし</p>
+                        <p className="text-sm text-gray-400 dark:text-zinc-600" data-sentry-unmask>記録なし</p>
                     )}
                     <p className="text-xs text-gray-500 dark:text-zinc-400 mt-1">今日: {todayCount}回</p>
                 </div>
@@ -102,6 +102,7 @@ export function FeedingWidget({ babyId, records, isError, mutate }: Props) {
                             onClick={(e) => handleQuickRecord("bottle", e)}
                             className="flex-1 bg-rose-50 dark:bg-rose-950/30 text-rose-600 dark:text-rose-400 hover:bg-rose-100 dark:hover:bg-rose-900/50 border-0 text-xs h-8"
                             variant="outline"
+                            data-sentry-unmask
                         >
                             ミルク
                         </Button>
@@ -111,6 +112,7 @@ export function FeedingWidget({ babyId, records, isError, mutate }: Props) {
                             onClick={(e) => handleQuickRecord("breast", e)}
                             className="flex-1 bg-rose-50 dark:bg-rose-950/30 text-rose-600 dark:text-rose-400 hover:bg-rose-100 dark:hover:bg-rose-900/50 border-0 text-xs h-8"
                             variant="outline"
+                            data-sentry-unmask
                         >
                             母乳
                         </Button>

--- a/frontend/components/dashboard/GrowthWidget.tsx
+++ b/frontend/components/dashboard/GrowthWidget.tsx
@@ -19,13 +19,13 @@ export function GrowthWidget({ babyId, records, isError }: Props) {
         return (
             <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 opacity-60 transition-colors">
                 <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
-                    <CardTitle className="text-sm font-medium text-gray-400 dark:text-zinc-500 flex items-center gap-1">
+                    <CardTitle className="text-sm font-medium text-gray-400 dark:text-zinc-500 flex items-center gap-1" data-sentry-unmask>
                         📏 成長
                     </CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-col items-center justify-center py-6">
                     <ShieldOff className="h-6 w-6 text-gray-300 dark:text-zinc-700 mb-1" />
-                    <p className="text-[10px] text-gray-400 dark:text-zinc-600">閲覧制限中</p>
+                    <p className="text-[10px] text-gray-400 dark:text-zinc-600" data-sentry-unmask>閲覧制限中</p>
                 </CardContent>
             </Card>
         )
@@ -44,7 +44,7 @@ export function GrowthWidget({ babyId, records, isError }: Props) {
     return (
         <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 transition-colors">
             <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
-                <CardTitle className="text-sm font-medium text-emerald-500 dark:text-emerald-400 flex items-center gap-1">
+                <CardTitle className="text-sm font-medium text-emerald-500 dark:text-emerald-400 flex items-center gap-1" data-sentry-unmask>
                     📏 成長
                 </CardTitle>
                 <Link href={`/growth?baby_id=${babyId}`}>
@@ -71,7 +71,7 @@ export function GrowthWidget({ babyId, records, isError }: Props) {
                         )}
                     </div>
                 ) : (
-                    <p className="text-sm text-gray-400 dark:text-zinc-600">記録なし</p>
+                    <p className="text-sm text-gray-400 dark:text-zinc-600" data-sentry-unmask>記録なし</p>
                 )}
             </CardContent>
         </Card>

--- a/frontend/components/dashboard/SleepWidget.tsx
+++ b/frontend/components/dashboard/SleepWidget.tsx
@@ -47,13 +47,13 @@ export function SleepWidget({ babyId, records, isError, mutate }: Props) {
         return (
             <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 opacity-60 transition-colors">
                 <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
-                    <CardTitle className="text-sm font-medium text-gray-400 dark:text-zinc-500 flex items-center gap-1">
+                    <CardTitle className="text-sm font-medium text-gray-400 dark:text-zinc-500 flex items-center gap-1" data-sentry-unmask>
                         💤 睡眠
                     </CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-col items-center justify-center py-6">
                     <ShieldOff className="h-6 w-6 text-gray-300 dark:text-zinc-700 mb-1" />
-                    <p className="text-[10px] text-gray-400 dark:text-zinc-600">閲覧制限中</p>
+                    <p className="text-[10px] text-gray-400 dark:text-zinc-600" data-sentry-unmask>閲覧制限中</p>
                 </CardContent>
             </Card>
         )
@@ -94,7 +94,7 @@ export function SleepWidget({ babyId, records, isError, mutate }: Props) {
     return (
         <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 transition-colors">
             <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
-                <CardTitle className="text-sm font-medium text-indigo-500 dark:text-indigo-400 flex items-center gap-1">
+                <CardTitle className="text-sm font-medium text-indigo-500 dark:text-indigo-400 flex items-center gap-1" data-sentry-unmask>
                     💤 睡眠
                     {isSleeping ? (
                         <span className="ml-1 inline-block w-2 h-2 rounded-full bg-indigo-400 animate-pulse" />
@@ -116,7 +116,7 @@ export function SleepWidget({ babyId, records, isError, mutate }: Props) {
                 <div>
                     {isSleeping ? (
                         <>
-                            <p className="text-lg font-bold text-indigo-600 dark:text-indigo-400">睡眠中</p>
+                            <p className="text-lg font-bold text-indigo-600 dark:text-indigo-400" data-sentry-unmask>睡眠中</p>
                             <p className="text-2xl font-bold text-gray-800 dark:text-zinc-100">{elapsed}</p>
                         </>
                     ) : (
@@ -138,6 +138,7 @@ export function SleepWidget({ babyId, records, isError, mutate }: Props) {
                                 : "bg-indigo-50 dark:bg-indigo-950/30 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/50"
                             }`}
                         variant="outline"
+                        data-sentry-unmask
                     >
                         {isSleeping ? "睡眠終了" : "睡眠開始"}
                     </Button>

--- a/frontend/components/diaper/DiaperForm.tsx
+++ b/frontend/components/diaper/DiaperForm.tsx
@@ -156,6 +156,7 @@ export function DiaperForm({ babyId, onSuccess }: Props) {
                             type="submit"
                             className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl h-11"
                             disabled={isSubmitting}
+                            data-sentry-unmask
                         >
                             {isSubmitting ? "保存中..." : "保存する"}
                         </Button>

--- a/frontend/components/feeding/feeding-form.tsx
+++ b/frontend/components/feeding/feeding-form.tsx
@@ -188,8 +188,8 @@ export function FeedingForm({ babyId, onAdd }: FeedingFormProps) {
             <CardContent className="pt-6">
                 <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as FeedingType)} className="w-full">
                     <TabsList className="grid w-full grid-cols-2 mb-4">
-                        <TabsTrigger value="BREAST">🤱 母乳</TabsTrigger>
-                        <TabsTrigger value="BOTTLE">🍼 ミルク</TabsTrigger>
+                        <TabsTrigger value="BREAST" data-sentry-unmask>🤱 母乳</TabsTrigger>
+                        <TabsTrigger value="BOTTLE" data-sentry-unmask>🍼 ミルク</TabsTrigger>
                     </TabsList>
 
                     <Form {...form}>
@@ -389,7 +389,7 @@ export function FeedingForm({ babyId, onAdd }: FeedingFormProps) {
                                 )}
                             />
 
-                            <Button type="submit" className="w-full bg-indigo-600 hover:bg-indigo-700 text-white">
+                            <Button type="submit" className="w-full bg-indigo-600 hover:bg-indigo-700 text-white" data-sentry-unmask>
                                 <Save className="w-4 h-4 mr-2" />
                                 記録する
                             </Button>

--- a/frontend/components/growth/GrowthRecordForm.tsx
+++ b/frontend/components/growth/GrowthRecordForm.tsx
@@ -173,10 +173,10 @@ export function GrowthRecordForm({
                     )}
 
                     <DialogFooter>
-                        <Button type="button" variant="outline" onClick={onClose}>
+                        <Button type="button" variant="outline" onClick={onClose} data-sentry-unmask>
                             キャンセル
                         </Button>
-                        <Button type="submit" disabled={isSubmitting}>
+                        <Button type="submit" disabled={isSubmitting} data-sentry-unmask>
                             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                             {record ? "更新" : "保存"}
                         </Button>

--- a/frontend/components/sleep/sleep-form.tsx
+++ b/frontend/components/sleep/sleep-form.tsx
@@ -60,7 +60,7 @@ export function SleepForm({ babyId }: Props) {
     return (
         <Dialog open={isOpen} onOpenChange={setIsOpen}>
             <DialogTrigger asChild>
-                <Button variant="outline" className="w-full bg-white dark:bg-zinc-900 text-indigo-600 dark:text-indigo-400 border-indigo-100 dark:border-zinc-800 hover:bg-indigo-50 dark:hover:bg-zinc-800 hover:text-indigo-700 dark:hover:text-indigo-300 h-12 rounded-xl shadow-sm transition-colors">
+                <Button variant="outline" className="w-full bg-white dark:bg-zinc-900 text-indigo-600 dark:text-indigo-400 border-indigo-100 dark:border-zinc-800 hover:bg-indigo-50 dark:hover:bg-zinc-800 hover:text-indigo-700 dark:hover:text-indigo-300 h-12 rounded-xl shadow-sm transition-colors" data-sentry-unmask>
                     <Plus className="mr-2 h-4 w-4" />
                     手動で記録を追加
                 </Button>
@@ -112,7 +112,7 @@ export function SleepForm({ babyId }: Props) {
                                 </FormItem>
                             )}
                         />
-                        <Button type="submit" className="w-full bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white shadow-none" disabled={form.formState.isSubmitting}>
+                        <Button type="submit" className="w-full bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white shadow-none" disabled={form.formState.isSubmitting} data-sentry-unmask>
                             {form.formState.isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                             記録する
                         </Button>

--- a/frontend/instrumentation-client.ts
+++ b/frontend/instrumentation-client.ts
@@ -8,7 +8,13 @@ Sentry.init({
   dsn: "https://df57b075f6f01f47246f03f44fb7f5d6@o4510904857526272.ingest.us.sentry.io/4510904861065216",
 
   // Add optional integrations for additional features
-  integrations: [Sentry.replayIntegration()],
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,                            // デフォルト全マスク（安全側を維持）
+      blockAllMedia: true,                          // 画像・メディアもデフォルトでブロック
+      unmask: ["[data-sentry-unmask]"],               // この属性の要素のみ表示する
+    }),
+  ],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,


### PR DESCRIPTION
## Summary

- **デフォルト全マスク方針**を採用し、Session Replay のプライバシーを強化
- ナビゲーション・ボタン・ページ見出しなど静的 UI テキストに `data-sentry-unmask` 属性を付与してアンマスク
- ユーザー入力・赤ちゃん名・育児記録数値・フリーテキストメモは属性なしでマスクのまま保護

## 変更ファイル

| ファイル | 変更内容 |
| :--- | :--- |
| `frontend/instrumentation-client.ts` | `replayIntegration` に `maskAllText: true` / `blockAllMedia: true` / `unmask: ["[data-sentry-unmask]"]` 追加 |
| `frontend/app/(dashboard)/layout.tsx` | `<nav>` / `Baby App` h1 / `メニュー` SheetTitle にアンマスク属性追加 |
| `frontend/components/dashboard/*Widget.tsx` (4ファイル) | CardTitle・クイック操作ボタン・閲覧制限中ラベルに追加 |
| `frontend/components/{feeding,sleep,diaper,growth}/` (4ファイル) | 送信ボタン・タブ切り替えに追加 |
| `frontend/app/(auth)/login/page.tsx` | CardTitle・CardDescription・ログインボタンに追加 |
| `frontend/app/(auth)/register/page.tsx` | TabsTrigger・CardTitle×2・送信ボタン×2に追加 |
| `.specify/specs/infrastructure/sentry_monitoring.md` | セクション 10「Session Replay プライバシー設定」を新規追加 |

## Test plan

- [ ] Session Replay で **ナビゲーションラベル**（ホーム、授乳など）が表示されていること
- [ ] Session Replay で **ボタン文言**（記録する、保存する、ログインなど）が表示されていること
- [ ] Session Replay で **入力フィールドの内容**（ユーザー名、パスワード）がマスクされていること
- [ ] Session Replay で **赤ちゃんの名前・育児記録数値**がマスクされていること
- [ ] `pnpm build` がエラーなく完了すること ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)