### PR TITLE
ci: semantic-release の認証エラーを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npx semantic-release
 
       - name: Check if new release was published


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN`（自動生成トークン）を `GH_TOKEN`（PAT）に変更
- semantic-release がタグ作成・リリース公開に必要な権限を確保

## 背景
`GITHUB_TOKEN` では semantic-release の `verifyConditions` が `EINVALIDGHTOKEN` で失敗していた。`repo` スコープを持つ PAT を `GH_TOKEN` シークレットとして登録し、ワークフローで参照するよう変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)