### PR TITLE
fix: 手動編集済み日誌の再生成が無声でスキップされるバグを修正

### DIFF
--- a/frontend/app/(dashboard)/diary/page.tsx
+++ b/frontend/app/(dashboard)/diary/page.tsx
@@ -64,11 +64,17 @@ export default function DiaryPage() {
     const hasSelectedSummary = selectedSummary !== null
     const isSelectedEdited = selectedSummary?.is_edited ?? false
 
-    const doGenerate = async () => {
+    const doGenerate = async (forceRegen = false) => {
         if (!babyId) return
         setIsGenerating(true)
         setGenerateError(null)
         try {
+            // 手動編集済みを確認の上で再生成する場合は先に編集をクリアする。
+            // バックエンドは is_edited=true のレコードを再生成せず返すため、
+            // クリアしないと再生成が行われないまま成功扱いになってしまう。
+            if (forceRegen && selectedSummary?.is_edited) {
+                await editDailySummary(babyId, selectedDate, null, selectedSummary.image_urls ?? [])
+            }
             await generateDailySummary(babyId, selectedDate)
             await mutate()
         } catch (err: unknown) {
@@ -231,7 +237,7 @@ export default function DiaryPage() {
                         <AlertDialogAction
                             onClick={() => {
                                 setRegenConfirmOpen(false)
-                                doGenerate()
+                                doGenerate(true)
                             }}
                             className="bg-amber-500 hover:bg-amber-600 text-white"
                         >


### PR DESCRIPTION
## Summary

- `is_edited=true` の日誌に対して確認ダイアログで「再生成する」を承認しても、バックエンドが編集済みレコードをスキップして既存データをそのまま返すため、実際には再生成されないまま成功扱いになっていたバグを修正
- 修正: `forceRegen=true` の場合は先に `PATCH` で `edited_content` を `null` にクリアしてから `generateDailySummary` を実行するよう変更

## Root cause

バックエンド (`ai_summary.py:44-46`) が `is_edited=true` のレコードを無条件にスキップして 200 OK を返すため、フロントエンドは成功とみなしてしまっていた。

## Test plan

- [ ] 手動編集済みの日誌を選択し「再生成」→確認ダイアログで承認すると、AIによる新しい内容に更新されること
- [ ] 「キャンセル」を押した場合は編集済みの内容が保持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)