### PR TITLE
fix: バージョン表示を GitHub リリースの tag_name に統一

### DIFF
--- a/app/routers/version.py
+++ b/app/routers/version.py
@@ -1,4 +1,3 @@
-import json
 import os
 import time
 from typing import Optional
@@ -9,14 +8,6 @@ from fastapi import APIRouter
 from app.schemas.version import VersionResponse
 
 router = APIRouter(prefix="/api", tags=["version"])
-
-# package.json からバージョンを読み込む（起動時に一度だけ）
-_package_json_path = os.path.join(os.path.dirname(__file__), "../../frontend/package.json")
-try:
-    with open(_package_json_path) as f:
-        _app_version: str = json.load(f)["version"]
-except Exception:
-    _app_version = "unknown"
 
 # GitHub API キャッシュ（TTL: 30分）
 _cache: dict = {}
@@ -40,7 +31,11 @@ async def _fetch_latest_release() -> dict:
             resp = await client.get(_GITHUB_API_URL, headers=headers)
             if resp.status_code == 200:
                 body = resp.json()
+                tag: str = body.get("tag_name", "")
+                # "v1.2.3" -> "1.2.3"
+                version = tag.lstrip("v") if tag else "unknown"
                 data = {
+                    "version": version,
                     "release_notes": body.get("body"),
                     "published_at": body.get("published_at"),
                     "html_url": body.get("html_url"),
@@ -57,7 +52,7 @@ async def _fetch_latest_release() -> dict:
 async def get_version() -> VersionResponse:
     release = await _fetch_latest_release()
     return VersionResponse(
-        version=_app_version,
+        version=release.get("version") or "unknown",
         release_notes=release.get("release_notes"),
         published_at=release.get("published_at"),
         html_url=release.get("html_url"),


### PR DESCRIPTION
## Summary

- バージョン情報ダイアログで `v0.1.0`（`frontend/package.json`）とリリースノートのバージョン（例: `1.34.0`）が不一致になっていた
- 原因: `.releaserc.json` に `@semantic-release/npm` が含まれておらず、`package.json` のバージョンが更新されない
- 修正: `version.py` が GitHub API の `tag_name` からバージョンを取得するよう変更し、リリースノートと版数のソースを統一

## Test plan

- [ ] バージョン情報ダイアログを開き、表示バージョンがリリースノートの版数と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)