### PR TITLE
feat: 設定画面のヘッダー統一 (#106)

### DIFF
--- a/.specify/specs/ui/ui_design_system.md
+++ b/.specify/specs/ui/ui_design_system.md
@@ -368,6 +368,49 @@ export function ErrorMessage({ message }: { message: string }) {
 - `{error && <div className="text-red-500 text-sm">{error}</div>}`
   → `{error && <ErrorMessage message={error} />}` に統一
 
+### 4.4 `SettingsHeader` (New)
+
+設定画面の各サブページ（プロフィール、通知、家族など）で共通して使用するヘッダーコンポーネント。
+ダッシュボードの設定メニュー階層に戻るためのナビゲーションを提供する。
+
+**ファイルパス**: `frontend/components/settings/SettingsHeader.tsx`
+
+```tsx
+// 仕様
+export function SettingsHeader({ 
+  title, 
+  icon: Icon, 
+  children 
+}: { 
+  title: string; 
+  icon?: LucideIcon;
+  children?: React.ReactNode;
+}) {
+  return (
+    <header className="sticky top-0 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center px-4 gap-3">
+      <Link
+        href="/settings"
+        className="p-1 -ml-1 text-gray-500 dark:text-zinc-400 hover:text-gray-800 dark:hover:text-zinc-100 transition-colors"
+      >
+        <ChevronLeft className="h-5 w-5" />
+      </Link>
+      <div className="flex items-center gap-2 flex-1">
+        {Icon && <Icon className="h-4 w-4 text-violet-600" />}
+        <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100">
+          {title}
+        </h1>
+      </div>
+      {children && <div>{children}</div>}
+    </header>
+  );
+}
+```
+
+**適用ルール**:
+- すべての設定サブページでこのコンポーネントを使用する。
+- 戻る先は常に `/settings` とする。
+- タイトルとアイコンはページ内容に合わせて設定する。
+
 ---
 
 ## 5. アイコン使用ルール
@@ -566,3 +609,9 @@ export function ErrorMessage({ message }: { message: string }) {
 
 - [x] サブページ内の「ダッシュボードへ戻る」ボタンを廃止し、グローバルヘッダーに集約
 - [x] Contraction の旧スタイル（`<a href="/">← ダッシュボード</a>`）を廃止
+
+### 設定画面
+
+- [ ] `SettingsHeader` コンポーネント新規作成
+- [ ] Profile, Notification, Family, Babies, Permissions 各ページで `SettingsHeader` を適用
+- [ ] 各ページの個別実装ヘッダーを削除

--- a/frontend/app/(dashboard)/settings/babies/page.tsx
+++ b/frontend/app/(dashboard)/settings/babies/page.tsx
@@ -10,10 +10,8 @@ import { BabyEditDialog } from "@/components/settings/BabyEditDialog"
 import { AddBabyDialog } from "@/components/settings/AddBabyDialog"
 import { BabyDeleteDialog } from "@/components/settings/BabyDeleteDialog"
 import { UserRole } from "@/lib/constants"
-
 import { Baby } from "@/types/baby"
-
-/* Removed local Baby interface */
+import { SettingsHeader } from "@/components/settings/SettingsHeader"
 
 export default function BabySettingsPage() {
     const { user, isLoading: userLoading } = useUser()
@@ -40,10 +38,7 @@ export default function BabySettingsPage() {
     return (
         <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 transition-colors">
             {/* sticky header */}
-            <header className="sticky top-0 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center justify-between px-4">
-                <div className="flex items-center">
-                    <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100">赤ちゃん管理</h1>
-                </div>
+            <SettingsHeader title="赤ちゃん管理">
                 {isAdmin && (
                     <Button
                         size="sm"
@@ -54,7 +49,7 @@ export default function BabySettingsPage() {
                         赤ちゃんを追加
                     </Button>
                 )}
-            </header>
+            </SettingsHeader>
 
             <div className="max-w-2xl mx-auto p-4 space-y-4">
                 {!babies || babies.length === 0 ? (

--- a/frontend/app/(dashboard)/settings/family/page.tsx
+++ b/frontend/app/(dashboard)/settings/family/page.tsx
@@ -1,11 +1,11 @@
 "use client"
-import Link from "next/link"
-import { Button } from "@/components/ui/button"
 import { useUser } from "@/hooks/useAuth"
 import { useFamilySettings, useFamilyMembers } from "@/hooks/useData"
 import { FamilyNameForm } from "@/components/settings/FamilyNameForm"
 import { InviteCodeCard } from "@/components/settings/InviteCodeCard"
 import { MemberList } from "@/components/settings/MemberList"
+
+import { SettingsHeader } from "@/components/settings/SettingsHeader"
 
 export default function FamilySettingsPage() {
     const { user, isLoading: userLoading } = useUser()
@@ -29,7 +29,6 @@ export default function FamilySettingsPage() {
     const handleFamilyUpdated = () => {
         mutateFamily()
     }
-
     const handleMembersUpdated = () => {
         mutateMembers()
     }
@@ -37,9 +36,7 @@ export default function FamilySettingsPage() {
     return (
         <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 transition-colors">
             {/* sticky header */}
-            <header className="sticky top-0 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center justify-center px-4">
-                <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100">家族設定</h1>
-            </header>
+            <SettingsHeader title="家族設定" />
 
             <div className="max-w-2xl mx-auto p-4 space-y-4">
                 {/* 家族名 */}

--- a/frontend/app/(dashboard)/settings/notifications/page.tsx
+++ b/frontend/app/(dashboard)/settings/notifications/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { ChevronLeft, Bell, BellOff, Shield, Clock } from "lucide-react";
+import { Bell, Shield, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { toast } from "sonner";
 import { usePushNotification } from "@/hooks/usePushNotification";
+import { SettingsHeader } from "@/components/settings/SettingsHeader";
 
 interface NotificationSettings {
   family_record_enabled: boolean;
@@ -20,7 +20,6 @@ interface NotificationSettings {
 }
 
 export default function NotificationsPage() {
-  const router = useRouter();
   const { permission, requestPermission, subscribeUser, sendSubscriptionToBackend } = usePushNotification();
   const [settings, setSettings] = useState<NotificationSettings | null>(null);
   const [loading, setLoading] = useState(true);
@@ -43,7 +42,7 @@ export default function NotificationsPage() {
     }
   };
 
-  const updateSetting = async (key: keyof NotificationSettings, value: any) => {
+  const updateSetting = async (key: keyof NotificationSettings, value: boolean | string | null) => {
     if (!settings) return;
 
     const newSettings = { ...settings, [key]: value };
@@ -57,7 +56,7 @@ export default function NotificationsPage() {
       });
       if (!response.ok) throw new Error();
       toast.success("設定を更新しました");
-    } catch (error) {
+    } catch {
       toast.error("設定の更新に失敗しました");
       fetchSettings(); // ロールバック
     }
@@ -104,7 +103,7 @@ export default function NotificationsPage() {
       case "granted": return "許可されています";
       case "denied": return "ブロックされています";
       case "default": return "未設定（クリックで許可を求める）";
-      case "unsupported" as any: return "非対応（ホーム画面に追加してください）";
+      case "unsupported" as unknown: return "非対応（ホーム画面に追加してください）";
       default: return "不明な状態";
     }
   };
@@ -113,12 +112,7 @@ export default function NotificationsPage() {
 
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-zinc-950">
-      <header className="sticky top-0 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center px-4">
-        <Button variant="ghost" size="icon" onClick={() => router.back()} className="mr-2">
-          <ChevronLeft className="h-5 w-5" />
-        </Button>
-        <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100">通知設定</h1>
-      </header>
+      <SettingsHeader title="通知設定" />
 
       <div className="max-w-2xl mx-auto p-4 space-y-6 pb-20">
         <Card className="dark:bg-zinc-900 dark:border-zinc-800">

--- a/frontend/app/(dashboard)/settings/permissions/page.tsx
+++ b/frontend/app/(dashboard)/settings/permissions/page.tsx
@@ -1,10 +1,9 @@
 "use client"
 
-import Link from "next/link"
-import { ChevronLeft, ShieldCheck, Loader2 } from "lucide-react"
+import { ShieldCheck, Loader2 } from "lucide-react"
 import { usePermissionsPage } from "@/hooks/usePermissionsPage"
 import { MemberPermissionCard } from "@/components/settings/MemberPermissionCard"
-import { ErrorMessage } from "@/components/ui/error-message"
+import { SettingsHeader } from "@/components/settings/SettingsHeader"
 
 export default function PermissionsPage() {
   const { memberPermissions, isLoading, mutate } = usePermissionsPage()
@@ -15,20 +14,7 @@ export default function PermissionsPage() {
 
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-zinc-950">
-      <header className="sticky top-0 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center px-4 gap-3">
-        <Link
-          href="/settings"
-          className="p-1 -ml-1 text-gray-500 dark:text-zinc-400 hover:text-gray-800 dark:hover:text-zinc-100"
-        >
-          <ChevronLeft className="h-5 w-5" />
-        </Link>
-        <div className="flex items-center gap-2">
-          <ShieldCheck className="h-4 w-4 text-violet-600" />
-          <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100">
-            権限管理
-          </h1>
-        </div>
-      </header>
+      <SettingsHeader title="権限管理" icon={ShieldCheck} />
 
       <div className="max-w-2xl mx-auto p-4 space-y-4 pb-20">
         <p className="text-xs text-gray-500 dark:text-zinc-500">

--- a/frontend/app/(dashboard)/settings/profile/page.tsx
+++ b/frontend/app/(dashboard)/settings/profile/page.tsx
@@ -1,7 +1,4 @@
-"use client"
 import { useState } from "react"
-import Link from "next/link"
-import { useRouter } from "next/navigation"
 import { User, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -10,10 +7,10 @@ import { useUser, User as UserType } from "@/hooks/useAuth"
 import { api } from "@/lib/api"
 import { toast } from "sonner"
 import { getDisplayName } from "@/lib/utils"
+import { SettingsHeader } from "@/components/settings/SettingsHeader"
 
 export default function ProfileSettingsPage() {
     const { user, mutate } = useUser()
-    const router = useRouter()
     const [isEditing, setIsEditing] = useState(false)
     const [displayName, setDisplayName] = useState("")
     const [isSaving, setIsSaving] = useState(false)
@@ -35,7 +32,7 @@ export default function ProfileSettingsPage() {
             toast.success("プロフィールを更新しました", {
                 description: "表示名が変更されました",
             })
-        } catch (e) {
+        } catch {
             toast.error("エラーが発生しました", {
                 description: "プロフィールの更新に失敗しました",
             })
@@ -48,9 +45,7 @@ export default function ProfileSettingsPage() {
 
     return (
         <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 transition-colors">
-            <header className="sticky top-0 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center justify-center px-4">
-                <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100">プロフィール設定</h1>
-            </header>
+            <SettingsHeader title="プロフィール設定" />
 
             <div className="max-w-md mx-auto p-4">
                 <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-6 space-y-6">

--- a/frontend/components/settings/SettingsHeader.tsx
+++ b/frontend/components/settings/SettingsHeader.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronLeft, LucideIcon } from "lucide-react";
+
+interface SettingsHeaderProps {
+    title: string;
+    icon?: LucideIcon;
+    children?: React.ReactNode;
+}
+
+export function SettingsHeader({
+    title,
+    icon: Icon,
+    children,
+}: SettingsHeaderProps) {
+    return (
+        <header className="sticky top-0 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center px-4 gap-3">
+            <Link
+                href="/settings"
+                className="p-1 -ml-1 text-gray-500 dark:text-zinc-400 hover:text-gray-800 dark:hover:text-zinc-100 transition-colors"
+            >
+                <ChevronLeft className="h-5 w-5" />
+            </Link>
+            <div className="flex items-center gap-2 flex-1">
+                {Icon && <Icon className="h-4 w-4 text-violet-600" />}
+                <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100">
+                    {title}
+                </h1>
+            </div>
+            {children && <div>{children}</div>}
+        </header>
+    );
+}


### PR DESCRIPTION
## 概要
設定画面の各ページにある戻るボタンとヘッダーのデザインを統一しました。

## 変更点
- `SettingsHeader` コンポーネントを新規作成
- 各設定ページ（権限、通知、プロフィール、赤ちゃん、家族）に `SettingsHeader` を適用
- 個別のヘッダー実装を削除

## 関連Issue
#106