### PR TITLE
feat: 設定画面のヘッダー統一とビルドエラー修正 (#106)

### DIFF
--- a/frontend/app/(dashboard)/settings/profile/page.tsx
+++ b/frontend/app/(dashboard)/settings/profile/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useState } from "react"
 import { User, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"


### PR DESCRIPTION
## 概要
設定画面の各ページにある戻るボタンとヘッダーのデザインを統一しました。また、ビルドエラーが発生したため修正を行いました。

## 変更点
- `SettingsHeader` コンポーネントを新規作成
- 各設定ページ（権限、通知、プロフィール、赤ちゃん、家族）に `SettingsHeader` を適用
- 個別のヘッダー実装を削除
- `profile/page.tsx` に `use client` ディレクティブを追加してビルドエラーを修正

## 関連Issue
#106