### PR TITLE
feat: adminによるメンバーのパスワード再発行機能を追加

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -9,7 +9,7 @@ from app.database import SessionLocal
 from app.dependencies import get_db, get_current_user
 from app.schemas.auth import LoginRequest
 from app.schemas.family import FamilyCreate, FamilyResponse
-from app.schemas.user import UserCreate, UserResponse, UserProfileUpdate
+from app.schemas.user import UserCreate, UserResponse, UserProfileUpdate, PasswordChangeRequest
 from app.models.user import User, UserSession
 from app.models.family import Family, FamilyUser, UserRole
 from app.services.auth import verify_password, get_password_hash
@@ -29,6 +29,18 @@ def _create_session(db: Session, user_id: int) -> str:
     db.add(session)
     db.commit()
     return token
+
+
+@router.post("/change-password", status_code=204)
+def change_password(
+    req: PasswordChangeRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    if not verify_password(req.current_password, current_user.hashed_password):
+        raise HTTPException(status_code=400, detail="Current password is incorrect")
+    current_user.hashed_password = get_password_hash(req.new_password)
+    db.commit()
 
 
 @router.patch("/me", response_model=UserResponse)

--- a/app/routers/family.py
+++ b/app/routers/family.py
@@ -12,7 +12,9 @@ from app.schemas.family import (
     FamilyUpdate,
     FamilyMemberResponse,
     MemberRoleUpdate,
+    PasswordResetResponse,
 )
+from app.services.auth import get_password_hash
 
 router = APIRouter(prefix="/api/family", tags=["family"])
 
@@ -133,6 +135,35 @@ def update_member_role(
         role=target.role,
         joined_at=target.joined_at,
     )
+
+
+@router.post("/members/{user_id}/reset-password", response_model=PasswordResetResponse)
+def reset_member_password(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> PasswordResetResponse:
+    family_user = _get_family_user(db, current_user)
+    _require_admin(family_user)
+    if user_id == current_user.id:
+        raise HTTPException(status_code=400, detail="Cannot reset your own password here")
+    target_family_user = (
+        db.query(FamilyUser)
+        .filter(
+            FamilyUser.family_id == family_user.family_id,
+            FamilyUser.user_id == user_id,
+        )
+        .first()
+    )
+    if not target_family_user:
+        raise HTTPException(status_code=404, detail="Member not found")
+    target_user = db.query(User).filter(User.id == user_id).first()
+    if not target_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    temporary_password = secrets.token_urlsafe(9)  # ~12 chars
+    target_user.hashed_password = get_password_hash(temporary_password)
+    db.commit()
+    return PasswordResetResponse(temporary_password=temporary_password)
 
 
 @router.delete("/members/{user_id}", status_code=204)

--- a/app/schemas/family.py
+++ b/app/schemas/family.py
@@ -44,3 +44,7 @@ class FamilyMemberResponse(BaseModel):
 
 class MemberRoleUpdate(BaseModel):
     role: UserRole
+
+
+class PasswordResetResponse(BaseModel):
+    temporary_password: str

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -21,6 +21,20 @@ class UserProfileUpdate(BaseModel):
     display_name: Optional[str] = Field(None, max_length=50)
 
 
+class PasswordChangeRequest(BaseModel):
+    current_password: str
+    new_password: str = Field(..., min_length=8, max_length=128)
+
+    @field_validator('new_password')
+    @classmethod
+    def password_complexity(cls, v: str) -> str:
+        if not any(c.isalpha() for c in v):
+            raise ValueError('Password must contain at least one letter')
+        if not any(c.isdigit() for c in v):
+            raise ValueError('Password must contain at least one digit')
+        return v
+
+
 class UserResponse(BaseModel):
     id: int
     username: str

--- a/frontend/app/(dashboard)/settings/profile/page.tsx
+++ b/frontend/app/(dashboard)/settings/profile/page.tsx
@@ -1,12 +1,12 @@
 "use client"
 
 import { useState } from "react"
-import { User, Loader2 } from "lucide-react"
+import { User, Loader2, Lock } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useUser, User as UserType } from "@/hooks/useAuth"
-import { api } from "@/lib/api"
+import { api, isApiError } from "@/lib/api"
 import { toast } from "sonner"
 import { getDisplayName } from "@/lib/utils"
 import { SettingsHeader } from "@/components/settings/SettingsHeader"
@@ -16,6 +16,13 @@ export default function ProfileSettingsPage() {
     const [isEditing, setIsEditing] = useState(false)
     const [displayName, setDisplayName] = useState("")
     const [isSaving, setIsSaving] = useState(false)
+
+    const [isChangingPassword, setIsChangingPassword] = useState(false)
+    const [currentPassword, setCurrentPassword] = useState("")
+    const [newPassword, setNewPassword] = useState("")
+    const [confirmPassword, setConfirmPassword] = useState("")
+    const [passwordError, setPasswordError] = useState<string | null>(null)
+    const [isSavingPassword, setIsSavingPassword] = useState(false)
 
     // 初期値をセット
     const handleEditStart = () => {
@@ -40,6 +47,48 @@ export default function ProfileSettingsPage() {
             })
         } finally {
             setIsSaving(false)
+        }
+    }
+
+    const handlePasswordChangeStart = () => {
+        setCurrentPassword("")
+        setNewPassword("")
+        setConfirmPassword("")
+        setPasswordError(null)
+        setIsChangingPassword(true)
+    }
+
+    const handlePasswordSave = async () => {
+        setPasswordError(null)
+        if (newPassword !== confirmPassword) {
+            setPasswordError("新しいパスワードが一致しません")
+            return
+        }
+        if (newPassword.length < 8) {
+            setPasswordError("パスワードは8文字以上で入力してください")
+            return
+        }
+        setIsSavingPassword(true)
+        try {
+            await api.post("/auth/change-password", {
+                current_password: currentPassword,
+                new_password: newPassword,
+            })
+            setIsChangingPassword(false)
+            toast.success("パスワードを変更しました")
+        } catch (e: unknown) {
+            if (isApiError(e)) {
+                const detail = (e.info as { detail?: string })?.detail
+                if (detail === "Current password is incorrect") {
+                    setPasswordError("現在のパスワードが正しくありません")
+                } else {
+                    setPasswordError(detail || "パスワードの変更に失敗しました")
+                }
+            } else {
+                setPasswordError("パスワードの変更に失敗しました")
+            }
+        } finally {
+            setIsSavingPassword(false)
         }
     }
 
@@ -119,6 +168,76 @@ export default function ProfileSettingsPage() {
                                 </div>
                             )}
                         </div>
+                    </div>
+
+                    <div className="pt-4 border-t border-gray-100 dark:border-zinc-800">
+                        <div className="flex items-center gap-2 mb-3">
+                            <Lock className="h-4 w-4 text-gray-400 dark:text-zinc-500" />
+                            <Label className="dark:text-zinc-300">パスワード</Label>
+                        </div>
+                        {isChangingPassword ? (
+                            <div className="space-y-3">
+                                <div className="space-y-1">
+                                    <Label htmlFor="currentPassword" className="text-xs text-gray-500 dark:text-zinc-500">現在のパスワード</Label>
+                                    <Input
+                                        id="currentPassword"
+                                        type="password"
+                                        value={currentPassword}
+                                        onChange={(e) => setCurrentPassword(e.target.value)}
+                                        autoFocus
+                                        className="dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100"
+                                    />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="newPassword" className="text-xs text-gray-500 dark:text-zinc-500">新しいパスワード（8文字以上、英字・数字を含む）</Label>
+                                    <Input
+                                        id="newPassword"
+                                        type="password"
+                                        value={newPassword}
+                                        onChange={(e) => setNewPassword(e.target.value)}
+                                        className="dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100"
+                                    />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="confirmPassword" className="text-xs text-gray-500 dark:text-zinc-500">新しいパスワード（確認）</Label>
+                                    <Input
+                                        id="confirmPassword"
+                                        type="password"
+                                        value={confirmPassword}
+                                        onChange={(e) => setConfirmPassword(e.target.value)}
+                                        className="dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100"
+                                    />
+                                </div>
+                                {passwordError && (
+                                    <p className="text-red-500 text-xs">{passwordError}</p>
+                                )}
+                                <div className="flex gap-2">
+                                    <Button
+                                        className="flex-1 bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white"
+                                        onClick={handlePasswordSave}
+                                        disabled={isSavingPassword}
+                                    >
+                                        {isSavingPassword && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                        変更する
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        className="flex-1 dark:bg-zinc-900 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                                        onClick={() => setIsChangingPassword(false)}
+                                        disabled={isSavingPassword}
+                                    >
+                                        キャンセル
+                                    </Button>
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="flex justify-between items-center bg-gray-50 dark:bg-zinc-800/50 p-3 rounded-md border border-gray-200 dark:border-zinc-800">
+                                <span className="text-gray-400 dark:text-zinc-600 text-sm italic">••••••••</span>
+                                <Button variant="ghost" size="sm" onClick={handlePasswordChangeStart} className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-950/30">
+                                    変更
+                                </Button>
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/frontend/components/settings/MemberList.tsx
+++ b/frontend/components/settings/MemberList.tsx
@@ -13,6 +13,7 @@ import {
     AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { MemberRoleDialog } from "./MemberRoleDialog"
+import { MemberPasswordResetDialog } from "./MemberPasswordResetDialog"
 import { api } from "@/lib/api"
 import { getDisplayName } from "@/lib/utils"
 import { UserRole } from "@/lib/constants"
@@ -40,6 +41,7 @@ function formatDate(iso: string) {
 export function MemberList({ members, currentUserId, isAdmin, onUpdated }: Props) {
     const [roleDialogTarget, setRoleDialogTarget] = useState<Member | null>(null)
     const [deleteTarget, setDeleteTarget] = useState<Member | null>(null)
+    const [passwordResetTarget, setPasswordResetTarget] = useState<Member | null>(null)
     const [deleting, setDeleting] = useState(false)
 
     const handleDelete = async () => {
@@ -101,12 +103,27 @@ export function MemberList({ members, currentUserId, isAdmin, onUpdated }: Props
                                     >
                                         削除
                                     </Button>
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        className="text-xs dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+                                        onClick={() => setPasswordResetTarget(member)}
+                                    >
+                                        PW再発行
+                                    </Button>
                                 </div>
                             )}
                         </div>
                     )
                 })}
             </div>
+
+            {/* パスワード再発行ダイアログ */}
+            <MemberPasswordResetDialog
+                member={passwordResetTarget}
+                open={!!passwordResetTarget}
+                onClose={() => setPasswordResetTarget(null)}
+            />
 
             {/* ロール変更ダイアログ */}
             <MemberRoleDialog

--- a/frontend/components/settings/MemberPasswordResetDialog.tsx
+++ b/frontend/components/settings/MemberPasswordResetDialog.tsx
@@ -1,0 +1,146 @@
+"use client"
+import { useState } from "react"
+import { Copy, Check } from "lucide-react"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogFooter,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { api, isApiError } from "@/lib/api"
+import { getDisplayName } from "@/lib/utils"
+
+interface Member {
+    user_id: number
+    username: string
+    display_name: string | null
+}
+
+interface Props {
+    member: Member | null
+    open: boolean
+    onClose: () => void
+}
+
+export function MemberPasswordResetDialog({ member, open, onClose }: Props) {
+    const [step, setStep] = useState<"confirm" | "result">("confirm")
+    const [temporaryPassword, setTemporaryPassword] = useState<string | null>(null)
+    const [resetting, setResetting] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [copied, setCopied] = useState(false)
+
+    const handleClose = () => {
+        setStep("confirm")
+        setTemporaryPassword(null)
+        setError(null)
+        setCopied(false)
+        onClose()
+    }
+
+    const handleReset = async () => {
+        if (!member) return
+        setResetting(true)
+        setError(null)
+        try {
+            const res = await api.post<{ temporary_password: string }>(
+                `/family/members/${member.user_id}/reset-password`,
+                {}
+            )
+            setTemporaryPassword(res.temporary_password)
+            setStep("result")
+        } catch (e: unknown) {
+            if (isApiError(e)) {
+                setError((e.info as { detail?: string })?.detail || "パスワード再発行に失敗しました")
+            } else {
+                setError("パスワード再発行に失敗しました")
+            }
+        } finally {
+            setResetting(false)
+        }
+    }
+
+    const handleCopy = () => {
+        if (!temporaryPassword) return
+        navigator.clipboard.writeText(temporaryPassword)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+    }
+
+    const displayName = member ? getDisplayName(member) : ""
+
+    if (step === "result" && temporaryPassword) {
+        return (
+            <Dialog open={open} onOpenChange={(v) => { if (!v) handleClose() }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>🔑 仮パスワードが発行されました</DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-4 py-2">
+                        <p className="text-sm text-gray-600 dark:text-zinc-400">
+                            <span className="font-medium">{displayName}</span> さんの仮パスワード:
+                        </p>
+                        <div className="flex items-center gap-2">
+                            <code className="flex-1 bg-gray-100 dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 px-4 py-3 rounded-lg font-mono text-sm tracking-widest select-all">
+                                {temporaryPassword}
+                            </code>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={handleCopy}
+                                className="shrink-0 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+                            >
+                                {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+                            </Button>
+                        </div>
+                        <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-3 text-xs text-amber-800 dark:text-amber-300 space-y-1">
+                            <p>⚠️ この画面を閉じると確認できなくなります。</p>
+                            <p>本人に安全な方法で伝えてください。</p>
+                        </div>
+                    </div>
+                    <DialogFooter>
+                        <Button onClick={handleClose} className="bg-indigo-600 hover:bg-indigo-700 text-white">
+                            閉じる
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        )
+    }
+
+    return (
+        <AlertDialog open={open} onOpenChange={(v) => { if (!v) handleClose() }}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{displayName} のパスワードを再発行しますか？</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        現在のパスワードは無効になり、新しい仮パスワードが発行されます。
+                        発行された仮パスワードを本人に伝えてください。
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                {error && <p className="text-red-500 text-sm px-1">{error}</p>}
+                <AlertDialogFooter>
+                    <AlertDialogCancel onClick={handleClose}>キャンセル</AlertDialogCancel>
+                    <AlertDialogAction
+                        onClick={handleReset}
+                        disabled={resetting}
+                        className="bg-indigo-600 hover:bg-indigo-700"
+                    >
+                        再発行する
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    )
+}

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1907,6 +1907,39 @@
         "title": "NotificationType",
         "type": "string"
       },
+      "PasswordChangeRequest": {
+        "properties": {
+          "current_password": {
+            "title": "Current Password",
+            "type": "string"
+          },
+          "new_password": {
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "New Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "current_password",
+          "new_password"
+        ],
+        "title": "PasswordChangeRequest",
+        "type": "object"
+      },
+      "PasswordResetResponse": {
+        "properties": {
+          "temporary_password": {
+            "title": "Temporary Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "temporary_password"
+        ],
+        "title": "PasswordResetResponse",
+        "type": "object"
+      },
       "PushSubscriptionCreate": {
         "properties": {
           "auth": {
@@ -2544,6 +2577,40 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/auth/change-password": {
+      "post": {
+        "operationId": "change_password_api_auth_change_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordChangeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Change Password",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
     "/api/auth/login": {
       "post": {
         "operationId": "login_api_auth_login_post",
@@ -4001,6 +4068,48 @@
           }
         },
         "summary": "Delete Member",
+        "tags": [
+          "family"
+        ]
+      }
+    },
+    "/api/family/members/{user_id}/reset-password": {
+      "post": {
+        "operationId": "reset_member_password_api_family_members__user_id__reset_password_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PasswordResetResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Reset Member Password",
         "tags": [
           "family"
         ]


### PR DESCRIPTION
## 概要

家族のadminが、メンバーのパスワードを再発行できる機能を追加しました。
また、ユーザー自身がパスワードを変更できる機能も同時に追加しています。

## 変更内容

### バックエンド

- **`POST /api/family/members/{user_id}/reset-password`** — adminによるメンバーのパスワード再発行
  - adminのみ呼び出し可能（自分自身は対象外）
  - 12文字のランダム仮パスワードを生成・保存し、平文をレスポンスで1度だけ返す
- **`POST /api/auth/change-password`** — ユーザー自身のパスワード変更
  - 現在のパスワードを検証してから新しいパスワードに変更する
- `PasswordResetResponse`, `PasswordChangeRequest` スキーマを追加

### フロントエンド

- **`MemberPasswordResetDialog.tsx`** — パスワード再発行フロー（新規作成）
  - ステップ1: 確認ダイアログ（「再発行しますか？」）
  - ステップ2: 仮パスワード表示（コピーボタン付き・警告メッセージ付き）
- **`MemberList.tsx`** — 「PW再発行」ボタンを追加（adminかつ自分以外の行のみ）
- **`/settings/profile`** — パスワード変更セクションを追加

## テスト方法

- [ ] adminとしてログインし、家族設定 → メンバー行の「PW再発行」をタップ
- [ ] 仮パスワードが表示され、コピーができることを確認
- [ ] 表示された仮パスワードでログインできることを確認
- [ ] プロフィール設定 → パスワード変更が正常に動作することを確認
- [ ] 誤ったパスワード入力時にエラーが表示されることを確認
- [ ] adminでないユーザーにボタンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)