### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure file upload and error leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Family invite codes were generated with low/inconsistent entropy (32-bit `token_hex(4)` in `auth.py` vs ~48-bit `token_urlsafe(8)` in `family.py`) and lacked collision checks during regeneration. This increased the risk of brute-force attacks and code guessing.
 **Learning:** Security-critical tokens should have consistent high entropy across the application. Relying on short tokens for user-friendly features can compromise security if not properly balanced with rate limiting or sufficient length.
 **Prevention:** Standardized on 64-bit entropy (16-character uppercase hex strings) using `secrets.token_hex(8).upper()` and enforced uniqueness checks for all generation paths.
+
+## 2025-02-23 - [Insecure File Upload & Error Leakage]
+**Vulnerability:** File upload endpoint relied solely on content-type header and extension, allowing potential file masquerading. Additionally, internal server errors leaked stack trace/implementation details.
+**Learning:** Checking `file.content_type` is insufficient as it is client-controlled. Always validate file content (magic bytes).
+**Prevention:** Implement server-side content validation using magic bytes. Use generic error messages for 500 responses.

--- a/app/routers/upload.py
+++ b/app/routers/upload.py
@@ -61,6 +61,22 @@ async def upload_image(
             detail=f"ファイルサイズが大きすぎます（上限 5MB）。",
         )
 
+    # Validate magic bytes
+    # JPEG: FF D8 FF
+    # PNG: 89 50 4E 47 0D 0A 1A 0A
+    # GIF: 47 49 46 38
+    # WebP: RIFF ... WEBP
+    if not (
+        content.startswith(b"\xFF\xD8\xFF")
+        or content.startswith(b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A")
+        or content.startswith(b"\x47\x49\x46\x38")
+        or (content.startswith(b"RIFF") and len(content) >= 12 and content[8:12] == b"WEBP")
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="無効な画像ファイル形式です。",
+        )
+
     original_ext = os.path.splitext(file.filename or "")[1].lower() or ".webp"
     object_key = f"{uuid.uuid4()}{original_ext}"
 
@@ -79,7 +95,7 @@ async def upload_image(
         logger.error("R2 upload failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"画像のアップロードに失敗しました: {e.response['Error']['Code']} - {e.response['Error']['Message']}",
+            detail="画像のアップロードに失敗しました。",
         )
 
     public_url = f"{public_endpoint.rstrip('/')}/{object_key}"

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 def test_upload_image_r2_failure(auth_client):
     """
-    R2アップロードが失敗した場合、500エラーが返されることをテストする
+    R2アップロードが失敗した場合、500エラーが返されるが、詳細なエラーメッセージは隠蔽されることをテストする
     """
     # Create a mock client that raises ClientError
     mock_s3_client = MagicMock()
@@ -12,18 +12,33 @@ def test_upload_image_r2_failure(auth_client):
     mock_s3_client.put_object.side_effect = ClientError(error_response, 'PutObject')
 
     # Mock _get_r2_client to return the mock client
-    # Note: We patch where it is defined since it is imported and used there
     with patch("app.routers.upload._get_r2_client", return_value=mock_s3_client):
         client = auth_client()
 
-        # Prepare a dummy file for upload
-        # Simulating a file upload
-        files = {'file': ('test_image.jpg', b'fake image content', 'image/jpeg')}
+        # マジックバイト検証を通過するために、有効なJPEGヘッダーを付与
+        files = {'file': ('test_image.jpg', b'\xFF\xD8\xFFfake image content', 'image/jpeg')}
 
         response = client.post("/api/upload/image", files=files)
 
         assert response.status_code == 500
         data = response.json()
-        # Verify the error details are propagated
-        assert "InternalError" in data["detail"]
-        assert "Something went wrong" in data["detail"]
+
+        # Verify the error details are HIDDEN
+        # 旧仕様: assert "InternalError" in data["detail"]
+        assert data["detail"] == "画像のアップロードに失敗しました。"
+        assert "InternalError" not in data["detail"]
+
+
+def test_upload_image_invalid_magic_bytes(auth_client):
+    """
+    マジックバイトが無効な場合、400エラーが返されることをテストする
+    """
+    client = auth_client()
+
+    # 拡張子はjpgだが中身はテキスト（マジックバイトなし）
+    files = {'file': ('test_image.jpg', b'This is definitely not an image', 'image/jpeg')}
+
+    response = client.post("/api/upload/image", files=files)
+
+    assert response.status_code == 400
+    assert "無効な画像ファイル形式です" in response.json()["detail"]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability:
  1. The file upload endpoint (`/api/upload/image`) relied solely on the `Content-Type` header and file extension for validation, allowing attackers to upload malicious files (e.g., scripts) by masquerading them as images.
  2. The endpoint leaked internal exception details (stack traces, error codes) from the R2 storage service in 500 error responses.

🎯 Impact:
  - Malicious file upload could lead to RCE (Remote Code Execution) or XSS if the file is served directly.
  - Information leakage aids attackers in reconnaissance by exposing backend implementation details.

🔧 Fix:
  - Implemented server-side magic byte validation for JPEG, PNG, GIF, and WebP formats.
  - Modified exception handling to catch `ClientError` and return a generic "Upload failed" message, logging the details internally instead.

✅ Verification:
  - Added unit tests in `tests/test_upload.py` to verify:
    - Masqueraded files (valid extension, invalid content) are rejected with 400 Bad Request.
    - Upstream errors result in a generic 500 error message without sensitive details.
  - Ran `pytest tests/test_upload.py` and confirmed all tests pass.


---
*PR created automatically by Jules for task [2744829081677161625](https://jules.google.com/task/2744829081677161625) started by @eburairu*