### PR TITLE
🛡️ Sentinel: Enhance Security Headers (Permissions-Policy & Cache-Control)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The login endpoint (`/api/auth/login`) was vulnerable to user enumeration via timing attacks. When a user was not found, the function returned immediately without verifying a password hash, whereas a valid user (with incorrect password) would undergo a time-consuming bcrypt verification. This difference in response time allowed attackers to determine if a username exists.
 **Learning:** Security controls like password hashing can introduce side channels if not applied consistently. Always ensure that sensitive operations like authentication take a similar amount of time regardless of the outcome (success/failure).
 **Prevention:** Implemented a dummy hash verification that runs when a user is not found, ensuring that `verify_password` is called in both scenarios to equalize execution time.
+
+## 2026-03-02 - Enhancing Security Headers
+**Vulnerability:** Missing `Permissions-Policy` allowed potential access to sensitive browser features. API endpoints lacked `Cache-Control: no-store`, risking sensitive data caching.
+**Learning:** Defense in depth includes proactively disabling unused browser features and strictly controlling caching for authenticated APIs.
+**Prevention:** Added `Permissions-Policy` to disable camera/mic/geo by default. Added `Cache-Control: no-store` middleware for `/api/` routes.

--- a/app/middleware/security.py
+++ b/app/middleware/security.py
@@ -12,4 +12,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
         # CSP: Allow self, unsafe-inline/eval for dev/Next.js compatibility, and common external sources for images/connect
         response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:;"
+
+        # Permissions Policy: Disable sensitive features by default
+        response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=(), payment=()"
+
+        # Cache Control for API endpoints to prevent sensitive data caching
+        if request.url.path.startswith("/api/"):
+            response.headers["Cache-Control"] = "no-store"
+
         return response

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -20,3 +20,26 @@ def test_security_headers():
     assert "default-src 'self'" in csp
     assert "script-src 'self' 'unsafe-inline' 'unsafe-eval'" in csp
     assert "img-src 'self' data: https:" in csp
+
+    # Permissions Policy
+    permissions = headers.get("Permissions-Policy")
+    assert permissions is not None
+    assert "camera=()" in permissions
+    assert "microphone=()" in permissions
+    assert "geolocation=()" in permissions
+    assert "browsing-topics=()" in permissions
+
+    # Cache Control for API endpoints
+    assert headers.get("Cache-Control") == "no-store"
+
+def test_security_headers_non_api():
+    """Verify that non-API endpoints do not get the no-store Cache-Control header."""
+    response = client.get("/robots.txt") # Random non-api path
+
+    # Permissions Policy should be present everywhere
+    assert response.headers.get("Permissions-Policy") is not None
+
+    # Cache-Control should NOT be 'no-store' for non-API routes
+    cache_control = response.headers.get("Cache-Control")
+    if cache_control:
+        assert "no-store" not in cache_control


### PR DESCRIPTION
Added `Permissions-Policy` header to disable sensitive browser features (camera, microphone, geolocation, etc.) by default.
Added `Cache-Control: no-store` header specifically for `/api/` endpoints to prevent sensitive data caching.
Updated `tests/test_security_headers.py` to verify the new headers.
Updated `.jules/sentinel.md` with new security learning.

---
*PR created automatically by Jules for task [12564108574856461357](https://jules.google.com/task/12564108574856461357) started by @eburairu*