### PR TITLE
fix: 204 No ContentレスポンスによるTypeErrorを修正

### DIFF
--- a/frontend/hooks/useNotifications.ts
+++ b/frontend/hooks/useNotifications.ts
@@ -54,11 +54,5 @@ export async function markAsRead(id: number): Promise<AppNotification> {
 }
 
 export async function markAllAsRead(): Promise<void> {
-    const res = await fetch(`${API_BASE}/notifications/read-all`, {
-        method: "PATCH",
-        credentials: "include",
-    })
-    if (!res.ok) {
-        throw new ApiError("Failed to mark all notifications as read", res.statusText, res.status)
-    }
+    await api.patch<void, Record<string, never>>(`/notifications/read-all`, {})
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -36,6 +36,7 @@ export const fetcher = async <T = unknown>(url: string): Promise<T> => {
             res.status
         );
     }
+    if (res.status === 204) return null as T;
     return res.json() as Promise<T>;
 };
 
@@ -52,6 +53,7 @@ export const api = {
         if (!res.ok) {
             throw new ApiError('API Error', await parseErrorBody(res), res.status);
         }
+        if (res.status === 204) return null as TRes;
         return res.json() as Promise<TRes>;
     },
     put: async <TRes = unknown, TReq = unknown>(url: string, body: TReq): Promise<TRes> => {
@@ -66,6 +68,7 @@ export const api = {
         if (!res.ok) {
             throw new ApiError('API Error', await parseErrorBody(res), res.status);
         }
+        if (res.status === 204) return null as TRes;
         return res.json() as Promise<TRes>;
     },
     patch: async <TRes = unknown, TReq = unknown>(url: string, body: TReq): Promise<TRes> => {
@@ -80,6 +83,7 @@ export const api = {
         if (!res.ok) {
             throw new ApiError('API Error', await parseErrorBody(res), res.status);
         }
+        if (res.status === 204) return null as TRes;
         return res.json() as Promise<TRes>;
     },
     delete: async <TRes = unknown>(url: string): Promise<TRes | null> => {

--- a/scripts/verify_all.sh
+++ b/scripts/verify_all.sh
@@ -35,12 +35,12 @@ set +a
 echo -e "
 ${YELLOW}--- [1/5] バックエンドテスト実行中... ---${NC}"
 # 仮想環境の python を使用
-python -m pytest tests/
+.venv/bin/python -m pytest tests/
 
 # 3. OpenAPI スキーマの更新
 echo -e "
 ${YELLOW}--- [2/5] OpenAPI スキーマの更新と検証... ---${NC}"
-python scripts/export_openapi.py
+.venv/bin/python scripts/export_openapi.py
 
 # 4. フロントエンド型定義の生成
 echo -e "


### PR DESCRIPTION
Sentryで報告されていたiOS Safariでの`TypeError: Load failed`（204 No Contentレスポンスの空ボディをJSONとしてパースしようとする問題）を修正しました。

- `frontend/lib/api.ts` 内の全HTTPメソッドにおいて、ステータス204の場合は `null` を返すように修正
- `useNotifications.ts` の `markAllAsRead` を `api.patch` を用いるように簡略化
- (CI向け) `scripts/verify_all.sh` でpythonのパス解決に失敗する環境があるため、venvのpythonを直接呼ぶように修正