### PR TITLE
fix: 管理者以外への招待コード露出を修正

### DIFF
--- a/frontend/components/settings/InviteCodeCard.tsx
+++ b/frontend/components/settings/InviteCodeCard.tsx
@@ -43,6 +43,8 @@ export function InviteCodeCard({ inviteCode, isAdmin, onRegenerated }: Props) {
         }
     }
 
+    if (!isAdmin) return null
+
     return (
         <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 transition-colors">
             <div className="flex items-center gap-2 mb-3">
@@ -64,35 +66,33 @@ export function InviteCodeCard({ inviteCode, isAdmin, onRegenerated }: Props) {
                 </Button>
             </div>
             {copied && <p className="text-green-600 dark:text-green-500 text-xs mt-1" role="status">コピーしました ✓</p>}
-            {isAdmin && (
-                <div className="mt-3">
-                    <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                            <Button variant="outline" size="sm" loading={regenerating} className="dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800">
-                                <RefreshCw className="h-4 w-4 mr-1" />
-                                再生成
-                            </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                            <AlertDialogHeader>
-                                <AlertDialogTitle>招待コードを再生成しますか？</AlertDialogTitle>
-                                <AlertDialogDescription>
-                                    既存のコードは無効になります。再生成すると元に戻せません。
-                                </AlertDialogDescription>
-                            </AlertDialogHeader>
-                            <AlertDialogFooter>
-                                <AlertDialogCancel>キャンセル</AlertDialogCancel>
-                                <AlertDialogAction
-                                    onClick={handleRegenerate}
-                                    className="bg-indigo-600 hover:bg-indigo-700"
-                                >
-                                    再生成する
-                                </AlertDialogAction>
-                            </AlertDialogFooter>
-                        </AlertDialogContent>
-                    </AlertDialog>
-                </div>
-            )}
+            <div className="mt-3">
+                <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                        <Button variant="outline" size="sm" loading={regenerating} className="dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800">
+                            <RefreshCw className="h-4 w-4 mr-1" />
+                            再生成
+                        </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                        <AlertDialogHeader>
+                            <AlertDialogTitle>招待コードを再生成しますか？</AlertDialogTitle>
+                            <AlertDialogDescription>
+                                既存のコードは無効になります。再生成すると元に戻せません。
+                            </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                            <AlertDialogAction
+                                onClick={handleRegenerate}
+                                className="bg-indigo-600 hover:bg-indigo-700"
+                            >
+                                再生成する
+                            </AlertDialogAction>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialog>
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## 概要

Issue #166 の修正。`isAdmin` に関係なく招待コードが全ユーザーに平文表示されていた問題を修正。

## 変更内容

- `InviteCodeCard` コンポーネントに `if (!isAdmin) return null` を追加
- 管理者以外のユーザーにはコンポーネント全体を非表示にする
- 管理者のみが到達するようになったため、再生成ボタンの `isAdmin &&` ラッパーを削除してコードを整理

## 修正前の問題

`isAdmin` チェックは「再生成」ボタンのみに適用されており、招待コード自体は全ユーザーに表示されていた。

## テスト観点

- [ ] 管理者アカウント: 招待コード・コピーボタン・再生成ボタンが表示される
- [ ] 一般ユーザーアカウント: 招待コードセクションが表示されない

Closes #166