### PR TITLE
fix: Alembicの複数headをマージ

### DIFF
--- a/alembic/versions/3bc9c82be9d6_merge_heads.py
+++ b/alembic/versions/3bc9c82be9d6_merge_heads.py
@@ -1,0 +1,28 @@
+"""merge heads
+
+Revision ID: 3bc9c82be9d6
+Revises: 0332ddd5a74c, e6d3c1a8f902
+Create Date: 2026-02-20 14:45:18.001606+09:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3bc9c82be9d6'
+down_revision: Union[str, Sequence[str], None] = ('0332ddd5a74c', 'e6d3c1a8f902')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary

- `0332ddd5a74c`（add_app_notifications_table）と `e6d3c1a8f902`（add_note_baby_time_index）の2つのheadが並存していたため、`alembic upgrade head` が失敗していた
- マージマイグレーション `3bc9c82be9d6_merge_heads.py` を追加してheadを1つに統合

## Test plan

- [ ] `alembic heads` で head が1つであることを確認
- [ ] `alembic upgrade head` が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)