### PR TITLE
chore: PWAアイコンを起動時のBabyBottleLoadingデザインに統一

### DIFF
--- a/frontend/public/icons/icon-192x192.svg
+++ b/frontend/public/icons/icon-192x192.svg
@@ -1,29 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -3 30 30">
   <defs>
-    <linearGradient id="bottleGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#F8FAFC;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#FFFFFF;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#F1F5F9;stop-opacity:1" />
-    </linearGradient>
+    <clipPath id="bc">
+      <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" />
+    </clipPath>
   </defs>
-  <rect width="512" height="512" fill="#4F46E5" />
-  
+  <rect x="-3" y="-3" width="30" height="30" fill="#4F46E5" />
+  <!-- Bottle body background -->
+  <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" fill="white" fill-opacity="0.2" stroke="none" />
+  <!-- Liquid (clipped to bottle) -->
+  <g clip-path="url(#bc)">
+    <path d="M5 15 q 7 2 14 0 V 24 H 5 Z" fill="white" stroke="none" />
+    <path d="M5 15 q 7 2 14 0" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
   <!-- Nipple -->
-  <path d="M256 100c-20 0-35 15-35 35v25h70v-25c0-20-15-35-35-35z" fill="#FBCFE8" />
-  
-  <!-- Cap -->
-  <rect x="196" y="160" width="120" height="30" rx="8" fill="#94A3B8" />
-  
-  <!-- Bottle Body -->
-  <path d="M206 190h100c8 0 15 7 15 15v170c0 25-15 45-40 45H231c-25 0-40-20-40-45V205c0-8 7-15 15-15z" fill="url(#bottleGradient)" />
-  
-  <!-- Milk level -->
-  <path d="M191 280h130v80c0 25-15 45-40 45H231c-25 0-40-20-40-45V280z" fill="#FEF9C3" opacity="0.9" />
-  
-  <!-- Scale Lines -->
-  <rect x="275" y="225" width="20" height="5" rx="2" fill="#CBD5E1" />
-  <rect x="275" y="255" width="20" height="5" rx="2" fill="#CBD5E1" />
-  <rect x="275" y="285" width="20" height="5" rx="2" fill="#94A3B8" />
-  <rect x="275" y="315" width="20" height="5" rx="2" fill="#94A3B8" />
-  <rect x="275" y="345" width="20" height="5" rx="2" fill="#94A3B8" />
+  <path d="M10 5V4a2 2 0 0 1 4 0v1" fill="white" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <!-- Collar -->
+  <rect x="7" y="5" width="10" height="2" rx="1" fill="white" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <!-- Bottle body outline -->
+  <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <!-- Measurement lines -->
+  <path d="M14 11h-2" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
+  <path d="M14 14h-2" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
+  <path d="M14 17h-2" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
 </svg>

--- a/frontend/public/icons/icon-512x512.svg
+++ b/frontend/public/icons/icon-512x512.svg
@@ -1,29 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -3 30 30">
   <defs>
-    <linearGradient id="bottleGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#F8FAFC;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#FFFFFF;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#F1F5F9;stop-opacity:1" />
-    </linearGradient>
+    <clipPath id="bc">
+      <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" />
+    </clipPath>
   </defs>
-  <rect width="512" height="512" fill="#4F46E5" />
-  
+  <rect x="-3" y="-3" width="30" height="30" fill="#4F46E5" />
+  <!-- Bottle body background -->
+  <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" fill="white" fill-opacity="0.2" stroke="none" />
+  <!-- Liquid (clipped to bottle) -->
+  <g clip-path="url(#bc)">
+    <path d="M5 15 q 7 2 14 0 V 24 H 5 Z" fill="white" stroke="none" />
+    <path d="M5 15 q 7 2 14 0" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
   <!-- Nipple -->
-  <path d="M256 100c-20 0-35 15-35 35v25h70v-25c0-20-15-35-35-35z" fill="#FBCFE8" />
-  
-  <!-- Cap -->
-  <rect x="196" y="160" width="120" height="30" rx="8" fill="#94A3B8" />
-  
-  <!-- Bottle Body -->
-  <path d="M206 190h100c8 0 15 7 15 15v170c0 25-15 45-40 45H231c-25 0-40-20-40-45V205c0-8 7-15 15-15z" fill="url(#bottleGradient)" />
-  
-  <!-- Milk level -->
-  <path d="M191 280h130v80c0 25-15 45-40 45H231c-25 0-40-20-40-45V280z" fill="#FEF9C3" opacity="0.9" />
-  
-  <!-- Scale Lines -->
-  <rect x="275" y="225" width="20" height="5" rx="2" fill="#CBD5E1" />
-  <rect x="275" y="255" width="20" height="5" rx="2" fill="#CBD5E1" />
-  <rect x="275" y="285" width="20" height="5" rx="2" fill="#94A3B8" />
-  <rect x="275" y="315" width="20" height="5" rx="2" fill="#94A3B8" />
-  <rect x="275" y="345" width="20" height="5" rx="2" fill="#94A3B8" />
+  <path d="M10 5V4a2 2 0 0 1 4 0v1" fill="white" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <!-- Collar -->
+  <rect x="7" y="5" width="10" height="2" rx="1" fill="white" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <!-- Bottle body outline -->
+  <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <!-- Measurement lines -->
+  <path d="M14 11h-2" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
+  <path d="M14 14h-2" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
+  <path d="M14 17h-2" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
 </svg>

--- a/frontend/public/icons/maskable-icon.svg
+++ b/frontend/public/icons/maskable-icon.svg
@@ -1,29 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <rect width="512" height="512" fill="#4F46E5" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-6 -6 36 36">
   <defs>
-    <linearGradient id="bottleGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#F8FAFC;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#FFFFFF;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#F1F5F9;stop-opacity:1" />
-    </linearGradient>
+    <clipPath id="bc">
+      <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" />
+    </clipPath>
   </defs>
-  
+  <rect x="-6" y="-6" width="36" height="36" fill="#4F46E5" />
+  <!-- Bottle body background -->
+  <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" fill="white" fill-opacity="0.2" stroke="none" />
+  <!-- Liquid (clipped to bottle) -->
+  <g clip-path="url(#bc)">
+    <path d="M5 15 q 7 2 14 0 V 24 H 5 Z" fill="white" stroke="none" />
+    <path d="M5 15 q 7 2 14 0" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
   <!-- Nipple -->
-  <path d="M256 100c-20 0-35 15-35 35v25h70v-25c0-20-15-35-35-35z" fill="#FBCFE8" />
-  
-  <!-- Cap -->
-  <rect x="196" y="160" width="120" height="30" rx="8" fill="#94A3B8" />
-  
-  <!-- Bottle Body -->
-  <path d="M206 190h100c8 0 15 7 15 15v170c0 25-15 45-40 45H231c-25 0-40-20-40-45V205c0-8 7-15 15-15z" fill="url(#bottleGradient)" />
-  
-  <!-- Milk level -->
-  <path d="M191 280h130v80c0 25-15 45-40 45H231c-25 0-40-20-40-45V280z" fill="#FEF9C3" opacity="0.9" />
-  
-  <!-- Scale Lines -->
-  <rect x="275" y="225" width="20" height="5" rx="2" fill="#CBD5E1" />
-  <rect x="275" y="255" width="20" height="5" rx="2" fill="#CBD5E1" />
-  <rect x="275" y="285" width="20" height="5" rx="2" fill="#94A3B8" />
-  <rect x="275" y="315" width="20" height="5" rx="2" fill="#94A3B8" />
-  <rect x="275" y="345" width="20" height="5" rx="2" fill="#94A3B8" />
+  <path d="M10 5V4a2 2 0 0 1 4 0v1" fill="white" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <!-- Collar -->
+  <rect x="7" y="5" width="10" height="2" rx="1" fill="white" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <!-- Bottle body outline -->
+  <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <!-- Measurement lines -->
+  <path d="M14 11h-2" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
+  <path d="M14 14h-2" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
+  <path d="M14 17h-2" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
 </svg>


### PR DESCRIPTION
## 概要

PWAアイコン（192x192・512x512・maskable）を、起動時スプラッシュ画面の `BabyBottleLoading` コンポーネントと同じデザインに統一。

## 変更内容

- `public/icons/icon-192x192.svg` — インディゴ背景（#4F46E5）＋白の哺乳瓶アイコン
- `public/icons/icon-512x512.svg` — 同上
- `public/icons/maskable-icon.svg` — 同上（セーフゾーン確保のため余白を拡大：viewBox `-6 -6 36 36`）

## Before / After

| 変更前 | 変更後 |
|---|---|
| フルカラー哺乳瓶（ピンク乳首・黄色ミルク） | インディゴ背景＋白ボトル（BabyBottleLoading と統一） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)