### PR TITLE
feat: Google AdSense 自動広告を追加

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Toaster } from "sonner";
 import { ThemeProvider } from "@/components/theme-provider";
 import { SplashScreen } from "@/components/ui/splash-screen";
+import Script from "next/script";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -60,6 +61,14 @@ export default function RootLayout({
           {children}
           <Toaster />
         </ThemeProvider>
+        {process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID && (
+          <Script
+            async
+            src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID}`}
+            crossOrigin="anonymous"
+            strategy="afterInteractive"
+          />
+        )}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- `layout.tsx` に Google AdSense 自動広告スクリプトを追加
- `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID` が設定されている場合のみスクリプトが読み込まれる（未設定時は広告なし）
- 審査通過後、Google が自動的に最適な位置に広告を表示する

## 環境変数（Render に設定が必要）

| 変数名 | 値 |
|--------|-----|
| `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID` | `ca-pub-3835661109883673` |

## 補足

- AdSense の審査通過後にスロットIDが取得できたら、5件ごとのインフィード広告（手動）に切り替える予定
- 仕様書: `.specify/specs/ui/google_adsense.md`

## Test plan

- [ ] ローカルで `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID` を設定してビルドが通ることを確認
- [ ] AdSense 審査通過後、広告が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)