### PR TITLE
feat: AIモデルをGemini 3 Proにアップグレード

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,9 @@ TEST_USER_PASSWORD=password123
 LLM_PROVIDER=google
 # LLM_API_KEY: OpenAI の場合は "sk-..."、Google の場合は "AIza..."
 LLM_API_KEY=
-# LLM_MODEL: 未設定時は provider に応じて自動選択（gpt-4o-mini / gemini-2.0-flash）
-LLM_MODEL=gemini-2.0-flash
+# LLM_MODEL: 未設定時は provider に応じて自動選択（gpt-4o-mini / gemini-3-flash）
+# 高品質な生成を希望する場合（Google AI Studio 有料枠など）は gemini-3-pro を推奨
+LLM_MODEL=gemini-3-pro
 
 # Security
 ALLOWED_HOSTS=*

--- a/.specify/specs/ai/ai_chatbot.md
+++ b/.specify/specs/ai/ai_chatbot.md
@@ -3,7 +3,7 @@
 ## 概要
 
 過去の育児記録をコンテキスト（RAG）として活用し、育児に関するパーソナライズされた相談ができるチャットボット機能。
-直近 7 日分の記録サマリーをシステムプロンプトに埋め込み、OpenAI GPT-4o mini が回答を生成する。
+直近 7 日分の記録サマリーをシステムプロンプトに埋め込み、高品質な LLM（Gemini 3 Pro）が回答を生成する。
 チャット履歴はセッション単位で DB に保存し、後から参照できる。
 
 ---
@@ -14,6 +14,11 @@
 - AI は医療行為を行わない。免責事項をシステムプロンプトとフロントエンドUIに明記する。
 - 会話の文脈を保つため、直近 5 件のメッセージ履歴を LLM に渡す。
 - セッションは赤ちゃん単位で管理し、複数のトピックを分けて会話できる。
+- **モデル選択の方針 (2026年2月更新)**: 
+    - Google AI Studio (Gemini) を優先プロバイダーとする。
+    - 予算（月額1,500円程度）の範囲内で、高品質な相談が可能な **Gemini 3 Pro** をデフォルトのメインモデルとする。
+    - 速度やコスト効率を重視する場合、またはバックアップとして **Gemini 3 Flash** を活用する。
+    - 入力トークンコストが低いため、過去数日間のコンテキストを含めた高品質な分析が可能。
 
 ---
 
@@ -93,7 +98,7 @@ alembic upgrade head
 | `app/models/chatbot.py` | **新規作成** | `ChatSession`, `ChatMessage` モデル |
 | `app/schemas/chatbot.py` | **新規作成** | Pydantic スキーマ |
 | `app/routers/chatbot.py` | **新規作成** | チャット API エンドポイント |
-| `app/services/chatbot.py` | **新規作成** | RAGコンテキスト生成・OpenAI 呼び出しロジック |
+| `app/services/chatbot.py` | **新規作成** | RAGコンテキスト生成・AI API 呼び出しロジック |
 | `app/models/__init__.py` | **変更** | `ChatSession`, `ChatMessage` をインポートに追加 |
 | `app/main.py` | **変更** | `chatbot` router を `include_router` |
 
@@ -183,7 +188,7 @@ class ChatSendResponse(BaseModel):
 3. `ChatSession` を DB に作成。
 4. ユーザーメッセージを `ChatMessage` として保存（`role="user"`）。
 5. RAGコンテキストを生成（後述）。
-6. OpenAI API (`gpt-4o-mini`) に送信（システムプロンプト + 会話履歴 + ユーザーメッセージ）。
+6. Gemini API (`gemini-3-pro`) に送信（システムプロンプト + 会話履歴 + ユーザーメッセージ）。
 7. AI 応答を `ChatMessage` として保存（`role="assistant"`）。
 8. `ChatSendResponse` を返す。
 
@@ -203,7 +208,7 @@ class ChatSendResponse(BaseModel):
 
 **エラーレスポンス**:
 - `400 Bad Request`: `first_message` が空
-- `503 Service Unavailable`: OpenAI API 障害
+- `503 Service Unavailable`: AI API 障害
 
 ---
 
@@ -224,7 +229,7 @@ class ChatSendResponse(BaseModel):
 3. ユーザーメッセージを `ChatMessage` として保存。
 4. 直近 5 件の会話履歴を取得して LLM に渡す。
 5. RAGコンテキストを生成（システムプロンプト再構築）。
-6. OpenAI API を呼び出し。
+6. Gemini API を呼び出し。
 7. AI 応答を `ChatMessage` として保存。
 8. `ChatSession.updated_at` を更新。
 9. `ChatSendResponse` を返す。
@@ -232,7 +237,7 @@ class ChatSendResponse(BaseModel):
 **エラーレスポンス**:
 - `400 Bad Request`: `content` が空
 - `404 Not Found`: `session_id` が存在しない・`baby_id` に属していない
-- `503 Service Unavailable`: OpenAI API 障害
+- `503 Service Unavailable`: AI API 障害
 
 ---
 
@@ -290,9 +295,28 @@ class ChatSendResponse(BaseModel):
 # app/services/chatbot.py
 
 import os
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from sqlalchemy.orm import Session
-from openai import OpenAI, APIError
+from openai import OpenAI
+
+
+def get_llm_client() -> Tuple[OpenAI, str]:
+    """(client, model_name) を返す (ai_summary と共通化を推奨)"""
+    provider = os.environ.get("LLM_PROVIDER", "google").lower()
+    api_key = os.environ.get("LLM_API_KEY")
+    model = os.environ.get("LLM_MODEL")
+
+    if provider == "google":
+        client = OpenAI(
+            api_key=api_key,
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+        )
+        model = model or "gemini-3-pro"
+    else:
+        client = OpenAI(api_key=api_key)
+        model = model or "gpt-4o"
+
+    return client, model
 
 from app.models.feeding import Feeding
 from app.models.sleep import Sleep
@@ -322,9 +346,9 @@ SYSTEM_PROMPT_TEMPLATE = """あなたは育児をサポートする専門的な�
 
 def build_rag_context(db: Session, baby_id: int, baby_name: str, birth_date: str) -> str:
     """直近7日分の記録を集計してRAGコンテキスト文字列を生成する。"""
-    today = date.today()
-    week_ago = datetime.combine(today - timedelta(days=7), datetime.min.time())
-    now = datetime.combine(today, datetime.max.time())
+    JST = timezone(timedelta(hours=9))
+    now = datetime.now(JST)
+    week_ago = now - timedelta(days=7)
 
     # 授乳
     feedings = db.query(Feeding).filter(
@@ -350,15 +374,15 @@ def build_rag_context(db: Session, baby_id: int, baby_name: str, birth_date: str
     # おむつ
     diapers = db.query(Diaper).filter(
         Diaper.baby_id == baby_id,
-        Diaper.diaper_time >= week_ago,
-        Diaper.diaper_time <= now,
+        Diaper.change_time >= week_ago,
+        Diaper.change_time <= now,
     ).all()
     avg_diaper_per_day = round(len(diapers) / 7, 1)
 
     # 成長（最新1件）
     latest_growth = db.query(Growth).filter(
         Growth.baby_id == baby_id,
-    ).order_by(Growth.recorded_at.desc()).first()
+    ).order_by(Growth.date.desc()).first()
 
     lines = [
         f"・授乳: 7日間合計{feeding_count}回（1日平均{avg_feeding_per_day}回）",
@@ -367,10 +391,10 @@ def build_rag_context(db: Session, baby_id: int, baby_name: str, birth_date: str
     ]
     if latest_growth:
         growth_parts = []
-        if latest_growth.weight_kg:
-            growth_parts.append(f"体重 {latest_growth.weight_kg}kg")
-        if latest_growth.height_cm:
-            growth_parts.append(f"身長 {latest_growth.height_cm}cm")
+        if latest_growth.weight:
+            growth_parts.append(f"体重 {latest_growth.weight / 1000:.3f}kg")
+        if latest_growth.height:
+            growth_parts.append(f"身長 {latest_growth.height}cm")
         if growth_parts:
             lines.append(f"・最新成長記録: {'、'.join(growth_parts)}")
 
@@ -410,9 +434,9 @@ def build_messages_for_llm(
     return messages
 
 
-def call_openai_chat(messages: list, model_name: str = "gpt-4o-mini") -> str:
-    """OpenAI API を呼び出してアシスタント応答テキストを返す。失敗時は APIError を raise する。"""
-    client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+def call_llm_chat(messages: list) -> str:
+    """API を呼び出してアシスタント応答テキストを返す。失敗時は例外を raise する。"""
+    client, model_name = get_llm_client()
     try:
         response = client.chat.completions.create(
             model=model_name,
@@ -421,7 +445,7 @@ def call_openai_chat(messages: list, model_name: str = "gpt-4o-mini") -> str:
             temperature=0.7,
         )
         return response.choices[0].message.content.strip()
-    except APIError as e:
+    except Exception as e:
         raise e
 ```
 
@@ -440,7 +464,9 @@ app.include_router(chatbot.router)
 
 | 変数名 | 説明 | 必須 |
 |--------|------|------|
-| `OPENAI_API_KEY` | OpenAI API キー（AI日誌生成と共用） | ✅ |
+| `LLM_API_KEY` | Gemini または OpenAI の API キー | ✅ |
+| `LLM_PROVIDER` | `google` または `openai` | ✅ |
+| `LLM_MODEL` | 使用するモデル名 (gemini-3-pro 等) | |
 
 ---
 
@@ -785,7 +811,7 @@ export function ChatInput({ onSend, disabled }: Props) {
 
 | エラー条件 | バックエンド | フロントエンド |
 |-----------|------------|--------------|
-| OpenAI API 障害 | `503 Service Unavailable` | トースト「AIサービスが一時的に利用できません」+ 入力フォームを再度有効化 |
+| AI API 障害 | `503 Service Unavailable` | トースト「AIサービスが一時的に利用できません」+ 入力フォームを再度有効化 |
 | 空メッセージ送信 | `400 Bad Request` | 送信ボタン disabled（フロント側で事前ガード） |
 | 自分のセッション以外を削除 | `403 Forbidden` | トースト「このセッションは削除できません」 |
 | 存在しないセッション | `404 Not Found` | トースト「セッションが見つかりません」 |
@@ -805,10 +831,10 @@ export function ChatInput({ onSend, disabled }: Props) {
 - [ ] マイグレーション内容確認（2テーブル新規作成のみ）
 - [ ] `alembic upgrade head` でマイグレーション適用
 - [ ] `app/schemas/chatbot.py` 作成（上記スキーマ定義）
-- [ ] `app/services/chatbot.py` 作成
+  - [ ] `app/services/chatbot.py` 作成
   - [ ] `build_rag_context()` 実装（直近7日分の記録集計）
   - [ ] `build_messages_for_llm()` 実装（システムプロンプト + 直近5件履歴）
-  - [ ] `call_openai_chat()` 実装（OpenAI 呼び出し、`APIError` を raise）
+  - [ ] `call_llm_chat()` 実装（AI API 呼び出し、例外を raise）
 - [ ] `app/routers/chatbot.py` 作成
   - [ ] `POST /api/babies/{baby_id}/chat/sessions` 実装
   - [ ] `POST /api/babies/{baby_id}/chat/sessions/{session_id}/messages` 実装
@@ -817,12 +843,11 @@ export function ChatInput({ onSend, disabled }: Props) {
   - [ ] `DELETE /api/babies/{baby_id}/chat/sessions/{session_id}` 実装（作成者 or admin のみ）
   - [ ] 全エンドポイントで `verify_baby_access()` 呼び出しを確認
   - [ ] セッションの `baby_id` 一致チェックを確認
-  - [ ] OpenAI `APIError` を 503 に変換するエラーハンドラを確認
+  - [ ] AI API 例外を 503 に変換するエラーハンドラを確認
 - [ ] `app/main.py` に `chatbot` router を登録
-- [ ] `.env` に `OPENAI_API_KEY` を設定（AI日誌と共用）
+- [ ] `.env` に `LLM_API_KEY` を設定（AI日誌と共用）
 
 ### フロントエンド
-
 - [ ] `frontend/hooks/useChatbot.ts` 作成
   - [ ] `useChatSessions()` SWR フック
   - [ ] `useChatSession()` SWR フック
@@ -857,7 +882,7 @@ export function ChatInput({ onSend, disabled }: Props) {
 ## 参照先ドキュメント
 
 - `.specify/specs/settings/baby_permissions.md` — `verify_baby_access()` の仕様
-- `.specify/specs/ai/ai_daily_summary.md` — AI日誌生成仕様（`OPENAI_API_KEY` 共用）
+- `.specify/specs/ai/ai_daily_summary.md` — AI日誌生成仕様（`LLM_API_KEY` 共用）
 - `.specify/specs/ui/ui_design_system.md` — カラーパレット・コンポーネントデザイン
 - `app/models/feeding.py` — `Feeding` モデル
 - `app/models/sleep.py` — `Sleep` モデル

--- a/.specify/specs/ai/ai_daily_summary.md
+++ b/.specify/specs/ai/ai_daily_summary.md
@@ -2,7 +2,7 @@
 
 ## 概要
 
-1日の育児記録（授乳・睡眠・おむつ・成長）を集計し、OpenAI GPT-4o mini を用いて自然な文体の育児日記（日誌）を自動生成する機能。
+1日の育児記録（授乳・睡眠・おむつ・成長）を集計し、最新の LLM（Gemini 3 Pro 等）を用いて自然な文体の育児日記（日誌）を自動生成する機能。
 生成した日誌はユーザーが手動編集でき、任意の日付の日誌を一覧・閲覧・削除できる。
 
 ---
@@ -13,6 +13,11 @@
 - 手動で日記を書く手間をなくし、記録データから自動的に文章化する。
 - 生成内容はユーザーが自由に編集できる（AI の生成物を確定にしない）。
 - AI API 障害時は HTTP 503 を返し、記録を壊さない。
+- **モデル選択の方針 (2026年2月更新)**: 
+    - Google AI Studio (Gemini) を優先プロバイダーとする。
+    - 予算（月額1,500円程度）の範囲内で、最高品質な生成が可能な **Gemini 3 Pro** をデフォルトのメインモデルとする。
+    - 速度やコスト効率を重視する場合、またはバックアップとして **Gemini 3 Flash** を活用する。
+    - 入力トークンコストが低いため、過去数日間のコンテキストを含めた高品質な分析が可能。
 
 ---
 
@@ -89,7 +94,7 @@ class DailySummary(Base):
 | `app/models/ai_summary.py` | **新規作成** | `DailySummary` モデル |
 | `app/schemas/ai_summary.py` | **新規作成** | Pydantic スキーマ |
 | `app/routers/ai_summary.py` | **新規作成** | AI日誌 API エンドポイント |
-| `app/services/ai_summary.py` | **新規作成** | AI生成ロジック（OpenAI 呼び出し・プロンプト生成） |
+| `app/services/ai_summary.py` | **新規作成** | AI生成ロジック（AI API 呼び出し・プロンプト生成） |
 | `app/models/__init__.py` | **変更** | `DailySummary` をインポートに追加 |
 | `app/main.py` | **変更** | `ai_summary` router を `include_router` |
 
@@ -158,8 +163,8 @@ class DailySummaryResponse(BaseModel):
 2. `summary_date` が未来の日付（JST 基準で今日より後）の場合は `400 Bad Request`（「未来の日付では生成できません」）。
 3. 対象日の全記録を集計（後述のプロンプト生成参照）。
 4. 対象日の記録が 0 件の場合は `400 Bad Request`（「記録がない日は生成できません」）。
-5. OpenAI API (`gpt-4o-mini`) を呼び出して日誌テキストを生成。
-6. OpenAI API 障害時: `503 Service Unavailable`（「AI サービスが一時的に利用できません」）。
+5. Gemini API (`gemini-3-pro`) を呼び出して日誌テキストを生成。
+6. AI API 障害時: `503 Service Unavailable`（「AI サービスが一時的に利用できません」）。
 7. 既存レコードが存在し `is_edited=true` の場合: 再生成しない（`edited_content` を保護）。再生成したい場合はフロントエンドから明示的にフラグ付き再生成を行う（将来の拡張）。
 8. `DailySummary` を upsert して返す。
 
@@ -169,7 +174,7 @@ class DailySummaryResponse(BaseModel):
 
 - `400 Bad Request`: 対象日の記録が 0 件、または未来日付を指定
 - `404 Not Found`: `baby_id` が存在しない・アクセス不可
-- `503 Service Unavailable`: OpenAI API 障害
+- `503 Service Unavailable`: AI API 障害
 
 ---
 
@@ -260,8 +265,8 @@ from app.models.note import Note
 
 def get_llm_client() -> Tuple[OpenAI, str]:
     """(client, model_name) を返す"""
-    provider = os.environ.get("LLM_PROVIDER", "openai").lower()
-    api_key = os.environ.get("LLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    provider = os.environ.get("LLM_PROVIDER", "google").lower()
+    api_key = os.environ.get("LLM_API_KEY")
     model = os.environ.get("LLM_MODEL")
 
     if provider == "google":
@@ -269,10 +274,10 @@ def get_llm_client() -> Tuple[OpenAI, str]:
             api_key=api_key,
             base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
         )
-        model = model or "gemini-2.0-flash"
+        model = model or "gemini-3-pro"
     else:
         client = OpenAI(api_key=api_key)
-        model = model or "gpt-4o-mini"
+        model = model or "gpt-4o"
 
     return client, model
 
@@ -489,7 +494,7 @@ def generate_daily_summary(
 ) -> Tuple[str, str]:
     """(generated_content, model_name) を返す。
     記録が0件の場合は ValueError を raise。
-    API障害時は openai.APIError を伝播。
+    API障害時は例外を伝播。
     """
     prompt, total_records, records_text = build_daily_prompt(db, baby_id, baby_name, target_date)
 
@@ -557,9 +562,11 @@ app.include_router(ai_summary.router)
 
 | 変数名 | 説明 | 必須 |
 |--------|------|------|
-| `OPENAI_API_KEY` | OpenAI API キー | ✅ |
+| `LLM_API_KEY` | Gemini または OpenAI の API キー | ✅ |
+| `LLM_PROVIDER` | `google` または `openai` | ✅ |
+| `LLM_MODEL` | 使用するモデル名 | |
 
-> Gemini への切替方法: `app/services/ai_summary.py` の `generate_daily_summary()` 関数内の client 部分を差し替えるだけで切替可能（インターフェースは変えない）。
+> Gemini への切替方法: `LLM_PROVIDER=google` を設定。デフォルトで `gemini-3-pro` を使用する。
 
 ---
 
@@ -754,7 +761,7 @@ AI日誌の操作は `record_type` 単位の権限制御対象外（`baby` レ�
 |-----------|------------|--------------|
 | 対象日の記録が 0 件 | `400 Bad Request` | トースト「この日の記録がないため生成できません」 |
 | 未来の日付を指定 | `400 Bad Request` | 日付ピッカーの `max` 属性で選択不可 + トースト「未来の日付では生成できません」 |
-| OpenAI API 障害 | `503 Service Unavailable` | トースト「AIサービスが一時的に利用できません。しばらく後に再試行してください」 |
+| AI API 障害 | `503 Service Unavailable` | トースト「AIサービスが一時的に利用できません。しばらく後に再試行してください」 |
 | 既に `is_edited=true` の日誌に再生成 | 再生成をスキップ（既存レコードをそのまま返す） | 確認ダイアログ表示後、「手動編集済みのため再生成されませんでした」メッセージ |
 | 存在しない日誌を取得・編集・削除 | `404 Not Found` | トースト「日誌が見つかりません」 |
 | 未認証 | `401 Unauthorized` | リダイレクト（既存の認証ガード） |
@@ -775,8 +782,8 @@ AI日誌の操作は `record_type` 単位の権限制御対象外（`baby` レ�
 - [x] `app/services/ai_summary.py` 作成
     - [x] `build_daily_prompt()` 実装（Feeding/Sleep/Diaper/Growth 集計）
     - [x] `build_daily_prompt()` 更新: 各記録の `notes` をプロンプトに含めるよう改修
-    - [x] `generate_daily_summary()` 実装（OpenAI 呼び出し）
-    - [x] `APIError` を raise して router 側で 503 に変換する設計を確認
+    - [x] `generate_daily_summary()` 実装（AI API 呼び出し）
+    - [x] API 例外を raise して router 側で 503 に変換する設計を確認
 - [x] `app/routers/ai_summary.py` 作成
     - [x] `POST /api/babies/{baby_id}/daily-summary` 実装（upsert）
     - [x] `GET  /api/babies/{baby_id}/daily-summary` 実装（一覧）
@@ -784,10 +791,10 @@ AI日誌の操作は `record_type` 単位の権限制御対象外（`baby` レ�
     - [x] `PATCH /api/babies/{baby_id}/daily-summary/{summary_date}` 実装
     - [x] `DELETE /api/babies/{baby_id}/daily-summary/{summary_date}` 実装
     - [x] 全エンドポイントで `verify_baby_access()` 呼び出しを確認
-    - [x] OpenAI `APIError` を 503 に変換するエラーハンドラを確認
+    - [x] AI API 例外を 503 に変換するエラーハンドラを確認
 - [x] `app/main.py` に `ai_summary` router を登録
-- [x] `.env` に `OPENAI_API_KEY` を設定（ローカル開発用）
-- [x] Render 環境変数に `OPENAI_API_KEY` を設定（本番用）
+- [x] `.env` に `LLM_API_KEY` を設定（ローカル開発用）
+- [x] Render 環境変数に `LLM_API_KEY` を設定（本番用）
 
 ### フロントエンド
 

--- a/app/services/ai_summary.py
+++ b/app/services/ai_summary.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def get_llm_client() -> Tuple[OpenAI, str]:
     """(client, model_name) を返す"""
-    provider = os.environ.get("LLM_PROVIDER", "openai").lower()
+    provider = os.environ.get("LLM_PROVIDER", "google").lower()
     api_key = os.environ.get("LLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
     model = os.environ.get("LLM_MODEL")
 
@@ -25,10 +25,10 @@ def get_llm_client() -> Tuple[OpenAI, str]:
             api_key=api_key,
             base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
         )
-        model = model or "gemini-2.0-flash"
+        model = model or "gemini-3-pro"
     else:
         client = OpenAI(api_key=api_key)
-        model = model or "gpt-4o-mini"
+        model = model or "gpt-4o"
 
     return client, model
 

--- a/render.yaml
+++ b/render.yaml
@@ -22,7 +22,7 @@ services:
       - key: LLM_API_KEY
         sync: false  # APIキーを Render Dashboard で手動設定
       - key: LLM_MODEL
-        value: "gemini-2.0-flash"  # 未設定時は provider に応じて自動選択（gpt-4o-mini / gemini-2.0-flash）
+        value: "gemini-3-pro"  # 未設定時は provider に応じて自動選択（gpt-4o / gemini-3-pro）
       - key: PYTHON_VERSION
         value: "3.10.12"
       - key: PYTHONUNBUFFERED


### PR DESCRIPTION
AI日誌生成およびチャットボットのモデルをGoogle AI Studioの最新モデル（Gemini 3 Pro）にアップグレードしました。

### 変更内容
- AI日誌生成のデフォルトモデルを `gemini-3-pro` に変更
- デフォルトのAIプロバイダーを `google` に設定
- `.specify/specs/ai/` 配下の仕様書を最新モデルと予算（月間1500円）に合わせて更新
- `render.yaml` および `.env.example` の環境変数設定を更新
- チャットボット仕様のDBフィールド名不整合を修正