### PR TITLE
fix: AIフィードバックのリトライロジックを修正

### DIFF
--- a/app/services/ai_feedback.py
+++ b/app/services/ai_feedback.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Tuple
 
+import openai
 from sqlalchemy.orm import Session
 from fastapi import HTTPException, status
 
@@ -229,8 +230,8 @@ def generate_record_feedback(
                 response_format={"type": "json_object"},
             )
             break
-        except Exception as e:
-            logger.warning("Error on attempt %d: %s", attempt + 1, e)
+        except (openai.RateLimitError, openai.APIConnectionError) as e:
+            logger.warning("Retryable error on attempt %d: %s", attempt + 1, e)
             last_error = e
     else:
         raise last_error


### PR DESCRIPTION
## 概要
AIフィードバック生成時の OpenAI API 呼び出しにおいて、リトライ対象の例外が広すぎた（Exception 全てをキャッチしていた）問題を修正しました。

## 変更内容
- `openai` パッケージをインポート。
- リトライ対象を `openai.RateLimitError` および `openai.APIConnectionError` に限定。
- これにより、認証エラーやモデル名不正などの恒久的な失敗時に、不要なリトライ（最大6秒の遅延）が発生しなくなります。

## 検証結果
- `pytest` によりバックエンドの正常動作を確認。
- `scripts/verify_all.sh` によるビルド・型チェック・Lintをパス。