### PR TITLE
fix: AIフィードバックのJSONパース処理の堅牢化

### DIFF
--- a/app/services/ai_feedback.py
+++ b/app/services/ai_feedback.py
@@ -58,13 +58,26 @@ def _extract_json(text: str) -> str:
     # 1. Markdownコードブロックを探す
     match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
     if match:
-        return match.group(1).strip()
+        text = match.group(1).strip()
+    else:
+        # 2. 最初と最後の { } を探す (コードブロックがない、または閉じフェンス後のテキスト対策)
+        start = text.find("{")
+        if start != -1:
+            end = text.rfind("}")
+            if end != -1 and end > start:
+                text = text[start : end + 1].strip()
+            else:
+                # 閉じ括弧がない場合でも、{ 以降を抽出対象とする（後の修復に期待）
+                text = text[start:].strip()
 
-    # 2. 最初と最後の { } を探す (コードブロックがない、または閉じフェンス後のテキスト対策)
-    start = text.find("{")
-    end = text.rfind("}")
-    if start != -1 and end != -1 and end > start:
-        return text[start : end + 1].strip()
+    # 簡易修復ロジック: 閉じられていない引用符や括弧を補完
+    if text.startswith("{"):
+        # 引用符の数が奇数なら閉じる（エスケープは考慮しない簡易版）
+        if text.count('"') % 2 != 0:
+            text += '"'
+        # 閉じ括弧がなければ閉じる
+        if not text.endswith("}"):
+            text += "}"
 
     return text
 
@@ -245,7 +258,7 @@ def generate_record_feedback(
                     {"role": "system", "content": SYSTEM_PROMPT},
                     {"role": "user", "content": prompt},
                 ],
-                max_tokens=config.get("llm_max_tokens", 300),
+                max_tokens=config.get("llm_max_tokens", 512),
                 temperature=config.get("llm_temperature", 0.5),
                 response_format={"type": "json_object"},
             )
@@ -264,8 +277,14 @@ def generate_record_feedback(
         feedback_text = str(parsed.get("feedback", raw))
         has_concern = bool(parsed.get("has_concern", False))
     except (json.JSONDecodeError, AttributeError):
-        logger.warning("AI response was not valid JSON, using raw text: %s", raw[:100])
-        feedback_text = raw
+        # json.loads が失敗した場合、正規表現で直接 feedback フィールドの抽出を試みる（最後の救済措置）
+        match = re.search(r'"feedback":\s*"(.*?)(?:"|,\s*"|$)', json_str, re.DOTALL)
+        if match:
+            feedback_text = match.group(1).strip()
+            logger.info("Extracted feedback using regex after JSON parse failure.")
+        else:
+            logger.warning("AI response was not valid JSON, using raw text: %s", raw[:100])
+            feedback_text = raw
         has_concern = False
 
     return feedback_text, has_concern, model_name


### PR DESCRIPTION
## 概要
AIフィードバックの応答が `MAX_TOKENS` 制限などにより途中で切れてしまった場合、JSONパースに失敗して生のレスポンス（`{"feedback": "...`）がUIに表示される問題を修正しました。

## 変更内容
- `_extract_json` において、閉じ括弧や引用符が欠落している場合に簡易的に補完するロジックを追加
- `json.loads` が失敗した場合の最終手段として、正規表現による `feedback` フィールドの抽出を追加
- 出力トークン不足を緩和するため、デフォルトの `max_tokens` を 300 から 512 に引き上げ

## 確認内容
- 途中で切れたJSON（`{"feedback": "たくちゃん...`）が正常にパースされ、メッセージのみが表示されることをテストコード (`tests/reproduce_json_parse_issue.py`) で確認
- `sh scripts/verify_all.sh` が全項目パスすることを確認
