### PR TITLE
fix: PWAアイコンの解像度が低い問題を修正

### DIFF
--- a/frontend/public/icons/icon-192x192.svg
+++ b/frontend/public/icons/icon-192x192.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -3 30 30">
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="-3 -3 30 30">
   <defs>
     <clipPath id="bc">
       <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" />

--- a/frontend/public/icons/icon-512x512.svg
+++ b/frontend/public/icons/icon-512x512.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -3 30 30">
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="-3 -3 30 30">
   <defs>
     <clipPath id="bc">
       <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" />

--- a/frontend/public/icons/maskable-icon.svg
+++ b/frontend/public/icons/maskable-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-6 -6 36 36">
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="-6 -6 36 36">
   <defs>
     <clipPath id="bc">
       <path d="M7 8v10a3 3 0 0 0 3 3h4a3 3 0 0 0 3-3V8H7z" />


### PR DESCRIPTION
## 概要
PWAアイコンの解像度が低く表示される問題を修正するため、SVGファイルに `width` と `height` 属性を明示的に追加しました。

## 変更内容
- `frontend/public/icons/icon-192x192.svg`: `width="192" height="192"` を追加
- `frontend/public/icons/icon-512x512.svg`: `width="512" height="512"` を追加
- `frontend/public/icons/maskable-icon.svg`: `width="512" height="512"` を追加

これにより、ブラウザがSVGをレンダリングする際に、意図した解像度でラスタライズされることが期待されます。

Closes #214