### PR TITLE
fix: 認証APIのレスポンスに is_superadmin フラグを追加

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -152,6 +152,7 @@ def join_family(user_in: UserCreate, invite_code: str, response: Response, db: S
         username=new_user.username,
         display_name=new_user.display_name,
         role=UserRole.VIEWER,
+        is_superadmin=new_user.is_superadmin,
         created_at=new_user.created_at
     )
 
@@ -188,6 +189,7 @@ def login(login_request: LoginRequest, response: Response, db: Session = Depends
         username=user.username,
         display_name=user.display_name,
         role=role,
+        is_superadmin=user.is_superadmin,
         created_at=user.created_at
     )
 
@@ -212,5 +214,6 @@ def read_users_me(db: Session = Depends(get_db), current_user: User = Depends(ge
         username=current_user.username,
         display_name=current_user.display_name,
         role=role,
+        is_superadmin=current_user.is_superadmin,
         created_at=current_user.created_at
     )


### PR DESCRIPTION
## 概要
ユーザーを SuperAdmin に設定してもフロントエンドの設定画面に反映されない問題を修正しました。

## 変更内容
- \`app/routers/auth.py\` の以下のエンドポイントで、\`UserResponse\` を生成する際に \`is_superadmin\` フィールドを明示的に渡すように修正
  - \`POST /api/auth/register/join\`
  - \`POST /api/auth/login\`
  - \`GET /api/auth/me\`

これにより、データベース上で \`is_superadmin=True\` に設定されたユーザーがログインまたはリロードした際、フロントエンドが正しく管理権限を認識できるようになります。