### PR TITLE
feat: 通知クリック時と一括既読時のローディング表示を追加

### DIFF
--- a/frontend/components/notifications/NotificationBell.tsx
+++ b/frontend/components/notifications/NotificationBell.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useState, useRef, useEffect } from "react"
-import { Bell } from "lucide-react"
+import { Bell, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useUnreadCount, useNotifications, markAllAsRead } from "@/hooks/useNotifications"
@@ -8,6 +8,7 @@ import { NotificationItem } from "./NotificationItem"
 
 export function NotificationBell() {
     const [open, setOpen] = useState(false)
+    const [isMarkingAllAsRead, setIsMarkingAllAsRead] = useState(false)
     const { count, mutate: mutateCount } = useUnreadCount()
     const { notifications, mutate: mutateList, isLoading } = useNotifications()
     const panelRef = useRef<HTMLDivElement>(null)
@@ -37,9 +38,14 @@ export function NotificationBell() {
     }
 
     const handleReadAll = async () => {
-        await markAllAsRead()
-        mutateList()
-        mutateCount()
+        if (isMarkingAllAsRead) return
+        setIsMarkingAllAsRead(true)
+        try {
+            await markAllAsRead()
+            await Promise.all([mutateList(), mutateCount()])
+        } finally {
+            setIsMarkingAllAsRead(false)
+        }
     }
 
     const displayCount = count > 99 ? "99+" : count > 0 ? String(count) : null
@@ -72,8 +78,13 @@ export function NotificationBell() {
                         {count > 0 && (
                             <button
                                 onClick={handleReadAll}
-                                className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+                                disabled={isMarkingAllAsRead}
+                                className={cn(
+                                    "text-xs text-indigo-600 dark:text-indigo-400 hover:underline flex items-center gap-1",
+                                    isMarkingAllAsRead && "opacity-70 cursor-wait"
+                                )}
                             >
+                                {isMarkingAllAsRead && <Loader2 className="h-3 w-3 animate-spin" />}
                                 すべて既読にする
                             </button>
                         )}

--- a/frontend/components/notifications/NotificationItem.tsx
+++ b/frontend/components/notifications/NotificationItem.tsx
@@ -1,6 +1,7 @@
 "use client"
+import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { Baby, MessageCircle, Sparkles, Bell, Clock } from "lucide-react"
+import { Baby, MessageCircle, Sparkles, Bell, Clock, Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { AppNotification } from "@/hooks/useNotifications"
 import { markAsRead } from "@/hooks/useNotifications"
@@ -33,28 +34,47 @@ type Props = {
 
 export function NotificationItem({ notification, onRead }: Props) {
     const router = useRouter()
+    const [isProcessing, setIsProcessing] = useState(false)
 
     const handleClick = async () => {
-        if (!notification.is_read) {
-            await markAsRead(notification.id)
-            onRead()
-        }
-        if (notification.url) {
-            router.push(notification.url)
+        if (isProcessing) return
+
+        setIsProcessing(true)
+        try {
+            if (!notification.is_read) {
+                await markAsRead(notification.id)
+                onRead()
+            }
+            if (notification.url) {
+                router.push(notification.url)
+                // NOTE: router.push does not return a promise. 
+                // We keep isProcessing=true to show loading until the page unmounts or navigates.
+            } else {
+                setIsProcessing(false)
+            }
+        } catch (error) {
+            console.error("Failed to process notification click:", error)
+            setIsProcessing(false)
         }
     }
 
     return (
         <button
             onClick={handleClick}
+            disabled={isProcessing}
             className={cn(
                 "w-full flex items-start gap-3 px-4 py-3 text-left transition-colors",
                 "hover:bg-gray-50 dark:hover:bg-zinc-800",
-                !notification.is_read && "bg-indigo-50/60 dark:bg-indigo-950/30"
+                !notification.is_read && "bg-indigo-50/60 dark:bg-indigo-950/30",
+                isProcessing && "opacity-70 cursor-wait"
             )}
         >
             <div className="mt-0.5 shrink-0 flex h-8 w-8 items-center justify-center rounded-full bg-white dark:bg-zinc-800 shadow-sm">
-                {TYPE_ICON[notification.type]}
+                {isProcessing ? (
+                    <Loader2 className="h-4 w-4 animate-spin text-indigo-500" />
+                ) : (
+                    TYPE_ICON[notification.type]
+                )}
             </div>
             <div className="flex-1 min-w-0">
                 <p className={cn(

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,14 +1,9 @@
 ## 概要
-AIフィードバックおよび育児日誌生成において、Gemini 2.0 Thinking などの思考プロセスを出力するモデルを使用した場合に、回答が `max_tokens` 制限に達して途中で途切れてしまう（finishReason: "MAX_TOKENS"）問題を修正しました。
+通知センターの UX 改善として、通知クリック時および「すべて既読にする」ボタン押下時にローディングインジケーター（Loader2）を表示するようにしました。
 
-## 変更内容
-- `app/services/ai_feedback.py`: `max_tokens` のデフォルト値を 512 から 2048 に引き上げ。
-- `app/services/ai_summary.py`: 育児日誌生成の `max_tokens` を 600 から 2048 に、特徴更新を 400 から 1024 に引き上げ。
-- データベースマイグレーションを追加し、`system_settings` テーブルの `llm_max_tokens` 設定を 800 から 2048 に更新。
-- 各所の `max_tokens` および `temperature` 設定において、DBから取得した値を安全に数値型（int/float）へキャストするように修正。
+## 変更点
+- `NotificationItem.tsx`: 通知クリック時に `isProcessing` ステートを導入し、APIリクエストおよびページ遷移中にボタンを無効化・スピナーを表示。
+- `NotificationBell.tsx`: 「すべて既読にする」ボタン押下時に `isMarkingAllAsRead` ステートを導入し、処理中にボタンを無効化・スピナーを表示。
 
-## 確認事項
-- [x] `sh scripts/verify_all.sh` が正常にパスすること。
-- [x] マイグレーションファイルが正しく生成・実行可能であること。
-
-Closes #226
+## 目的
+非同期処理中にユーザーが操作不能であることを視覚的に示し、フリーズしているような誤解を防ぐため。


### PR DESCRIPTION
## 概要
通知センターの UX 改善として、通知クリック時および「すべて既読にする」ボタン押下時にローディングインジケーター（Loader2）を表示するようにしました。

## 変更点
- `NotificationItem.tsx`: 通知クリック時に `isProcessing` ステートを導入し、APIリクエストおよびページ遷移中にボタンを無効化・スピナーを表示。
- `NotificationBell.tsx`: 「すべて既読にする」ボタン押下時に `isMarkingAllAsRead` ステートを導入し、処理中にボタンを無効化・スピナーを表示。

## 目的
非同期処理中にユーザーが操作不能であることを視覚的に示し、フリーズしているような誤解を防ぐため。
