### PR TITLE
fix: SuperAdminがAI設定や赤ちゃん管理画面にアクセスできない問題を修正

### DIFF
--- a/app/routers/ai_settings.py
+++ b/app/routers/ai_settings.py
@@ -14,8 +14,11 @@ router = APIRouter(prefix="/api/ai", tags=["ai-settings"])
 
 def verify_admin_access(db: Session, user: User):
     """
-    ユーザーがいずれかの家族の admin ロールを持っているか検証する。
+    ユーザーが SuperAdmin であるか、いずれかの家族の admin ロールを持っているか検証する。
     """
+    if user.is_superadmin:
+        return True
+
     admin_user = db.query(FamilyUser).filter(
         FamilyUser.user_id == user.id,
         FamilyUser.role == UserRole.ADMIN

--- a/frontend/app/(dashboard)/settings/ai/page.tsx
+++ b/frontend/app/(dashboard)/settings/ai/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useAISettings, updateAISettings } from "@/hooks/useAISettings"
 import { usePermissions } from "@/hooks/usePermissions"
+import { useUser } from "@/hooks/useAuth"
 import { SettingsHeader } from "@/components/settings/SettingsHeader"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -15,6 +16,7 @@ import { toast } from "sonner"
 
 export default function AISettingsPage() {
   const router = useRouter()
+  const { user, isLoading: isUserLoading } = useUser()
   const { data, isLoading, isError, mutate } = useAISettings()
   const { isAdmin, isLoading: isPermsLoading } = usePermissions()
   
@@ -35,13 +37,13 @@ export default function AISettingsPage() {
 
   // 権限チェック
   useEffect(() => {
-    if (!isPermsLoading && !isAdmin) {
+    if (!isPermsLoading && !isUserLoading && !isAdmin && !user?.is_superadmin) {
       toast.error("管理者権限が必要です")
       router.push("/settings")
     }
-  }, [isAdmin, isPermsLoading, router])
+  }, [isAdmin, isPermsLoading, isUserLoading, user, router])
 
-  if (isLoading || isPermsLoading) {
+  if (isLoading || isPermsLoading || isUserLoading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <Loader2 className="w-8 h-8 animate-spin text-violet-500" />
@@ -49,7 +51,7 @@ export default function AISettingsPage() {
     )
   }
 
-  if (isError || !isAdmin) return null
+  if (isError || (!isAdmin && !user?.is_superadmin)) return null
 
   const handleChange = (key: string, value: string) => {
     setFormData((prev) => ({ ...prev, [key]: value }))

--- a/frontend/app/(dashboard)/settings/babies/page.tsx
+++ b/frontend/app/(dashboard)/settings/babies/page.tsx
@@ -25,10 +25,10 @@ export default function BabySettingsPage() {
 
     // 管理者以外はリダイレクト (正確な判定に基づいた修正済みの usePermissions を使用)
     useEffect(() => {
-        if (!permsLoading && !isAdmin) {
+        if (!permsLoading && !isAdmin && !user?.is_superadmin) {
             router.push("/dashboard")
         }
-    }, [permsLoading, isAdmin, router])
+    }, [permsLoading, isAdmin, user, router])
 
     if (permsLoading || babiesLoading) {
         return (
@@ -38,13 +38,15 @@ export default function BabySettingsPage() {
         )
     }
 
-    if (!user || !isAdmin) return null
+    const canManage = isAdmin || user?.is_superadmin
+
+    if (!user || !canManage) return null
 
     return (
         <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 transition-colors">
             {/* sticky header */}
             <SettingsHeader title="赤ちゃん管理">
-                {isAdmin && (
+                {canManage && (
                     <Button
                         size="sm"
                         onClick={() => setAddOpen(true)}
@@ -60,7 +62,7 @@ export default function BabySettingsPage() {
                 {!babies || babies.length === 0 ? (
                     <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-8 text-center transition-colors">
                         <p className="text-gray-400 dark:text-zinc-500 text-sm mb-4">👶 まだ赤ちゃんが登録されていません</p>
-                        {isAdmin && (
+                        {canManage && (
                             <Button
                                 onClick={() => setAddOpen(true)}
                                 className="bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white"
@@ -75,7 +77,7 @@ export default function BabySettingsPage() {
                         <BabyCard
                             key={baby.id}
                             baby={baby}
-                            isAdmin={isAdmin}
+                            isAdmin={Boolean(canManage)}
                             onEdit={setEditTarget}
                             onDelete={setDeleteTarget}
                         />

--- a/frontend/app/(dashboard)/settings/page.tsx
+++ b/frontend/app/(dashboard)/settings/page.tsx
@@ -106,7 +106,7 @@ export default function SettingsPage() {
     }
 
     const visibleItems = menuItems.filter(
-        (item) => !item.adminOnly || isAdmin
+        (item) => !item.adminOnly || isAdmin || user?.is_superadmin
     )
 
     return (
@@ -116,6 +116,24 @@ export default function SettingsPage() {
             </header>
 
             <div className="max-w-2xl mx-auto p-4 space-y-3 pb-20">
+                {user?.is_superadmin && (
+                    <section className="space-y-3">
+                        <h2 className="text-xs font-semibold text-gray-500 dark:text-zinc-500 uppercase tracking-wider ml-1 mb-1">システム管理</h2>
+                        <Link href="/admin">
+                            <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 flex items-center gap-4 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer border-l-4 border-l-indigo-500">
+                                <div className="p-2 rounded-xl bg-indigo-50 dark:bg-indigo-950/30">
+                                    <ShieldCheck className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+                                </div>
+                                <div className="flex-1">
+                                    <p className="font-semibold text-gray-900 dark:text-zinc-100 text-sm">管理者ダッシュボード</p>
+                                    <p className="text-xs text-gray-500 dark:text-zinc-400 mt-0.5">システム全体の管理・監視</p>
+                                </div>
+                                <ChevronRight className="h-4 w-4 text-gray-400 dark:text-zinc-600" />
+                            </div>
+                        </Link>
+                    </section>
+                )}
+
                 <section className="space-y-3">
                     <h2 className="text-xs font-semibold text-gray-500 dark:text-zinc-500 uppercase tracking-wider ml-1 mb-1">一般</h2>
                     <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 flex items-center gap-4 transition-colors">

--- a/frontend/app/(dashboard)/settings/permissions/page.tsx
+++ b/frontend/app/(dashboard)/settings/permissions/page.tsx
@@ -11,18 +11,20 @@ import { useUser } from "@/hooks/useAuth"
 
 export default function PermissionsPage() {
   const { isAdmin } = usePermissions()
-  const { isLoading: userLoading } = useUser()
+  const { user, isLoading: userLoading } = useUser()
   const router = useRouter()
   const { memberPermissions, isLoading, mutate } = usePermissionsPage()
 
+  const canManage = isAdmin || user?.is_superadmin
+
   // 管理者以外はリダイレクト
   useEffect(() => {
-    if (!userLoading && !isAdmin) {
+    if (!userLoading && !canManage) {
       router.push("/dashboard")
     }
-  }, [userLoading, isAdmin, router])
+  }, [userLoading, canManage, router])
 
-  if (userLoading || isLoading || !isAdmin) {
+  if (userLoading || isLoading || !canManage) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <Loader2 className="h-8 w-8 animate-spin text-gray-300" />

--- a/tests/test_ai_settings_access.py
+++ b/tests/test_ai_settings_access.py
@@ -1,0 +1,80 @@
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from app.models.user import User
+from app.models.family import Family, FamilyUser, UserRole
+from app.services.auth import get_password_hash
+
+def test_superadmin_access_ai_settings(client: TestClient, db: Session):
+    # 1. Create a SuperAdmin user who is NOT a family admin (or not in a family at all, or just a viewer)
+    # Let's make them a Viewer in a family to be safe, but SuperAdmin = True
+    
+    # Family
+    family = Family(name="Test Family", invite_code="TESTCODE")
+    db.add(family)
+    db.commit()
+    
+    # SuperAdmin User
+    superadmin = User(
+        username="superadmin_test",
+        hashed_password=get_password_hash("password123"),
+        is_superadmin=True
+    )
+    db.add(superadmin)
+    db.commit()
+    
+    # Add as VIEWER (not ADMIN)
+    family_user = FamilyUser(family_id=family.id, user_id=superadmin.id, role=UserRole.VIEWER)
+    db.add(family_user)
+    db.commit()
+    
+    # Login
+    response = client.post(
+        "/api/auth/login",
+        json={"username": "superadmin_test", "password": "password123"}
+    )
+    assert response.status_code == 200
+    
+    # 2. Try to access AI settings
+    response = client.get("/api/ai/settings")
+    
+    # Before fix, this would be 403. After fix, it should be 200.
+    assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert "settings" in data
+    assert "available_models" in data
+
+def test_superadmin_update_ai_settings(client: TestClient, db: Session):
+    # Reuse setup or similar logic
+    family = Family(name="Test Family 2", invite_code="TESTCODE2")
+    db.add(family)
+    db.commit()
+    
+    superadmin = User(
+        username="superadmin_update",
+        hashed_password=get_password_hash("password123"),
+        is_superadmin=True
+    )
+    db.add(superadmin)
+    db.commit()
+    
+    family_user = FamilyUser(family_id=family.id, user_id=superadmin.id, role=UserRole.VIEWER)
+    db.add(family_user)
+    db.commit()
+    
+    client.post(
+        "/api/auth/login",
+        json={"username": "superadmin_update", "password": "password123"}
+    )
+    
+    # Update settings
+    payload = {
+        "settings": {
+            "llm_temperature": "0.5"
+        }
+    }
+    response = client.patch("/api/ai/settings", json=payload)
+    assert response.status_code == 200
+    assert response.json()["message"].startswith("Updated")
+


### PR DESCRIPTION
## 概要
SuperAdmin ユーザーが設定画面で「AI設定」「赤ちゃん管理」「権限管理」などの項目にアクセスできない問題を修正しました。
また、SuperAdmin 用に「管理者ダッシュボード」へのリンクを追加しました。

## 変更点
- **Backend:** `app/routers/ai_settings.py` で `verify_admin_access` を修正し、SuperAdmin 権限を持つユーザーを許可するように変更。
- **Frontend:**
  - `frontend/app/(dashboard)/settings/page.tsx`: SuperAdmin に管理者メニューを表示し、`/admin` へのリンクを追加。
  - `frontend/app/(dashboard)/settings/ai/page.tsx`: SuperAdmin のアクセスを許可。
  - `frontend/app/(dashboard)/settings/babies/page.tsx`: SuperAdmin のアクセスを許可。
  - `frontend/app/(dashboard)/settings/permissions/page.tsx`: SuperAdmin のアクセスを許可。
- **Tests:** `tests/test_ai_settings_access.py` を追加し、SuperAdmin が AI 設定にアクセスできることを確認。

## 関連 Issue
- (なし)

## 動作確認
- 新規テストケース `tests/test_ai_settings_access.py` がパスすることを確認。
- `scripts/verify_all.sh` による全チェックがパスすることを確認。
