### PR TITLE
fix: SuperAdminがバックエンドAPI操作時に403エラーになる問題を修正

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from app.database import SessionLocal
 from app.models.baby import Baby, BabyPermission
 from app.models.family import FamilyUser, UserRole
+from app.models.user import User, UserSession
 from app.config import SESSION_EXPIRE_DAYS, COOKIE_SECURE
 
 
@@ -20,8 +21,6 @@ db_dependency = Annotated[Session, Depends(get_db)]
 
 
 def get_current_user(request: Request, response: Response, db: db_dependency):
-    from app.models.user import User, UserSession
-
     token = request.cookies.get("access_token")
     if not token:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
@@ -80,26 +79,34 @@ def verify_baby_access(
     require_write=True の場合、viewer ロールを拒否する。
     失敗時 403 を raise。
     """
+    user = db.query(User).filter(User.id == user_id).first()
+    is_superadmin = user and user.is_superadmin
+
     family_user = db.query(FamilyUser).filter(FamilyUser.user_id == user_id).first()
-    if not family_user:
+    
+    if not family_user and not is_superadmin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not in a family")
 
     # 書き込み制限のチェック
-    if require_write and family_user.role == UserRole.VIEWER:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Read-only users cannot perform this action"
-        )
+    if require_write:
+        can_write = (family_user and family_user.role != UserRole.VIEWER) or is_superadmin
+        if not can_write:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Read-only users cannot perform this action"
+            )
 
-    baby = db.query(Baby).filter(
-        Baby.id == baby_id,
-        Baby.family_id == family_user.family_id,
-    ).first()
+    baby_query = db.query(Baby).filter(Baby.id == baby_id)
+    if not is_superadmin:
+        # 通常ユーザーは自身のファミリーの赤ちゃんのみ閲覧可能
+        baby_query = baby_query.filter(Baby.family_id == family_user.family_id)
+        
+    baby = baby_query.first()
     if not baby:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied to this baby")
 
-    # admin は常に許可
-    if family_user.role == UserRole.ADMIN:
+    # admin / superadmin は常に許可
+    if is_superadmin or (family_user and family_user.role == UserRole.ADMIN):
         return baby
 
     # "baby" レベルの可視性チェック（デフォルト拒否）
@@ -132,11 +139,15 @@ def verify_write_access(db: Session, user_id: int) -> FamilyUser:
     ユーザーが書き込み権限（admin または member）を持っているか検証する。
     viewer の場合は 403 を raise。
     """
+    user = db.query(User).filter(User.id == user_id).first()
+    is_superadmin = user and user.is_superadmin
+
     family_user = db.query(FamilyUser).filter(FamilyUser.user_id == user_id).first()
-    if not family_user:
+    if not family_user and not is_superadmin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not in a family")
 
-    if family_user.role == UserRole.VIEWER:
+    can_write = (family_user and family_user.role != UserRole.VIEWER) or is_superadmin
+    if not can_write:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Read-only users cannot perform this action"

--- a/app/routers/baby.py
+++ b/app/routers/baby.py
@@ -49,8 +49,8 @@ def get_babies(db: Session = Depends(get_db), current_user: User = Depends(get_c
 
     babies = db.query(Baby).filter(Baby.family_id == family_user.family_id).all()
 
-    # admin は全件返す
-    if family_user.role == UserRole.ADMIN:
+    # admin / superadmin は全件返す
+    if family_user.role == UserRole.ADMIN or current_user.is_superadmin:
         return babies
 
     # member/viewer: can_view=true の BabyPermission が存在する赤ちゃんのみ返す（デフォルト拒否）
@@ -69,7 +69,7 @@ def create_baby(baby_in: BabyCreate, db: Session = Depends(get_db), current_user
     family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
     if not family_user:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not in a family")
-    if family_user.role != UserRole.ADMIN:
+    if family_user.role != UserRole.ADMIN and not current_user.is_superadmin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only admins can add babies")
 
     new_baby = Baby(
@@ -91,7 +91,7 @@ def update_baby(baby_id: int, baby_in: BabyUpdate, db: Session = Depends(get_db)
     family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
     if not family_user:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not in a family")
-    if family_user.role != UserRole.ADMIN:
+    if family_user.role != UserRole.ADMIN and not current_user.is_superadmin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only admins can edit babies")
 
     baby = db.query(Baby).filter(Baby.id == baby_id, Baby.family_id == family_user.family_id).first()
@@ -109,7 +109,7 @@ def delete_baby(baby_id: int, db: Session = Depends(get_db), current_user: User 
     family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
     if not family_user:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not in a family")
-    if family_user.role != UserRole.ADMIN:
+    if family_user.role != UserRole.ADMIN and not current_user.is_superadmin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only admins can delete babies")
 
     baby = db.query(Baby).filter(Baby.id == baby_id, Baby.family_id == family_user.family_id).first()

--- a/app/routers/baby_permissions.py
+++ b/app/routers/baby_permissions.py
@@ -26,14 +26,22 @@ def get_baby_permissions(
     # 1. verify_baby_access() でアクセス検証（admin ロール確認を追加）
     verify_baby_access(db, baby_id, current_user.id)
     family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
-    if family_user.role != UserRole.ADMIN:
+    
+    is_superadmin = current_user.is_superadmin
+    if (not family_user or family_user.role != UserRole.ADMIN) and not is_superadmin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only admins can manage permissions")
 
     baby = db.query(Baby).filter(Baby.id == baby_id).first()
     
+    # SuperAdmin who is not in the family needs to fetch family_id from baby
+    family_id = baby.family_id
+    
     # 2. 同一ファミリーの member/viewer ロールユーザー全員を FamilyUser から取得（自身 = admin は除外）
+    # SuperAdmin の場合は、自身を含めるかどうか？ 通常は「管理対象」を表示する。
+    # 既存ロジックは "family_user.family_id" を使っている。
+    
     members = db.query(FamilyUser, User).join(User, FamilyUser.user_id == User.id).filter(
-        FamilyUser.family_id == family_user.family_id,
+        FamilyUser.family_id == family_id,
         FamilyUser.role.in_([UserRole.MEMBER, UserRole.VIEWER])
     ).all()
 
@@ -87,8 +95,13 @@ def update_baby_permissions(
     # 1. verify_baby_access() でアクセス検証（admin ロール確認を追加）
     verify_baby_access(db, baby_id, current_user.id)
     family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
-    if family_user.role != UserRole.ADMIN:
+    
+    is_superadmin = current_user.is_superadmin
+    if (not family_user or family_user.role != UserRole.ADMIN) and not is_superadmin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only admins can manage permissions")
+
+    baby = db.query(Baby).filter(Baby.id == baby_id).first()
+    family_id = baby.family_id
 
     # 2. リクエストの各エントリについて検証
     valid_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "note"]
@@ -99,7 +112,7 @@ def update_baby_permissions(
         # 3. user_id が同一ファミリーの member/viewer ロールであることを確認
         target_member = db.query(FamilyUser).filter(
             FamilyUser.user_id == entry.user_id,
-            FamilyUser.family_id == family_user.family_id,
+            FamilyUser.family_id == family_id,
             FamilyUser.role.in_([UserRole.MEMBER, UserRole.VIEWER])
         ).first()
         if not target_member:

--- a/app/routers/family.py
+++ b/app/routers/family.py
@@ -26,8 +26,8 @@ def _get_family_user(db: Session, current_user: User) -> FamilyUser:
     return family_user
 
 
-def _require_admin(family_user: FamilyUser) -> None:
-    if family_user.role != UserRole.ADMIN:
+def _require_admin(family_user: FamilyUser, current_user: User) -> None:
+    if family_user.role != UserRole.ADMIN and not current_user.is_superadmin:
         raise HTTPException(status_code=403, detail="Admin role required")
 
 
@@ -47,7 +47,7 @@ def update_family(
     current_user: User = Depends(get_current_user),
 ):
     family_user = _get_family_user(db, current_user)
-    _require_admin(family_user)
+    _require_admin(family_user, current_user)
     if not body.name.strip():
         raise HTTPException(status_code=422, detail="Family name cannot be empty")
     family = db.query(Family).filter(Family.id == family_user.family_id).first()
@@ -63,7 +63,7 @@ def regenerate_invite_code(
     current_user: User = Depends(get_current_user),
 ):
     family_user = _get_family_user(db, current_user)
-    _require_admin(family_user)
+    _require_admin(family_user, current_user)
     family = db.query(Family).filter(Family.id == family_user.family_id).first()
     new_code = secrets.token_hex(8).upper()
     while db.query(Family).filter(Family.invite_code == new_code).first():
@@ -108,7 +108,7 @@ def update_member_role(
     current_user: User = Depends(get_current_user),
 ):
     family_user = _get_family_user(db, current_user)
-    _require_admin(family_user)
+    _require_admin(family_user, current_user)
     target = (
         db.query(FamilyUser)
         .filter(
@@ -146,7 +146,7 @@ def reset_member_password(
     current_user: User = Depends(get_current_user),
 ) -> PasswordResetResponse:
     family_user = _get_family_user(db, current_user)
-    _require_admin(family_user)
+    _require_admin(family_user, current_user)
     if user_id == current_user.id:
         raise HTTPException(status_code=400, detail="Cannot reset your own password here")
     target_family_user = (
@@ -176,7 +176,7 @@ def delete_member(
     current_user: User = Depends(get_current_user),
 ):
     family_user = _get_family_user(db, current_user)
-    _require_admin(family_user)
+    _require_admin(family_user, current_user)
     target = (
         db.query(FamilyUser)
         .filter(

--- a/tests/test_superadmin_backend_auth.py
+++ b/tests/test_superadmin_backend_auth.py
@@ -1,0 +1,77 @@
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from datetime import datetime, date
+
+from app.models.user import User
+from app.models.family import Family, FamilyUser, UserRole
+from app.models.baby import Baby
+from app.services.auth import get_password_hash
+
+def test_superadmin_backend_auth_bypass(client: TestClient, db: Session):
+    # 1. Setup: Create Family and SuperAdmin (Role: Viewer)
+    family = Family(name="Test Family Auth", invite_code="TESTAUTH")
+    db.add(family)
+    db.commit()
+
+    superadmin = User(
+        username="superadmin_backend",
+        hashed_password=get_password_hash("password123"),
+        is_superadmin=True
+    )
+    db.add(superadmin)
+    db.commit()
+
+    # Add as VIEWER (not ADMIN)
+    family_user = FamilyUser(family_id=family.id, user_id=superadmin.id, role=UserRole.VIEWER)
+    db.add(family_user)
+    db.commit()
+
+    # Create a baby for testing permissions/updates
+    baby = Baby(
+        family_id=family.id,
+        name="Test Baby",
+        birthday=date(2023, 1, 1),
+        gender="girl"
+    )
+    db.add(baby)
+    db.commit()
+
+    # Login
+    response = client.post(
+        "/api/auth/login",
+        json={"username": "superadmin_backend", "password": "password123"}
+    )
+    assert response.status_code == 200
+
+    # 2. Test Baby Management (POST /api/babies) - Should be allowed for SuperAdmin
+    # Currently fails with 403
+    response = client.post(
+        "/api/babies/",
+        json={
+            "name": "New Baby",
+            "birthday": "2024-01-01",
+            "gender": "boy"
+        }
+    )
+    # Expectation: 200 OK (after fix), currently 403
+    if response.status_code == 403:
+        pytest.fail("SuperAdmin blocked from creating baby (403 Forbidden)")
+    assert response.status_code == 200
+
+    # 3. Test Permission Management (GET /api/babies/{id}/permissions)
+    response = client.get(f"/api/babies/{baby.id}/permissions")
+    if response.status_code == 403:
+        pytest.fail("SuperAdmin blocked from reading permissions (403 Forbidden)")
+    assert response.status_code == 200
+
+    # 4. Test Family Management (PATCH /api/family)
+    response = client.patch(
+        "/api/family/",
+        json={"name": "Updated Family Name"}
+    )
+    if response.status_code == 403:
+        pytest.fail("SuperAdmin blocked from updating family (403 Forbidden)")
+    assert response.status_code == 200
+    assert response.json()["name"] == "Updated Family Name"


### PR DESCRIPTION
## 概要
SuperAdmin ユーザーがバックエンドの管理 API（赤ちゃん管理、権限管理、家族管理）を実行しようとした際、家族管理者（Family Admin）でない場合に 403 Forbidden エラーが発生する問題を修正しました。

## 変更点
- **`app/dependencies.py`**: `verify_baby_access`, `verify_write_access` 関数で `is_superadmin` をチェックし、SuperAdmin であれば許可するように変更。
- **`app/routers/baby.py`**: `create_baby`, `update_baby`, `delete_baby`, `get_records` で `is_superadmin` をチェックするように変更。
- **`app/routers/baby_permissions.py`**: `get_baby_permissions`, `update_baby_permissions` で `is_superadmin` をチェックするように変更。
- **`app/routers/family.py`**: `_require_admin` 関数に `current_user` 引数を追加し、`is_superadmin` を許可するように変更。各エンドポイントの呼び出し箇所を修正。
- **Tests**: `tests/test_superadmin_backend_auth.py` を追加し、SuperAdmin (Viewer ロール) がこれらの操作を実行できることを確認。

## 関連 Issue
- (なし)

## 動作確認
- 新規テストケース `tests/test_superadmin_backend_auth.py` がパスすることを確認。
- `scripts/verify_all.sh` による全チェックがパスすることを確認。
