### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to registration endpoints

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -18,7 +18,18 @@ from app.utils.rate_limit import RateLimiter
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 # Limit login attempts to 5 per 60 seconds
-login_limiter = RateLimiter(requests_limit=5, time_window=60)
+login_limiter = RateLimiter(
+    requests_limit=5,
+    time_window=60,
+    error_message="Too many login attempts. Please try again later.",
+)
+
+# Limit registration attempts to 3 per 60 seconds to prevent spam
+register_limiter = RateLimiter(
+    requests_limit=3,
+    time_window=60,
+    error_message="Too many registration attempts. Please try again later.",
+)
 
 # Generate a dummy hash for timing attack mitigation
 # This ensures verify_password is called even if user is not found,
@@ -73,7 +84,11 @@ def update_profile(
 
 
 
-@router.post("/register/family", response_model=FamilyResponse)
+@router.post(
+    "/register/family",
+    response_model=FamilyResponse,
+    dependencies=[Depends(register_limiter)],
+)
 def register_family(family_in: FamilyCreate, response: Response, db: Session = Depends(get_db)):
     existing_user = db.query(User).filter(User.username == family_in.username).first()
     if existing_user:
@@ -112,7 +127,11 @@ def register_family(family_in: FamilyCreate, response: Response, db: Session = D
     return new_family
 
 
-@router.post("/register/join", response_model=UserResponse)
+@router.post(
+    "/register/join",
+    response_model=UserResponse,
+    dependencies=[Depends(register_limiter)],
+)
 def join_family(user_in: UserCreate, invite_code: str, response: Response, db: Session = Depends(get_db)):
     existing_user = db.query(User).filter(User.username == user_in.username).first()
     if existing_user:

--- a/app/utils/rate_limit.py
+++ b/app/utils/rate_limit.py
@@ -6,10 +6,17 @@ class RateLimiter:
     """
     Simple in-memory rate limiter based on IP address.
     """
-    def __init__(self, requests_limit: int = 5, time_window: int = 60, max_size: int = 10000):
+    def __init__(
+        self,
+        requests_limit: int = 5,
+        time_window: int = 60,
+        max_size: int = 10000,
+        error_message: str = "Too many requests. Please try again later.",
+    ):
         self.requests_limit = requests_limit
         self.time_window = time_window
         self.max_size = max_size
+        self.error_message = error_message
         self.requests = defaultdict(list)
 
     async def __call__(self, request: Request):
@@ -31,7 +38,7 @@ class RateLimiter:
         if len(self.requests[client_ip]) >= self.requests_limit:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="Too many login attempts. Please try again later."
+                detail=self.error_message,
             )
 
         self.requests[client_ip].append(now)

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -56,3 +56,36 @@ async def test_rate_limit_with_none_client():
     limiter = RateLimiter(requests_limit=5)
     await limiter(request)
     assert len(limiter.requests["unknown"]) == 1
+
+
+@pytest.mark.enable_rate_limit
+def test_register_rate_limit(client):
+    """
+    Verify that the registration endpoint enforces rate limiting (3 requests per 60s).
+    """
+    # 3 attempts should succeed (or fail with 400 if user exists/invalid, but pass rate limiter)
+    # The rate limiter runs as a dependency, so it counts requests regardless of the handler result.
+
+    for i in range(3):
+        res = client.post(
+            "/api/auth/register/family",
+            json={
+                "username": f"test_register_{i}",
+                "password": "password1",
+                "name": f"Test Family {i}"
+            }
+        )
+        # We expect 200 OK or 400 Bad Request (if something else is wrong), but not 429
+        assert res.status_code != 429
+
+    # 4th attempt should fail with 429
+    res = client.post(
+        "/api/auth/register/family",
+        json={
+            "username": "test_register_4",
+            "password": "password1",
+            "name": "Test Family 4"
+        }
+    )
+    assert res.status_code == 429
+    assert res.json()["detail"] == "Too many registration attempts. Please try again later."


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The family registration and join endpoints (`/api/auth/register/family` and `/api/auth/register/join`) lacked rate limiting, allowing for potential automated account creation (spam) and resource exhaustion attacks.
🎯 Impact: Attackers could create thousands of spam accounts, filling the database and potentially degrading service performance.
🔧 Fix:
- Updated `RateLimiter` utility to support custom error messages.
- Implemented `register_limiter` (3 requests per 60 seconds) and applied it to registration endpoints.
- Explicitly set `login_limiter` error message to maintain existing behavior.
✅ Verification: Added `test_register_rate_limit` in `tests/test_rate_limit.py` to verify that the 4th request within 60 seconds is blocked with a 429 status code and the correct error message.

---
*PR created automatically by Jules for task [5662583495276741881](https://jules.google.com/task/5662583495276741881) started by @eburairu*