### PR TITLE
fix: openapi-fetchのbaseUrlから重複する/apiプレフィックスを除去

### DIFF
--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1,7 +1,7 @@
 import createClient from "openapi-fetch";
 import type { paths } from "@/types/generated/api";
 
-const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? "") + "/api";
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 /**
  * 型安全な API クライアント


### PR DESCRIPTION
## 原因

`openapi-fetch` はURLを `${baseUrl}${pathname}` で単純文字列結合する。

`api-client.ts` の `baseUrl` に `/api` が含まれていたため:
- `baseUrl = "/api"`
- `pathname = "/api/feedings/"` (OpenAPIスペック由来)
- 結果: `/api/api/feedings/` → **リクエスト失敗**

## 修正

`baseUrl` から `/api` を除去。OpenAPIスペックのパスが既に `/api/` で始まるため、`baseUrl` にはオリジンのみを指定する。

```ts
// Before
const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? "") + "/api";
// After
const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
```

## 影響

- 授乳記録の保存（POST /api/feedings/）が動作するようになる
- 授乳記録の履歴表示（GET /api/feedings/）が動作するようになる

## 原因コミット

`d21d560 feat: openapi-fetch による型安全な API クライアントの導入と useFeeding フックの移行` で導入されたバグ。