### PR TITLE
docs+test: openapi-fetch URL構築の仕様書修正とテスト追加

### DIFF
--- a/.specify/specs/development/openapi_type_generation.md
+++ b/.specify/specs/development/openapi_type_generation.md
@@ -194,12 +194,27 @@ export type Feeding = components["schemas"]["FeedingResponse"];
 
 `openapi-fetch` を導入し、パス文字列のハードコードを排除する。
 
+#### ⚠️ URL 構築の注意点
+
+`openapi-fetch` は URL を **`${baseUrl}${pathname}` で単純文字列結合** する。
+FastAPI のルーターは `/api` プレフィックス付き（例: `prefix="/api/feedings"`）のため、
+OpenAPI スキーマのパスは `/api/feedings/` のように `/api/` で始まる。
+
+したがって **`baseUrl` に `/api` を含めてはいけない**。含めると二重パス（`/api/api/feedings/`）になってリクエストが失敗する。
+
+| 設定 | baseUrl | pathname | 結果 |
+|---|---|---|---|
+| 誤り | `"/api"` | `"/api/feedings/"` | `"/api/api/feedings/"` ❌ |
+| 正しい | `""` | `"/api/feedings/"` | `"/api/feedings/"` ✅ |
+| 本番（正しい） | `"https://example.com"` | `"/api/feedings/"` | `"https://example.com/api/feedings/"` ✅ |
+
 1. **`frontend/lib/api-client.ts` の作成**:
    ```typescript
    import createClient from "openapi-fetch";
    import type { paths } from "@/types/generated/api";
 
-   const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? "") + "/api";
+   // ⚠️ "/api" を付加しない。OpenAPI スキーマのパスが既に /api/ で始まるため。
+   const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
    export const client = createClient<paths>({
      baseUrl: API_BASE,
@@ -209,10 +224,9 @@ export type Feeding = components["schemas"]["FeedingResponse"];
    /**
     * SWR 等で使用するための、エラー時に throw する標準 fetcher
     */
-   export async function throwOnError<T>(promise: Promise<{ data?: T; error?: any }>) {
+   export async function throwOnError<T>(promise: Promise<{ data?: T; error?: unknown }>) {
      const { data, error } = await promise;
      if (error) {
-       // 必要に応じて ApiError クラス等でラップする
        throw error;
      }
      return data as T;
@@ -226,14 +240,17 @@ export type Feeding = components["schemas"]["FeedingResponse"];
 
    export function useFeeding(babyId: number | null) {
      const { data, error, mutate } = useSWR(
-       babyId ? ["/feedings/", babyId] : null,
-       ([url, id]) => throwOnError(client.GET("/feedings/", {
+       babyId ? ["/api/feedings/", babyId] : null,
+       ([_, id]) => throwOnError(client.GET("/api/feedings/", {
          params: { query: { baby_id: id } },
        }))
      );
      // ...
    }
    ```
+
+   > パス文字列は OpenAPI スキーマのパスをそのまま使う（`/api/feedings/`）。
+   > 型チェックにより、スキーマに存在しないパスはコンパイルエラーになる。
 
 3. **段階的移行**:
    既存の `frontend/lib/api.ts` を使用している箇所を、順次 `openapi-fetch` に置き換えていく。

--- a/frontend/__tests__/api-client.test.ts
+++ b/frontend/__tests__/api-client.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+
+// openapi-fetch はグローバルの fetch を使うため、モックする
+const fetchMock = vi.fn()
+global.fetch = fetchMock
+
+// openapi-fetch は Node.js 環境で new URL() を使うため、
+// テスト用の絶対 URL ベースが必要（ブラウザでは相対URL が動作するが Node.js では不可）
+const TEST_BASE = "http://localhost"
+
+// mock response ファクトリ（openapi-fetch は response.text() を呼ぶため必要）
+function mockJsonResponse(body: unknown, status = 200) {
+    const json = JSON.stringify(body)
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        text: async () => json,
+        json: async () => body,
+        clone: function () { return this },
+    }
+}
+
+describe("api-client", () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+        vi.unstubAllEnvs()
+        vi.resetModules()
+        fetchMock.mockReset()
+    })
+
+    describe("URL 構築 — /api/api/ の二重パスにならないことの検証", () => {
+        it("NEXT_PUBLIC_API_BASE_URL がオリジンのみのとき、GET /api/feedings/ が正しい URL でリクエストされる", async () => {
+            // baseUrl = "http://localhost"、pathname = "/api/feedings/"
+            // → 結果: "http://localhost/api/feedings/"（二重パスなし）
+            vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", TEST_BASE)
+            vi.resetModules()
+            const { client } = await import("@/lib/api-client")
+
+            fetchMock.mockResolvedValueOnce(mockJsonResponse([]))
+
+            await client.GET("/api/feedings/", {
+                params: { query: { baby_id: 1 } },
+            })
+
+            expect(fetchMock).toHaveBeenCalledOnce()
+            // openapi-fetch は fetch() に Request オブジェクトを渡すため .url で取得する
+            const calledUrl: string = (fetchMock.mock.calls[0][0] as Request).url
+
+            // 正しいパスでリクエストされていること
+            expect(calledUrl).toBe(`${TEST_BASE}/api/feedings/?baby_id=1`)
+
+            // /api/api/ という二重パスになっていないこと（回帰テスト）
+            expect(calledUrl).not.toContain("/api/api/")
+        })
+
+        it("NEXT_PUBLIC_API_BASE_URL がオリジンのみのとき、POST /api/feedings/ が正しい URL でリクエストされる", async () => {
+            vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", TEST_BASE)
+            vi.resetModules()
+            const { client } = await import("@/lib/api-client")
+
+            const responseBody = {
+                id: 1,
+                baby_id: 1,
+                feeding_type: "BREAST",
+                feeding_time: "2026-02-22T10:00:00",
+                comment_count: 0,
+            }
+            fetchMock.mockResolvedValueOnce(mockJsonResponse(responseBody))
+
+            await client.POST("/api/feedings/", {
+                body: {
+                    baby_id: 1,
+                    feeding_type: "BREAST",
+                    feeding_time: "2026-02-22T10:00:00",
+                },
+            })
+
+            // openapi-fetch は fetch() に Request オブジェクトを渡すため .url で取得する
+            const calledUrl: string = (fetchMock.mock.calls[0][0] as Request).url
+            expect(calledUrl).toBe(`${TEST_BASE}/api/feedings/`)
+            expect(calledUrl).not.toContain("/api/api/")
+        })
+
+        it("NEXT_PUBLIC_API_BASE_URL が本番URLのとき、正しいエンドポイントにリクエストされる", async () => {
+            const prodBase = "https://example.com"
+            vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", prodBase)
+            vi.resetModules()
+            const { client } = await import("@/lib/api-client")
+
+            fetchMock.mockResolvedValueOnce(mockJsonResponse([]))
+
+            await client.GET("/api/feedings/", {
+                params: { query: { baby_id: 42 } },
+            })
+
+            // openapi-fetch は fetch() に Request オブジェクトを渡すため .url で取得する
+            const calledUrl: string = (fetchMock.mock.calls[0][0] as Request).url
+            expect(calledUrl).toBe(`${prodBase}/api/feedings/?baby_id=42`)
+            expect(calledUrl).not.toContain("/api/api/")
+        })
+
+        it("DELETE /api/feedings/{feeding_id} がパスパラメータ付きで正しく構築される", async () => {
+            vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", TEST_BASE)
+            vi.resetModules()
+            const { client } = await import("@/lib/api-client")
+
+            fetchMock.mockResolvedValueOnce(mockJsonResponse({ message: "Deleted" }))
+
+            await client.DELETE("/api/feedings/{feeding_id}", {
+                params: { path: { feeding_id: 99 } },
+            })
+
+            // openapi-fetch は fetch() に Request オブジェクトを渡すため .url で取得する
+            const calledUrl: string = (fetchMock.mock.calls[0][0] as Request).url
+            expect(calledUrl).toBe(`${TEST_BASE}/api/feedings/99`)
+            expect(calledUrl).not.toContain("/api/api/")
+        })
+    })
+
+    describe("throwOnError", () => {
+        it("成功時にデータを返す", async () => {
+            vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", TEST_BASE)
+            vi.resetModules()
+            const { throwOnError } = await import("@/lib/api-client")
+
+            const data = { id: 1 }
+            const result = await throwOnError(Promise.resolve({ data, error: undefined }))
+            expect(result).toEqual(data)
+        })
+
+        it("error が存在するときに throw する", async () => {
+            vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", TEST_BASE)
+            vi.resetModules()
+            const { throwOnError } = await import("@/lib/api-client")
+
+            const error = { detail: "Unauthorized" }
+            await expect(
+                throwOnError(Promise.resolve({ data: undefined, error }))
+            ).rejects.toEqual(error)
+        })
+
+        it("data が undefined でも error がなければ undefined を返す", async () => {
+            vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", TEST_BASE)
+            vi.resetModules()
+            const { throwOnError } = await import("@/lib/api-client")
+
+            const result = await throwOnError(
+                Promise.resolve({ data: undefined, error: undefined })
+            )
+            expect(result).toBeUndefined()
+        })
+    })
+})


### PR DESCRIPTION
## 概要

PR #246 の追跡作業。`api-client.ts` の URL 二重パスバグを今後発生させないための仕様書修正とテスト追加。

## 変更内容

### 仕様書（`.specify/specs/development/openapi_type_generation.md`）

Phase 4 の `api-client.ts` サンプルコードが修正前の誤ったコードのままだったため修正。

- `const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? "") + "/api"` → `+ "/api"` を除去
- `openapi-fetch` の URL 構築メカニズム（`${baseUrl}${pathname}` の単純文字列結合）を表で明記
- 二重パス `/api/api/` になる誤りパターンと正しいパターンを対比

### テスト（`frontend/__tests__/api-client.test.ts`）

```
7 tests passing
  URL 構築テスト（4件）
    - GET /api/feedings/ が二重パスにならないこと
    - POST /api/feedings/ が二重パスにならないこと
    - 本番 URL でも正しく構築されること
    - DELETE パスパラメータ付きで正しく構築されること
  throwOnError テスト（3件）
    - 成功時にデータを返す
    - エラー時に throw する
    - undefined でも throw しない
```