### PR TITLE
fix: useFeeding の SWR キーを文字列化しヘッダー赤ちゃん切り替えを修正

### DIFF
--- a/frontend/hooks/useFeeding.ts
+++ b/frontend/hooks/useFeeding.ts
@@ -5,10 +5,11 @@ import { useMemo } from 'react';
 
 export function useFeeding(babyId: number | null) {
     const { data: feedings, error, mutate } = useSWR(
-        babyId ? ['/api/feedings/', babyId] : null,
-        ([_, id]) => throwOnError(client.GET('/api/feedings/', {
-            params: { query: { baby_id: id } }
-        }))
+        babyId ? `/api/feedings/?baby_id=${babyId}` : null,
+        () => throwOnError(client.GET('/api/feedings/', {
+            params: { query: { baby_id: babyId! } }
+        })),
+        { keepPreviousData: true }
     );
 
     const loading = !feedings && !error;


### PR DESCRIPTION
## 問題

ヘッダーのドロップダウンで赤ちゃんを切り替えると名前は変わるが、授乳記録ページのデータが前の赤ちゃんのもののまま変わらなかった。

## 原因

`useFeeding.ts` の SWR キーが配列 `['/api/feedings/', babyId]` で、フェッチャーが `([_, id]) =>` というデストラクチャリングを使用していた。SWR の配列キーのフェッチャー呼び出し方とのミスマッチにより、`babyId` の変更が SWR に正しく検出されない問題があった。

他のフック（`useSleeps`, `useDiapers`）は `useBabyResource` 経由で文字列キーを使用しており、切り替えが正常に機能していた。

## 修正内容

- SWR キーを文字列 `/api/feedings/?baby_id=${babyId}` に変更（`useBabyResource` と同一パターン）
- `keepPreviousData: true` を追加し、切り替え中の空表示を防止

## テスト

- [ ] 複数の赤ちゃんがいる環境でヘッダー切り替えを確認
- [ ] 授乳記録ページで切り替え後にデータが更新されることを確認