### PR TITLE
🎨 Palette: ダイアログとシートの閉じるボタンを日本語化

### DIFF
--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -73,7 +73,7 @@ function DialogContent({
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">閉じる</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>
@@ -111,7 +111,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button variant="outline">閉じる</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/frontend/components/ui/sheet.tsx
+++ b/frontend/components/ui/sheet.tsx
@@ -67,7 +67,7 @@ const SheetContent = React.forwardRef<
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">閉じる</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>


### PR DESCRIPTION
shadcn/ui の `Dialog` と `Sheet` コンポーネントに含まれる、デフォルトの閉じるボタンのテキストを日本語化しました。
- `sr-only` のテキストを "Close" から "閉じる" に変更
- `DialogFooter` のデフォルト閉じるボタンを "Close" から "閉じる" に変更

これにより、スクリーンリーダーユーザーへのアクセシビリティが向上し、アプリ全体の日本語化がより完全になります。

---
*PR created automatically by Jules for task [2244458337237061399](https://jules.google.com/task/2244458337237061399) started by @eburairu*