### PR TITLE
🎨 Palette: QuickActionBarのアクセシビリティとフィードバックを改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,3 +3,7 @@
 ## 2026-02-20 - [Password Visibility Toggle Pattern]
 **Learning:** Adding a password visibility toggle requires careful positioning relative to the input field. While implementing this directly in the page works, it leads to code duplication and inconsistent positioning across different forms (Login vs Register).
 **Action:** In the future, advocate for extending the base `Input` component to support an `endAdornment` prop or creating a dedicated `PasswordInput` component in the design system to encapsulate this pattern and ensure accessibility consistency.
+
+## 2026-02-23 - [Icons and Feedback in Quick Actions]
+**学び:** 絵文字のみのボタンはスクリーンリーダーのサポートが不足しがちで、意図が正しく伝わらない可能性があります。また、非同期アクション（ミルク記録など）が実行されている間、フィードバックがないとユーザーは操作が成功したのか不安になり、連打してしまう可能性があります。
+**アクション:** アイコンのみのボタンには必ず `aria-label` を付与し、非同期アクション中は `Loader2` などのスピナーを表示して明確なフィードバックを提供するパターンを標準化します。

--- a/frontend/components/dashboard/QuickActionBar.tsx
+++ b/frontend/components/dashboard/QuickActionBar.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { api } from "@/lib/api"
 import { usePermissions } from "@/hooks/usePermissions"
 import { BabyRecord } from "@/hooks/useData"
-import { Moon, Bed } from "lucide-react"
+import { Moon, Bed, Loader2 } from "lucide-react"
 import { useRecordFeedback } from "@/hooks/useRecordFeedback"
 
 interface Props {
@@ -71,8 +71,15 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     onClick={() => handleQuickRecord("feeding_bottle")}
                     disabled={loading}
                     title="ミルク記録"
+                    aria-label="ミルクを記録"
                 >
-                    <span className="text-xl">🍼</span>
+                    {loading ? (
+                        <Loader2 className="animate-spin" />
+                    ) : (
+                        <span className="text-xl" role="img" aria-hidden="true">
+                            🍼
+                        </span>
+                    )}
                 </Button>
                 <Button
                     variant="ghost"
@@ -81,8 +88,15 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     onClick={() => handleQuickRecord("sleep")}
                     disabled={loading}
                     title={activeSleep ? '睡眠終了' : '睡眠開始'}
+                    aria-label={activeSleep ? '睡眠終了' : '睡眠開始'}
                 >
-                    {activeSleep ? <Bed className="h-6 w-6" /> : <Moon className="h-6 w-6" />}
+                    {loading ? (
+                        <Loader2 className="animate-spin" />
+                    ) : activeSleep ? (
+                        <Bed className="h-6 w-6" />
+                    ) : (
+                        <Moon className="h-6 w-6" />
+                    )}
                 </Button>
                 <div className="w-px h-8 bg-gray-200 dark:bg-zinc-700 mx-1" />
                 <Button
@@ -92,8 +106,15 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     onClick={() => handleQuickRecord("diaper_wet")}
                     disabled={loading}
                     title="おしっこ記録"
+                    aria-label="おしっこを記録"
                 >
-                    <span className="text-xl">💧</span>
+                    {loading ? (
+                        <Loader2 className="animate-spin" />
+                    ) : (
+                        <span className="text-xl" role="img" aria-hidden="true">
+                            💧
+                        </span>
+                    )}
                 </Button>
                 <Button
                     variant="ghost"
@@ -102,8 +123,15 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     onClick={() => handleQuickRecord("diaper_dirty")}
                     disabled={loading}
                     title="うんち記録"
+                    aria-label="うんちを記録"
                 >
-                    <span className="text-xl">💩</span>
+                    {loading ? (
+                        <Loader2 className="animate-spin" />
+                    ) : (
+                        <span className="text-xl" role="img" aria-hidden="true">
+                            💩
+                        </span>
+                    )}
                 </Button>
             </div>
         </div>


### PR DESCRIPTION
アイコンのみのボタンにARIAラベルを追加し、非同期アクション中のローディングフィードバックを追加しました。
また、絵文字を適切にラップしてアクセシビリティを向上させました。
変更は50行未満に抑え、既存のデザインシステムを使用しています。

---
*PR created automatically by Jules for task [16363721295568244748](https://jules.google.com/task/16363721295568244748) started by @eburairu*