### PR TITLE
🎨 Palette: 成長記録とおむつ記録のアイコンボタンにARIAラベルを追加

### DIFF
--- a/frontend/components/diaper/DiaperHistory.tsx
+++ b/frontend/components/diaper/DiaperHistory.tsx
@@ -150,6 +150,7 @@ export function DiaperHistory({ diapers, onDeleteSuccess, canWrite = true, initi
                                         ) : null}
                                         <button
                                             onClick={() => setCommentTarget({ id: diaper.id, title: `${style.label} ${formatDate(diaper.change_time)}` })}
+                                            aria-label={`${style.label} ${formatDate(diaper.change_time)} へのコメント`}
                                             className="inline-flex items-center gap-0.5 text-xs text-gray-400 dark:text-zinc-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors mt-0.5"
                                         >
                                             <MessageCircle className="w-3 h-3" />
@@ -164,6 +165,7 @@ export function DiaperHistory({ diapers, onDeleteSuccess, canWrite = true, initi
                                             size="icon"
                                             className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-blue-500 dark:hover:text-blue-400 hover:bg-transparent"
                                             onClick={() => handleEdit(diaper)}
+                                            aria-label={`${style.label} ${formatDate(diaper.change_time)} を編集`}
                                         >
                                             <Pencil className="h-4 w-4" />
                                         </Button>
@@ -172,6 +174,7 @@ export function DiaperHistory({ diapers, onDeleteSuccess, canWrite = true, initi
                                             size="icon"
                                             className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-transparent"
                                             onClick={() => setDeleteTargetId(diaper.id)}
+                                            aria-label={`${style.label} ${formatDate(diaper.change_time)} を削除`}
                                         >
                                             <Trash2 className="h-4 w-4" />
                                         </Button>

--- a/frontend/components/growth/GrowthHistoryList.tsx
+++ b/frontend/components/growth/GrowthHistoryList.tsx
@@ -103,7 +103,7 @@ export function GrowthHistoryList({
                                     {record.recorded_by_display_name ?? "-"}
                                 </td>
                                 <td className="py-2 px-4">
-                                    <button
+                                    <button aria-label={`${record.date} の成長記録へのコメント`}
                                         onClick={() => setCommentTarget({ id: record.id, title: `成長記録 ${record.date}` })}
                                         className="inline-flex items-center gap-0.5 text-xs text-gray-400 dark:text-zinc-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors"
                                     >
@@ -118,6 +118,7 @@ export function GrowthHistoryList({
                                                 variant="ghost"
                                                 size="icon-xs"
                                                 onClick={() => onEdit(record)}
+                                                aria-label={`${record.date} の成長記録を編集`}
                                             >
                                                 <Edit2 className="h-4 w-4" />
                                             </Button>
@@ -125,7 +126,7 @@ export function GrowthHistoryList({
                                                 variant="ghost"
                                                 size="icon-xs"
                                                 className="text-destructive hover:text-destructive"
-                                                onClick={() => setDeleteId(record.id)}
+                                                onClick={() => setDeleteId(record.id)} aria-label={`${record.date} の成長記録を削除`}
                                             >
                                                 <Trash2 className="h-4 w-4" />
                                             </Button>


### PR DESCRIPTION
🎨 Palette: 成長記録とおむつ記録のアイコンボタンにARIAラベルを追加

## 💡 何を
`GrowthHistoryList.tsx` と `DiaperHistory.tsx` にある、アイコンのみで構成されたボタン（コメント、編集、削除）に `aria-label` を追加しました。

## 🎯 なぜ
これらのボタンにはテキストラベルがなく、スクリーンリーダーユーザーにとっては「ボタン」としか認識されない、あるいは文脈から操作対象が不明確である可能性がありました。
今回の変更により、どの記録に対する操作なのか（例：「2024-03-20 の成長記録を編集」）が明確になります。

## ♿ アクセシビリティ
- コメント、編集、削除ボタンに動的な `aria-label` を付与しました。
- 日付や記録の種類を含めることで、リスト内の特定の項目に対する操作であることを明示しました。

---
*PR created automatically by Jules for task [14361965768459884306](https://jules.google.com/task/14361965768459884306) started by @eburairu*