### PR TITLE
feat: ダッシュボードとナビゲーションの表示順を更新

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -92,8 +92,11 @@ export default function DashboardPage() {
                         isError={recordsError}
                         mutate={() => mutateRecords()}
                     />
-                    <DiaryWidget
+                    <GrowthWidget
                         babyId={effectiveBabyId}
+                        records={records}
+                        isLoading={recordsLoading}
+                        isError={recordsError}
                     />
                     <NoteWidget
                         babyId={effectiveBabyId}
@@ -101,11 +104,8 @@ export default function DashboardPage() {
                         isLoading={recordsLoading}
                         isError={recordsError}
                     />
-                    <GrowthWidget
+                    <DiaryWidget
                         babyId={effectiveBabyId}
-                        records={records}
-                        isLoading={recordsLoading}
-                        isError={recordsError}
                     />
                 </div>
 

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -32,11 +32,11 @@ import { DashboardSkeleton } from "@/components/dashboard/DashboardSkeleton"
 const ALL_NAV_ITEMS = [
     { label: "ホーム", href: "/dashboard", icon: "🏠", prenatal: true, postnatal: true },
     { label: "授乳", href: "/feeding", icon: "🍼", prenatal: false, postnatal: true },
-    { label: "おむつ", href: "/diaper", icon: "👶", prenatal: false, postnatal: true },
     { label: "睡眠", href: "/sleep", icon: "💤", prenatal: false, postnatal: true },
-    { label: "日誌", href: "/diary", icon: "📔", prenatal: false, postnatal: true },
+    { label: "おむつ", href: "/diaper", icon: "👶", prenatal: false, postnatal: true },
     { label: "成長", href: "/growth", icon: "📈", prenatal: false, postnatal: true },
     { label: "メモ", href: "/note", icon: "📝", prenatal: false, postnatal: true },
+    { label: "日誌", href: "/diary", icon: "📔", prenatal: false, postnatal: true },
     { label: "陣痛タイマー", href: "/contraction", icon: "⏱", prenatal: true, postnatal: false },
 ]
 
@@ -212,7 +212,7 @@ export default function DashboardLayout({
                         { label: "授乳", href: "/feeding", icon: "🍼" },
                         { label: "睡眠", href: "/sleep", icon: "💤" },
                         { label: "おむつ", href: "/diaper", icon: "👶" },
-                        { label: "日誌", href: "/diary", icon: "📔" },
+                        { label: "成長", href: "/growth", icon: "📈" },
                     ].map(item => (
                         <Link
                             key={item.href}


### PR DESCRIPTION
## 概要
ダッシュボードのウィジェットおよびナビゲーション項目の表示順を更新しました。

## 変更内容
- ダッシュボードのウィジェット順序を「授乳、睡眠、おむつ、成長、メモ、育児日誌」に変更
- ナビゲーション（サイドバー/メニュー）の順序を上記に合わせる形で更新
- モバイル用ボトムナビゲーションの項目を「ホーム、授乳、睡眠、おむつ、成長」に更新し、順序を統一

Closes #none
