### PR TITLE
🛡️ Sentinel: [セキュリティ強化] 画像アップロードにレート制限を追加

### DIFF
--- a/app/routers/upload.py
+++ b/app/routers/upload.py
@@ -8,6 +8,7 @@ from botocore.exceptions import ClientError
 
 from app.dependencies import get_db, get_current_user, verify_write_access
 from app.models.user import User
+from app.utils.rate_limit import RateLimiter
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -15,6 +16,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/upload", tags=["upload"])
 
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
+
+# Limit upload attempts to 10 per 60 seconds per user
+upload_limiter = RateLimiter(
+    requests_limit=10,
+    time_window=60,
+    error_message="Too many upload attempts. Please try again later.",
+)
 
 
 class UploadResponse(BaseModel):
@@ -47,6 +55,9 @@ async def upload_image(
     current_user: User = Depends(get_current_user),
 ):
     """画像をバックエンド経由で R2 にアップロードする。"""
+    # Enforce rate limiting per user
+    upload_limiter.check(f"user_{current_user.id}")
+
     verify_write_access(db, current_user.id)
     if not file.content_type or not file.content_type.startswith("image/"):
         raise HTTPException(

--- a/app/utils/rate_limit.py
+++ b/app/utils/rate_limit.py
@@ -4,7 +4,7 @@ from fastapi import Request, HTTPException, status
 
 class RateLimiter:
     """
-    Simple in-memory rate limiter based on IP address.
+    Simple in-memory rate limiter based on IP address or custom key.
     """
     def __init__(
         self,
@@ -19,26 +19,32 @@ class RateLimiter:
         self.error_message = error_message
         self.requests = defaultdict(list)
 
-    async def __call__(self, request: Request):
-        # Rely on request.client.host, which is populated by uvicorn (with --proxy-headers)
-        client_ip = request.client.host if request.client and request.client.host else "unknown"
-
+    def check(self, key: str):
+        """
+        Check if the key has exceeded the rate limit.
+        Raises HTTPException(429) if limit exceeded.
+        """
         now = time.time()
 
         # Prevent memory exhaustion by clearing if too large
         if len(self.requests) > self.max_size:
             self.requests.clear()
 
-        # Clean up old requests for this IP
-        self.requests[client_ip] = [
-            req_time for req_time in self.requests[client_ip]
+        # Clean up old requests for this key
+        self.requests[key] = [
+            req_time for req_time in self.requests[key]
             if now - req_time < self.time_window
         ]
 
-        if len(self.requests[client_ip]) >= self.requests_limit:
+        if len(self.requests[key]) >= self.requests_limit:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail=self.error_message,
             )
 
-        self.requests[client_ip].append(now)
+        self.requests[key].append(now)
+
+    async def __call__(self, request: Request):
+        # Rely on request.client.host, which is populated by uvicorn (with --proxy-headers)
+        client_ip = request.client.host if request.client and request.client.host else "unknown"
+        self.check(client_ip)

--- a/tests/test_upload_limit.py
+++ b/tests/test_upload_limit.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest.mock import MagicMock
+from app.routers.upload import upload_limiter
+
+@pytest.fixture
+def mock_upload_limiter():
+    """Reset the upload limiter before each test."""
+    upload_limiter.requests.clear()
+    yield
+    upload_limiter.requests.clear()
+
+@pytest.fixture
+def mock_r2_client(monkeypatch):
+    """Mock R2/S3 client to avoid actual uploads."""
+    mock_client = MagicMock()
+    # put_object returns None on success
+    mock_client.put_object.return_value = {}
+
+    def get_mock_client():
+        return mock_client
+
+    monkeypatch.setattr("app.routers.upload._get_r2_client", get_mock_client)
+    monkeypatch.setenv("R2_ACCOUNT_ID", "dummy")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "dummy")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "dummy")
+    monkeypatch.setenv("R2_BUCKET_NAME", "dummy-bucket")
+    monkeypatch.setenv("R2_PUBLIC_ENDPOINT", "https://dummy.r2.cloudflarestorage.com")
+    return mock_client
+
+def test_upload_rate_limit(client, mock_upload_limiter, mock_r2_client):
+    # 1. Register and login
+    # Registration might fail due to rate limiting if run repeatedly without clearing
+    # But conftest clears DB for each test function
+    res = client.post("/api/auth/register/family", json={
+        "username": "limit_user",
+        "password": "password123",
+        "name": "Limit Family"
+    })
+    assert res.status_code == 200
+
+    # Login to get token in cookies
+    res = client.post("/api/auth/login", json={
+        "username": "limit_user",
+        "password": "password123"
+    })
+    assert res.status_code == 200
+
+    # 2. Upload 10 images (limit is 10)
+    # Magic bytes for PNG
+    png_content = b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A" + b"\x00" * 10
+
+    for i in range(10):
+        res = client.post(
+            "/api/upload/image",
+            files={"file": ("test.png", png_content, "image/png")}
+        )
+        assert res.status_code == 200, f"Upload {i+1} failed: {res.text}"
+
+    # 3. 11th upload should fail with 429
+    res = client.post(
+        "/api/upload/image",
+        files={"file": ("test.png", png_content, "image/png")}
+    )
+    assert res.status_code == 429
+    assert "Too many upload attempts" in res.json()["detail"]


### PR DESCRIPTION
🛡️ Sentinel: [セキュリティ強化]

*   **概要:** 画像アップロードエンドポイント (`/api/upload/image`) にユーザーごとのレート制限（1分間に10回）を追加しました。
*   **目的:** 悪意のあるユーザーによる大量の画像アップロード（DoS攻撃やストレージ枯渇、コスト攻撃）を防ぐため。
*   **変更点:**
    *   `app/utils/rate_limit.py`: `RateLimiter` クラスをリファクタリングし、任意のキー（ユーザーIDなど）で制限をチェックできる `check(key)` メソッドを追加しました。
    *   `app/routers/upload.py`: `upload_image` 関数内で `upload_limiter.check(f"user_{current_user.id}")` を呼び出し、ユーザーごとに制限を適用しました。
    *   `tests/test_upload_limit.py`: レート制限が正しく機能することを確認するテストを追加しました。
*   **検証:** `pytest tests/test_upload_limit.py` および `pytest tests/test_rate_limit.py` を実行し、全てのテストがパスすることを確認しました。


---
*PR created automatically by Jules for task [13081209237803868119](https://jules.google.com/task/13081209237803868119) started by @eburairu*