### PR TITLE
🧹 Tidy: Refactor BabyForm to use shadcn/ui Form components

### DIFF
--- a/.jules/tidy.md
+++ b/.jules/tidy.md
@@ -32,3 +32,13 @@
 学び: GrowthRecordForm.tsx は shadcn/ui の Form コンポーネントを使用せず、独自の実装を行っていたため、コードベース全体の一貫性が損なわれていた。
 また、useEffect による手動のリセットロジックは React Hook Form の values オプションを使用することで簡素化できる。
 アクション: GrowthRecordForm.tsx を shadcn/ui の Form コンポーネントを使用するようにリファクタリングし、React Hook Form のベストプラクティスに従う。これにより、コードの可読性が向上し、ボイラープレートコードが削減される。
+
+2026-02-23 - [Refactor] BabyFormのshadcn/ui化と非推奨パターンの排除
+
+学び:
+- `BabyForm` コンポーネントが標準的な `shadcn/ui` の `Form` コンポーネントを使用しておらず、一貫性が欠けていた。
+- `useEffect` を使用したフォーム値のリセットは、`react-hook-form` の `values` オプションを使用することで宣言的に記述でき、複雑さを排除できる。
+- `Controller` パターン (`FormField`) を使用することで、`RadioGroup` などの制御コンポーネントも統一的に扱える。
+
+アクション:
+- 他のフォームコンポーネントでも同様の `useEffect` によるリセットパターンがないか確認し、あれば `values` オプションへの置き換えを推奨する。

--- a/frontend/components/settings/BabyForm.tsx
+++ b/frontend/components/settings/BabyForm.tsx
@@ -5,9 +5,15 @@ import { z } from "zod"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
-import { useEffect } from "react"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form"
 
 const babySchema = z.object({
     name: z.string().min(1, "名前を入力してください"),
@@ -36,14 +42,7 @@ export function BabyForm({
     isSubmitting,
     error,
 }: Props) {
-    const {
-        register,
-        handleSubmit,
-        reset,
-        setValue,
-        watch,
-        formState: { errors },
-    } = useForm<BabyFormData>({
+    const form = useForm<BabyFormData>({
         resolver: zodResolver(babySchema),
         defaultValues: {
             name: "",
@@ -53,86 +52,136 @@ export function BabyForm({
             characteristics: "",
             ...defaultValues,
         },
+        values: defaultValues ? {
+            name: defaultValues.name || "",
+            gender: defaultValues.gender || "unknown",
+            birthday: defaultValues.birthday || "",
+            due_date: defaultValues.due_date || "",
+            characteristics: defaultValues.characteristics || "",
+        } : undefined,
     })
 
-    const selectedGender = watch("gender")
-
-    useEffect(() => {
-        if (defaultValues) {
-            reset({
-                name: defaultValues.name || "",
-                gender: defaultValues.gender || "unknown",
-                birthday: defaultValues.birthday || "",
-                due_date: defaultValues.due_date || "",
-                characteristics: defaultValues.characteristics || "",
-            })
-        }
-    }, [defaultValues, reset])
-
     return (
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 py-2">
-            <div className="space-y-1">
-                <Label htmlFor="baby-name">名前 <span className="text-red-500">*</span></Label>
-                <Input id="baby-name" {...register("name")} autoFocus />
-                {errors.name && <p className="text-red-500 text-xs">{errors.name.message}</p>}
-            </div>
-
-            <div className="space-y-2">
-                <Label>性別</Label>
-                <RadioGroup
-                    value={selectedGender}
-                    onValueChange={(v) => setValue("gender", v as "boy" | "girl" | "unknown")}
-                    className="flex gap-4"
-                >
-                    <div className="flex items-center space-x-2">
-                        <RadioGroupItem value="boy" id="gender-boy" />
-                        <Label htmlFor="gender-boy" className="cursor-pointer">男の子</Label>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                        <RadioGroupItem value="girl" id="gender-girl" />
-                        <Label htmlFor="gender-girl" className="cursor-pointer">女の子</Label>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                        <RadioGroupItem value="unknown" id="gender-unknown" />
-                        <Label htmlFor="gender-unknown" className="cursor-pointer">わからない</Label>
-                    </div>
-                </RadioGroup>
-            </div>
-
-            <div className="space-y-1">
-                <Label htmlFor="baby-birthday">生年月日</Label>
-                <Input id="baby-birthday" type="date" max="9999-12-31" {...register("birthday")} />
-            </div>
-
-            <div className="space-y-1">
-                <Label htmlFor="baby-due-date">出産予定日</Label>
-                <Input id="baby-due-date" type="date" max="9999-12-31" {...register("due_date")} />
-            </div>
-
-            <div className="space-y-1">
-                <Label htmlFor="baby-characteristics">特徴・傾向</Label>
-                <Textarea
-                    id="baby-characteristics"
-                    {...register("characteristics")}
-                    placeholder="赤ちゃんのペースや特徴、AIが生成した傾向などが表示されます。"
-                    className="min-h-[100px]"
+        <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 py-2">
+                <FormField
+                    control={form.control}
+                    name="name"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>名前 <span className="text-red-500">*</span></FormLabel>
+                            <FormControl>
+                                <Input {...field} autoFocus />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
                 />
-            </div>
 
-            {error && <p className="text-red-500 text-sm">{error}</p>}
+                <FormField
+                    control={form.control}
+                    name="gender"
+                    render={({ field }) => (
+                        <FormItem className="space-y-3">
+                            <FormLabel>性別</FormLabel>
+                            <FormControl>
+                                <RadioGroup
+                                    onValueChange={field.onChange}
+                                    defaultValue={field.value}
+                                    className="flex gap-4"
+                                >
+                                    <FormItem className="flex items-center space-x-2 space-y-0">
+                                        <FormControl>
+                                            <RadioGroupItem value="boy" />
+                                        </FormControl>
+                                        <FormLabel className="font-normal cursor-pointer">
+                                            男の子
+                                        </FormLabel>
+                                    </FormItem>
+                                    <FormItem className="flex items-center space-x-2 space-y-0">
+                                        <FormControl>
+                                            <RadioGroupItem value="girl" />
+                                        </FormControl>
+                                        <FormLabel className="font-normal cursor-pointer">
+                                            女の子
+                                        </FormLabel>
+                                    </FormItem>
+                                    <FormItem className="flex items-center space-x-2 space-y-0">
+                                        <FormControl>
+                                            <RadioGroupItem value="unknown" />
+                                        </FormControl>
+                                        <FormLabel className="font-normal cursor-pointer">
+                                            わからない
+                                        </FormLabel>
+                                    </FormItem>
+                                </RadioGroup>
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
 
-            <div className="flex justify-end gap-2 pt-2">
-                <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
-                    キャンセル
-                </Button>
-                <Button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className="bg-indigo-600 hover:bg-indigo-700 text-white"
-                >
-                    {submitLabel}
-                </Button>
-            </div>
-        </form>
+                <FormField
+                    control={form.control}
+                    name="birthday"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>生年月日</FormLabel>
+                            <FormControl>
+                                <Input type="date" max="9999-12-31" {...field} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+
+                <FormField
+                    control={form.control}
+                    name="due_date"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>出産予定日</FormLabel>
+                            <FormControl>
+                                <Input type="date" max="9999-12-31" {...field} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+
+                <FormField
+                    control={form.control}
+                    name="characteristics"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>特徴・傾向</FormLabel>
+                            <FormControl>
+                                <Textarea
+                                    placeholder="赤ちゃんのペースや特徴、AIが生成した傾向などが表示されます。"
+                                    className="min-h-[100px]"
+                                    {...field}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+
+                {error && <p className="text-red-500 text-sm">{error}</p>}
+
+                <div className="flex justify-end gap-2 pt-2">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+                        キャンセル
+                    </Button>
+                    <Button
+                        type="submit"
+                        disabled={isSubmitting}
+                        className="bg-indigo-600 hover:bg-indigo-700 text-white"
+                    >
+                        {submitLabel}
+                    </Button>
+                </div>
+            </form>
+        </Form>
     )
 }


### PR DESCRIPTION
💡 何を:
- frontend/components/settings/BabyForm.tsx を shadcn/ui の Form コンポーネントを使用するようにリファクタリングしました。
- Input や RadioGroup を FormField でラップし、form.control で制御するように変更しました。
- useEffect を使用したフォーム値のリセットロジックを削除し、useForm の values オプションを使用して宣言的に実装しました。

🎯 なぜ:
- プロジェクト全体で shadcn/ui の使用を統一するため。
- useEffect による手動リセットは複雑さを増し、バグの原因になりやすいため、より宣言的なアプローチを採用することで可読性と保守性を向上させました。
- バリデーションエラーの表示などが標準化され、DXが向上しました。

🛡️ 安全性:
- BabyForm の Props インターフェースは変更しておらず、利用側の BabyEditDialog と AddBabyDialog に影響を与えません。
- pnpm lint, pnpm build, pnpm test を実行し、リグレッションがないことを確認しました。
- frontend ディレクトリ配下で全てのチェックがパスしています。

---
*PR created automatically by Jules for task [3281792437830792335](https://jules.google.com/task/3281792437830792335) started by @eburairu*