### PR TITLE
fix: ダッシュボードでボトムバーとクイックアクションが重なる問題を修正

### DIFF
--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -235,7 +235,7 @@ export default function DashboardLayout({
                 {children}
             </div>
 
-            <ScrollToTopButton />
+            <ScrollToTopButton hasBottomBar={born} />
         </div>
     )
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -117,6 +117,16 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+@utility pb-safe {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+@utility pt-safe {
+  padding-top: env(safe-area-inset-top);
+}
+@utility min-h-screen-safe {
+  min-height: calc(100vh - (env(safe-area-inset-top) + env(safe-area-inset-bottom)));
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/frontend/components/dashboard/QuickActionBar.tsx
+++ b/frontend/components/dashboard/QuickActionBar.tsx
@@ -67,7 +67,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
     }
 
     return (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 w-[90%] max-sm:max-w-[320px] max-w-sm">
+        <div className="fixed bottom-[calc(5.5rem+env(safe-area-inset-bottom))] md:bottom-6 left-1/2 -translate-x-1/2 z-50 w-[90%] max-sm:max-w-[320px] max-w-sm">
             <div className="bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md rounded-2xl shadow-lg border border-gray-100 dark:border-zinc-800 p-2 flex justify-around items-center transition-all duration-300">
                 <Button
                     variant="ghost"

--- a/frontend/components/ui/scroll-to-top-button.tsx
+++ b/frontend/components/ui/scroll-to-top-button.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ArrowUp } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
-export function ScrollToTopButton() {
+export function ScrollToTopButton({ hasBottomBar = false }: { hasBottomBar?: boolean }) {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
@@ -21,7 +22,10 @@ export function ScrollToTopButton() {
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.8 }}
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="fixed bottom-6 right-6 z-40 rounded-full p-3 shadow-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          className={cn(
+            "fixed right-6 z-40 rounded-full p-3 shadow-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors",
+            hasBottomBar ? "bottom-[calc(5.5rem+env(safe-area-inset-bottom))] md:bottom-6" : "bottom-6"
+          )}
           aria-label="ページトップへ戻る"
         >
           <ArrowUp className="h-5 w-5" />


### PR DESCRIPTION
## 概要
ダッシュボード画面において、モバイル表示時にボトムナビゲーションバーとクイックアクションバー（およびトップへ戻るボタン）が重なってしまう問題を修正しました。

## 変更内容
- `QuickActionBar`: モバイル表示時、ボトムバー（h-16）とセーフエリアを考慮した位置 (`bottom-[calc(5.5rem+env(safe-area-inset-bottom))]`) に配置されるよう修正
- `ScrollToTopButton`: `hasBottomBar` プロップを追加し、ボトムバーが存在する場合に位置を自動調整するよう変更
- `DashboardLayout`: `born` 状態（ボトムバーの表示条件）を `ScrollToTopButton` に伝播
- `globals.css`: Tailwind v4 の `@utility` を使用して `pb-safe`、`pt-safe` などのセーフエリアユーティリティを定義

## 確認事項
- [x] `sh scripts/verify_all.sh` がパスすること
- [x] モバイル表示（疑似環境）で重なりが解消されていること（コード上での計算による確認）

Closes #282
