### PR TITLE
feat: Google AdSense審査通過のためにLPとサイト全体を改善

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,21 +1,147 @@
-"use client"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { ArrowLeft, Heart, Shield, Zap, Users } from "lucide-react"
+import type { Metadata } from "next"
 
-import { useUser } from "@/hooks/useAuth"
-import { LandingContent } from "@/components/landing/LandingContent"
+export const metadata: Metadata = {
+    title: "Baby App について",
+    description: "Baby Appは、育児をもっと楽しく・家族で共有できるようにするために作られた育児記録アプリです。開発の想いとサービス情報をご紹介します。",
+}
 
 export default function AboutPage() {
-    const { user, isLoading } = useUser()
+    return (
+        <div className="min-h-screen bg-slate-50 py-20 px-4">
+            <div className="max-w-3xl mx-auto space-y-12">
+                <Link href="/">
+                    <Button variant="ghost" className="gap-2 text-slate-600">
+                        <ArrowLeft className="h-4 w-4" />
+                        トップページに戻る
+                    </Button>
+                </Link>
 
-    if (isLoading) {
-        return (
-            <div className="min-h-screen bg-slate-50 flex items-center justify-center">
-                <div className="animate-pulse flex flex-col items-center gap-4">
-                    <div className="h-12 w-12 bg-indigo-100 rounded-full" />
-                    <div className="h-4 w-24 bg-indigo-50 rounded" />
+                {/* メインカード */}
+                <div className="bg-white rounded-3xl p-8 md:p-12 shadow-sm space-y-10 text-slate-900">
+                    <div className="space-y-2">
+                        <h1 className="text-3xl font-bold tracking-tight">Baby App について</h1>
+                        <p className="text-indigo-600 font-medium">家族の育児を、もっとつながりのある時間に。</p>
+                    </div>
+
+                    {/* コンセプト紹介 */}
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">サービスの想い</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            赤ちゃんが生まれると、育児は24時間365日の連続した仕事になります。授乳のタイミング、最後のおむつ交換から何時間が経ったか、今日はどれだけ眠れたか——これらを一人で把握し続けることは、とても大変なことです。
+                        </p>
+                        <p className="text-slate-600 leading-relaxed">
+                            Baby Appは、「育児を一人で抱え込まず、家族全員で分かち合える」ようにするために作られました。
+                            パパが記録すれば、ママが確認できる。おじいちゃん・おばあちゃんも一緒に成長を見守れる。そんな「つながりのある育児」を実現するのが、Baby Appのミッションです。
+                        </p>
+                    </section>
+
+                    {/* 特徴 */}
+                    <section className="space-y-6">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">Baby App の特徴</h2>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                            <div className="flex gap-4 items-start">
+                                <div className="w-10 h-10 rounded-xl bg-rose-50 flex items-center justify-center shrink-0">
+                                    <Users className="h-5 w-5 text-rose-500" />
+                                </div>
+                                <div>
+                                    <h3 className="font-bold text-slate-800 mb-1">招待制のプライバシー保護</h3>
+                                    <p className="text-slate-600 text-sm leading-relaxed">招待コードを知っている家族だけがアクセス可能。大切な育児記録を安全に守ります。</p>
+                                </div>
+                            </div>
+                            <div className="flex gap-4 items-start">
+                                <div className="w-10 h-10 rounded-xl bg-indigo-50 flex items-center justify-center shrink-0">
+                                    <Zap className="h-5 w-5 text-indigo-500" />
+                                </div>
+                                <div>
+                                    <h3 className="font-bold text-slate-800 mb-1">片手で操作できるUI</h3>
+                                    <p className="text-slate-600 text-sm leading-relaxed">赤ちゃんを抱っこしながらでも、片手でサッと記録できるシンプルな設計です。</p>
+                                </div>
+                            </div>
+                            <div className="flex gap-4 items-start">
+                                <div className="w-10 h-10 rounded-xl bg-emerald-50 flex items-center justify-center shrink-0">
+                                    <Shield className="h-5 w-5 text-emerald-500" />
+                                </div>
+                                <div>
+                                    <h3 className="font-bold text-slate-800 mb-1">AIによる育児サポート</h3>
+                                    <p className="text-slate-600 text-sm leading-relaxed">毎日の記録をAIが分析し、授乳リズムや睡眠パターンをわかりやすくサマリー。</p>
+                                </div>
+                            </div>
+                            <div className="flex gap-4 items-start">
+                                <div className="w-10 h-10 rounded-xl bg-amber-50 flex items-center justify-center shrink-0">
+                                    <Heart className="h-5 w-5 text-amber-500" />
+                                </div>
+                                <div>
+                                    <h3 className="font-bold text-slate-800 mb-1">役割に応じたアクセス管理</h3>
+                                    <p className="text-slate-600 text-sm leading-relaxed">管理者・メンバー・閲覧者の3段階ロールで、祖父母など遠くの家族も安心して招待できます。</p>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* 機能一覧 */}
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">主な機能</h2>
+                        <div className="grid grid-cols-2 gap-3">
+                            {[
+                                { icon: "🤱", label: "授乳・ミルク記録" },
+                                { icon: "💤", label: "睡眠記録" },
+                                { icon: "💩", label: "おむつ・健康記録" },
+                                { icon: "📈", label: "成長グラフ（体重・身長）" },
+                                { icon: "🤖", label: "AIによる育児サマリー" },
+                                { icon: "💬", label: "家族への応援コメント" },
+                                { icon: "🔔", label: "プッシュ通知" },
+                                { icon: "👨‍👩‍👧", label: "複数メンバー招待" },
+                            ].map((item) => (
+                                <div key={item.label} className="flex items-center gap-3 bg-slate-50 rounded-xl p-3">
+                                    <span className="text-2xl">{item.icon}</span>
+                                    <span className="text-sm font-medium text-slate-700">{item.label}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </section>
+
+                    {/* サービス情報 */}
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">サービス情報</h2>
+                        <div className="space-y-3 text-slate-600">
+                            <div className="flex flex-col sm:flex-row sm:gap-4">
+                                <span className="font-medium text-slate-800 w-32 shrink-0">サービス名</span>
+                                <span>Baby App</span>
+                            </div>
+                            <div className="flex flex-col sm:flex-row sm:gap-4">
+                                <span className="font-medium text-slate-800 w-32 shrink-0">運営者</span>
+                                <span>Baby App 運営者</span>
+                            </div>
+                            <div className="flex flex-col sm:flex-row sm:gap-4">
+                                <span className="font-medium text-slate-800 w-32 shrink-0">サービス開始</span>
+                                <span>2026年</span>
+                            </div>
+                            <div className="flex flex-col sm:flex-row sm:gap-4">
+                                <span className="font-medium text-slate-800 w-32 shrink-0">対応環境</span>
+                                <span>モダンブラウザ（Chrome, Safari, Firefox）/ iOS・Android（PWA対応）</span>
+                            </div>
+                            <div className="flex flex-col sm:flex-row sm:gap-4">
+                                <span className="font-medium text-slate-800 w-32 shrink-0">利用料金</span>
+                                <span>完全無料（クレジットカード登録不要）</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* CTA */}
+                    <div className="bg-indigo-50 rounded-2xl p-6 text-center space-y-4">
+                        <p className="font-bold text-slate-800">Baby Appを使ってみませんか？</p>
+                        <p className="text-slate-600 text-sm">今すぐ無料でアカウントを作成できます。</p>
+                        <Link href="/register">
+                            <Button className="bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl px-8">
+                                無料で始める
+                            </Button>
+                        </Link>
+                    </div>
                 </div>
             </div>
-        )
-    }
-
-    return <LandingContent isLoggedIn={!!user} />
+        </div>
+    )
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -19,8 +19,12 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Baby App",
-  description: "家族で共有する育児記録アプリ",
+  title: {
+    default: "Baby App - 家族で共有する育児記録アプリ",
+    template: "%s | Baby App",
+  },
+  description: "授乳・睡眠・おむつ記録をリアルタイムで家族共有。AIによる育児サマリーで赤ちゃんの成長をもっと身近に。招待制のプライベートな育児記録アプリです。",
+  keywords: ["育児記録", "授乳記録", "睡眠記録", "おむつ記録", "家族共有", "赤ちゃん", "育児アプリ"],
   manifest: "/manifest.json",
   appleWebApp: {
     capable: true,
@@ -30,6 +34,12 @@ export const metadata: Metadata = {
   icons: {
     icon: "/favicon.svg",
     apple: "/icons/icon-192x192.svg",
+  },
+  openGraph: {
+    title: "Baby App - 家族で共有する育児記録アプリ",
+    description: "授乳・睡眠・おむつ記録をリアルタイムで家族共有。AIサマリーで育児をもっと楽しく。",
+    locale: "ja_JP",
+    type: "website",
   },
 };
 
@@ -47,7 +57,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="ja" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft } from "lucide-react"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+    title: "プライバシーポリシー",
+    description: "Baby App のプライバシーポリシーです。個人情報の取り扱いについて説明します。",
+}
 
 export default function PrivacyPage() {
     return (
@@ -12,40 +18,151 @@ export default function PrivacyPage() {
                         トップページに戻る
                     </Button>
                 </Link>
-                
-                <div className="bg-white rounded-3xl p-8 md:p-12 shadow-sm space-y-8 text-slate-900">
-                    <h1 className="text-3xl font-bold tracking-tight">プライバシーポリシー</h1>
-                    
+
+                <div className="bg-white rounded-3xl p-8 md:p-12 shadow-sm space-y-10 text-slate-900">
+                    <div className="space-y-2">
+                        <h1 className="text-3xl font-bold tracking-tight">プライバシーポリシー</h1>
+                        <p className="text-slate-500 text-sm">最終更新日: 2026年2月23日</p>
+                    </div>
+
+                    <p className="text-slate-600 leading-relaxed">
+                        Baby App運営者（以下「当方」）は、Baby App（以下「本サービス」）における利用者の個人情報の取り扱いについて、以下のとおりプライバシーポリシー（以下「本ポリシー」）を定めます。
+                    </p>
+
                     <section className="space-y-4">
-                        <h2 className="text-xl font-bold">1. 収集する情報</h2>
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">1. 運営者情報</h2>
                         <p className="text-slate-600 leading-relaxed">
-                            当アプリでは、赤ちゃんの育児記録（授乳、睡眠、おむつ、成長記録等）および、
-                            家族アカウント作成のためのメールアドレス、プロフィール情報を収集します。
+                            サービス名: Baby App<br />
+                            運営者: Baby App 運営者<br />
+                            お問い合わせ: <a href="https://baby-app-next.onrender.com/" className="text-indigo-600 underline">サービストップページ</a>よりご確認ください。
                         </p>
                     </section>
 
                     <section className="space-y-4">
-                        <h2 className="text-xl font-bold">2. 利用目的</h2>
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">2. 収集する個人情報</h2>
                         <p className="text-slate-600 leading-relaxed">
-                            収集した情報は、以下の目的で利用します：
+                            本サービスでは、以下の情報を収集する場合があります。
                         </p>
-                        <ul className="list-disc list-inside text-slate-600 space-y-2">
-                            <li>家族間での育児情報の共有</li>
-                            <li>AIによる育児アドバイスの生成</li>
-                            <li>サービス改善および新機能の開発</li>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li><strong>アカウント情報:</strong> メールアドレス、パスワード（ハッシュ化して保存）、表示名</li>
+                            <li><strong>育児記録データ:</strong> 授乳・ミルク記録、睡眠記録、おむつ記録、成長記録（体重・身長）、健康状態メモ</li>
+                            <li><strong>赤ちゃん情報:</strong> 赤ちゃんの名前、生年月日</li>
+                            <li><strong>利用ログ:</strong> アクセス日時、利用機能、エラーログ（Sentryによる収集）</li>
+                            <li><strong>デバイス情報:</strong> プッシュ通知を利用する場合の通知トークン</li>
                         </ul>
                     </section>
 
                     <section className="space-y-4">
-                        <h2 className="text-xl font-bold">3. データの管理</h2>
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">3. 利用目的</h2>
                         <p className="text-slate-600 leading-relaxed">
-                            お客様のデータは厳重に管理され、招待された家族メンバー以外に公開されることはありません。
+                            収集した情報は、以下の目的でのみ利用します。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>本サービスの提供・運営・維持・改善</li>
+                            <li>家族間での育児情報のリアルタイム共有機能の実現</li>
+                            <li>AIによる育児サマリー・アドバイスの生成</li>
+                            <li>プッシュ通知の配信</li>
+                            <li>不正アクセスや利用規約違反の検知・対応</li>
+                            <li>障害・バグの検知・修正（エラーログの分析）</li>
+                        </ul>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">4. 第三者への提供</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            当方は、以下のいずれかに該当する場合を除き、収集した個人情報を第三者に提供することはありません。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>利用者ご自身が同意された場合</li>
+                            <li>法令に基づく開示要請があった場合</li>
+                            <li>人の生命・身体・財産の保護のために必要で、本人の同意を得ることが困難な場合</li>
+                        </ul>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">5. 委託先・外部サービスの利用</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            本サービスでは、以下の外部サービスを利用しており、利用目的の範囲内でデータを共有する場合があります。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li><strong>Neon（データベース）:</strong> 育児記録等のデータ保存</li>
+                            <li><strong>Render（ホスティング）:</strong> サービスの稼働・配信</li>
+                            <li><strong>Sentry（エラー監視）:</strong> バグ・エラーの検知と修正</li>
+                            <li><strong>Google Gemini API（AI）:</strong> 育児サマリー生成時の解析</li>
+                        </ul>
+                        <p className="text-slate-600 leading-relaxed text-sm mt-2">
+                            ※ AIサマリー生成時、育児記録の一部データを含むプロンプトが送信される場合があります。個人を特定する情報は含みません。
                         </p>
                     </section>
 
-                    <footer className="pt-8 border-t border-slate-100 text-sm text-slate-400">
-                        最終更新日: 2026年2月21日
-                    </footer>
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">6. Cookie・ローカルストレージの利用</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            本サービスでは、以下の目的でCookieおよびブラウザのローカルストレージを利用しています。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>ログイン状態の維持（HttpOnlyセッションCookie）</li>
+                            <li>アプリの設定保存（ローカルストレージ）</li>
+                        </ul>
+                        <p className="text-slate-600 leading-relaxed">
+                            ブラウザの設定からCookieを無効にすることができますが、その場合、一部機能が正常に動作しない場合があります。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">7. セキュリティ対策</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            当方は、収集した個人情報の漏洩・紛失・改ざんを防ぐため、以下のセキュリティ対策を実施しています。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>通信のSSL/TLS暗号化</li>
+                            <li>パスワードのハッシュ化（Bcrypt）</li>
+                            <li>HttpOnly・SameSite属性付きセッションCookieの使用</li>
+                            <li>招待制による家族以外のアクセス遮断</li>
+                            <li>ロールベースアクセス制御（管理者・メンバー・閲覧者）</li>
+                        </ul>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">8. データの保管期間</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            収集した個人情報は、アカウントが有効である期間中保管します。アカウントを削除した場合、関連する個人情報も速やかに削除されます。ただし、法令上の保存義務が生じる場合はこの限りではありません。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">9. 利用者の権利</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            利用者は、自身の個人情報について以下の権利を有します。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>個人情報の開示請求</li>
+                            <li>個人情報の訂正・追加・削除請求</li>
+                            <li>個人情報の利用停止・削除請求</li>
+                            <li>アカウントの削除（アプリ内設定から実行可能）</li>
+                        </ul>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">10. 免責事項</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            本サービスは、利用者が入力した情報の正確性・完全性について責任を負いません。また、利用者自身による情報の漏洩（招待コードの第三者共有等）について、当方は責任を負いかねます。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">11. プライバシーポリシーの改訂</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            本ポリシーは、法令の改正やサービスの変更に伴い、予告なく改訂される場合があります。改訂後の内容は、本ページへの掲載をもって通知に代えるものとします。重要な変更については、アプリ内で通知します。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">12. 準拠法・管轄</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            本ポリシーは日本法に準拠し、本ポリシーに関する一切の紛争は、東京地方裁判所を第一審の専属的合意管轄裁判所とします。
+                        </p>
+                    </section>
                 </div>
             </div>
         </div>

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft } from "lucide-react"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+    title: "利用規約",
+    description: "Baby App の利用規約です。サービスを利用するにあたってのルールと条件をご確認ください。",
+}
 
 export default function TermsPage() {
     return (
@@ -12,38 +18,147 @@ export default function TermsPage() {
                         トップページに戻る
                     </Button>
                 </Link>
-                
-                <div className="bg-white rounded-3xl p-8 md:p-12 shadow-sm space-y-8 text-slate-900">
-                    <h1 className="text-3xl font-bold tracking-tight">利用規約</h1>
-                    
+
+                <div className="bg-white rounded-3xl p-8 md:p-12 shadow-sm space-y-10 text-slate-900">
+                    <div className="space-y-2">
+                        <h1 className="text-3xl font-bold tracking-tight">利用規約</h1>
+                        <p className="text-slate-500 text-sm">最終更新日: 2026年2月23日</p>
+                    </div>
+
+                    <p className="text-slate-600 leading-relaxed">
+                        この利用規約（以下「本規約」）は、Baby App運営者（以下「当方」）が提供するBaby App（以下「本サービス」）の利用条件を定めるものです。本サービスを利用するすべての方（以下「利用者」）は、本規約に同意した上でご利用ください。
+                    </p>
+
                     <section className="space-y-4">
-                        <h2 className="text-xl font-bold">1. サービスの利用</h2>
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">1. 総則</h2>
                         <p className="text-slate-600 leading-relaxed">
-                            本アプリは、家族間での育児情報の共有を目的として提供されます。
-                            利用者は、自らの責任において本サービスを利用するものとします。
+                            本規約は、本サービスの利用に関する当方と利用者との間の権利義務関係を定めることを目的とします。利用者が本サービスを利用した時点で、本規約に同意したものとみなします。
                         </p>
                     </section>
 
                     <section className="space-y-4">
-                        <h2 className="text-xl font-bold">2. アカウント管理</h2>
-                        <p className="text-slate-600 leading-relaxed">
-                            利用者は、自らのログイン情報を厳重に管理するものとします。
-                            家族メンバー以外への不用意な招待コードの公開は控えてください。
-                        </p>
-                    </section>
-
-                    <section className="space-y-4">
-                        <h2 className="text-xl font-bold">3. 禁止事項</h2>
-                        <ul className="list-disc list-inside text-slate-600 space-y-2">
-                            <li>法令または公序良俗に反する行為</li>
-                            <li>本サービスの運営を妨害する行為</li>
-                            <li>他者の個人情報を不正に収集・利用する行為</li>
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">2. 定義</h2>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li><strong>「本サービス」:</strong> 当方が提供する育児記録共有アプリ「Baby App」およびその関連サービス。</li>
+                            <li><strong>「利用者」:</strong> 本サービスのアカウントを作成・利用するすべての個人。</li>
+                            <li><strong>「ファミリー」:</strong> 本サービス上の招待制グループ単位。</li>
+                            <li><strong>「コンテンツ」:</strong> 利用者が本サービスに登録・投稿するすべての情報（育児記録、コメント等）。</li>
                         </ul>
                     </section>
 
-                    <footer className="pt-8 border-t border-slate-100 text-sm text-slate-400">
-                        最終更新日: 2026年2月21日
-                    </footer>
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">3. 利用条件</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            本サービスは、以下の条件を満たす方のみご利用いただけます。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>本規約に同意された方</li>
+                            <li>13歳以上の方（13歳未満の方は保護者の同意が必要です）</li>
+                            <li>過去に本規約違反により利用停止となっていない方</li>
+                        </ul>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">4. アカウント管理</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            利用者は、以下の事項を遵守してください。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>登録情報（メールアドレス・パスワード等）を正確かつ最新の状態に保つこと。</li>
+                            <li>パスワードを第三者と共有しないこと。</li>
+                            <li>招待コードを家族以外の第三者に不用意に共有しないこと。</li>
+                            <li>アカウントが不正に利用された場合、直ちに当方に通知すること。</li>
+                        </ul>
+                        <p className="text-slate-600 leading-relaxed">
+                            アカウントの管理は利用者ご自身の責任で行っていただきます。アカウントの不正利用によって生じた損害について、当方は責任を負いません。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">5. 禁止事項</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            利用者は、本サービスの利用にあたり、以下の行為を行ってはなりません。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>法令または公序良俗に違反する行為</li>
+                            <li>犯罪に関連する行為</li>
+                            <li>本サービスのサーバー・ネットワークへの不正アクセス</li>
+                            <li>本サービスの運営を妨害する行為</li>
+                            <li>他の利用者への嫌がらせ・誹謗中傷</li>
+                            <li>第三者の個人情報を無断で収集・利用する行為</li>
+                            <li>当方の許可なく本サービスを商業目的で利用する行為</li>
+                            <li>リバースエンジニアリング・逆コンパイル等</li>
+                            <li>本サービスに含まれるすべてのコンテンツを無断で複製・転用する行為</li>
+                            <li>その他当方が不適切と判断する行為</li>
+                        </ul>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">6. コンテンツの扱い</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            利用者が本サービスに登録したコンテンツの権利は、引き続き利用者に帰属します。ただし、利用者はサービス提供に必要な範囲内で、当方がコンテンツを使用することを許諾するものとします（AI分析・サマリー生成等）。
+                        </p>
+                        <p className="text-slate-600 leading-relaxed">
+                            利用者は、自身が登録するコンテンツが第三者の権利（著作権・肖像権等）を侵害しないことについて保証するものとします。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">7. 知的財産権</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            本サービスのデザイン・ロゴ・ソフトウェア・文章等の知的財産権は、当方または正当な権利者に帰属します。利用者は、本規約で認められた範囲を超えて、これらを利用することはできません。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">8. 免責事項</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            当方は、以下について責任を負いません。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>本サービスの中断・停止・廃止により生じた損害</li>
+                            <li>利用者が登録したコンテンツの正確性・完全性</li>
+                            <li>AIサマリー・アドバイスの医学的正確性（本サービスは医療アドバイスを提供するものではありません）</li>
+                            <li>利用者間または利用者と第三者の間で生じたトラブル</li>
+                            <li>第三者による不正アクセス・情報漏洩</li>
+                        </ul>
+                        <p className="text-slate-600 leading-relaxed text-sm bg-amber-50 p-3 rounded-lg border border-amber-100">
+                            ⚠️ 本サービスが提供するAIによる育児アドバイスは参考情報です。お子様の健康に関するご判断は、必ず医師・専門家にご相談ください。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">9. サービスの変更・停止・終了</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            当方は、以下の場合にサービスを変更・一時停止・終了することがあります。運営上やむを得ない場合を除き、事前にお知らせします。
+                        </p>
+                        <ul className="list-disc list-inside text-slate-600 space-y-2 pl-2">
+                            <li>システムのメンテナンス・更新時</li>
+                            <li>天災・インフラ障害等の不可抗力が発生した場合</li>
+                            <li>運営継続が困難と当方が判断した場合</li>
+                        </ul>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">10. アカウントの停止・削除</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            利用者が本規約に違反した場合、当方は予告なくアカウントを停止または削除することがあります。また、利用者はいつでも設定画面からアカウントを削除できます。アカウント削除後のデータ復元はできません。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">11. 規約の改訂</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            当方は、必要に応じて本規約を改訂することがあります。重要な変更は事前にアプリ内でお知らせします。改訂後にサービスを継続して利用した場合、新しい利用規約に同意したものとみなします。
+                        </p>
+                    </section>
+
+                    <section className="space-y-4">
+                        <h2 className="text-xl font-bold border-b border-slate-100 pb-2">12. 準拠法・管轄</h2>
+                        <p className="text-slate-600 leading-relaxed">
+                            本規約は日本法に準拠します。本サービスに関する紛争は、東京地方裁判所を第一審の専属的合意管轄裁判所とします。
+                        </p>
+                    </section>
                 </div>
             </div>
         </div>

--- a/frontend/components/landing/LandingContent.tsx
+++ b/frontend/components/landing/LandingContent.tsx
@@ -2,10 +2,11 @@
 
 import { motion } from "framer-motion"
 import Link from "next/link"
-import { Baby, Smile, MessageSquare } from "lucide-react"
+import { Baby, Smile, MessageSquare, ChevronDown, ChevronUp } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
+import { useState } from "react"
 
 const FEATURES = [
     {
@@ -37,6 +38,78 @@ const DETAILED_FEATURES = [
     { label: "プッシュ通知", icon: "🔔", color: "text-purple-500" }
 ]
 
+const HOW_TO_STEPS = [
+    {
+        step: "01",
+        title: "アカウントを作成",
+        description: "メールアドレスだけで簡単登録。クレジットカードは不要、完全無料で始められます。",
+        icon: "📝",
+    },
+    {
+        step: "02",
+        title: "家族を招待",
+        description: "発行された招待コードをパートナーや祖父母に共有。家族全員でつながりましょう。",
+        icon: "👨‍👩‍👧",
+    },
+    {
+        step: "03",
+        title: "一緒に記録・共有",
+        description: "授乳、睡眠、おむつをリアルタイムで記録。全員がいつでも最新状態を確認できます。",
+        icon: "📱",
+    },
+]
+
+const FAQ_ITEMS = [
+    {
+        question: "利用料金はかかりますか？",
+        answer: "完全無料でご利用いただけます。クレジットカードの登録も不要です。",
+    },
+    {
+        question: "何人まで家族を招待できますか？",
+        answer: "複数名を招待できます。パートナー、祖父母など家族全員でご利用ください。",
+    },
+    {
+        question: "iPhoneやAndroidでも使えますか？",
+        answer: "はい。モバイルブラウザから利用できるPWA（プログレッシブウェブアプリ）に対応しています。ホーム画面に追加するとアプリのように使えます。",
+    },
+    {
+        question: "データは安全に管理されますか？",
+        answer: "招待コードを知っている家族だけがアクセスできる招待制を採用しています。通信はSSL暗号化され、パスワードはハッシュ化して保管します。",
+    },
+    {
+        question: "AIサマリーは有料機能ですか？",
+        answer: "いいえ。AIによる育児サマリー機能も含めてすべて無料でご利用いただけます。",
+    },
+    {
+        question: "複数の赤ちゃんを登録できますか？",
+        answer: "はい。きょうだいがいるご家庭でも、複数の赤ちゃんを登録して別々に記録を管理できます。",
+    },
+]
+
+function FaqItem({ question, answer }: { question: string; answer: string }) {
+    const [open, setOpen] = useState(false)
+    return (
+        <div className="border border-slate-100 rounded-2xl overflow-hidden">
+            <button
+                onClick={() => setOpen(!open)}
+                className="w-full flex items-center justify-between p-6 text-left hover:bg-slate-50 transition-colors"
+            >
+                <span className="font-bold text-slate-800">{question}</span>
+                {open ? (
+                    <ChevronUp className="h-5 w-5 text-slate-400 shrink-0" />
+                ) : (
+                    <ChevronDown className="h-5 w-5 text-slate-400 shrink-0" />
+                )}
+            </button>
+            {open && (
+                <div className="px-6 pb-6 text-slate-600 leading-relaxed text-sm border-t border-slate-100 pt-4">
+                    {answer}
+                </div>
+            )}
+        </div>
+    )
+}
+
 export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean }) {
     return (
         <div className="min-h-screen bg-slate-50 text-slate-900 font-sans overflow-x-hidden">
@@ -49,6 +122,8 @@ export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean })
                     <nav className="hidden md:flex items-center gap-8">
                         <a href="#features" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">特徴</a>
                         <a href="#details" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">機能</a>
+                        <a href="#howto" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">使い方</a>
+                        <a href="#faq" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">よくある質問</a>
                     </nav>
                     <div>
                         {isLoggedIn ? (
@@ -68,7 +143,7 @@ export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean })
                 {/* Hero Section */}
                 <section className="relative px-4 py-20 lg:py-32 overflow-hidden">
                     <div className="max-w-7xl mx-auto grid lg:grid-cols-2 gap-12 items-center">
-                        <motion.div 
+                        <motion.div
                             initial={{ opacity: 0, x: -20 }}
                             animate={{ opacity: 1, x: 0 }}
                             transition={{ duration: 0.6 }}
@@ -93,10 +168,10 @@ export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean })
                                     <>
                                         <div className="flex flex-col gap-2 w-full sm:w-auto items-center sm:items-start">
                                             <Link href="/register" className="w-full sm:w-auto">
-                                            <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:scale-105">
-                                                今すぐ無料で始める
-                                            </Button>
-                                        </Link>
+                                                <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:scale-105">
+                                                    今すぐ無料で始める
+                                                </Button>
+                                            </Link>
                                             <p className="text-xs text-slate-500 font-medium">
                                                 クレジットカード登録不要・完全無料
                                             </p>
@@ -110,7 +185,7 @@ export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean })
                                 )}
                             </div>
                         </motion.div>
-                        <motion.div 
+                        <motion.div
                             initial={{ opacity: 0, scale: 0.9 }}
                             animate={{ opacity: 1, scale: 1 }}
                             transition={{ duration: 0.8, delay: 0.2 }}
@@ -118,8 +193,8 @@ export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean })
                         >
                             <div className="relative z-10 bg-slate-200 rounded-[2rem] shadow-2xl border-8 border-slate-100 overflow-hidden aspect-[9/19] max-w-[300px] mx-auto">
                                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                                <img 
-                                    src="/screenshots/dashboard.png" 
+                                <img
+                                    src="/screenshots/dashboard.png"
                                     alt="育児記録ダッシュボードの画面。授乳や睡眠の記録が一目でわかり、AIによる分析も表示されます"
                                     className="w-full h-full object-cover"
                                 />
@@ -139,7 +214,7 @@ export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean })
                         </div>
                         <div className="grid md:grid-cols-3 gap-8">
                             {FEATURES.map((feature, i) => (
-                                <motion.div 
+                                <motion.div
                                     key={i}
                                     initial={{ opacity: 0, y: 20 }}
                                     whileInView={{ opacity: 1, y: 0 }}
@@ -183,8 +258,48 @@ export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean })
                     </div>
                 </section>
 
+                {/* How to Section */}
+                <section id="howto" className="px-4 py-24 bg-white">
+                    <div className="max-w-7xl mx-auto space-y-16">
+                        <div className="text-center space-y-4">
+                            <h2 className="text-3xl font-bold tracking-tight">3ステップで始められる</h2>
+                            <p className="text-slate-500">難しい設定は不要。すぐに家族と育児を共有できます。</p>
+                        </div>
+                        <div className="grid md:grid-cols-3 gap-8">
+                            {HOW_TO_STEPS.map((step, i) => (
+                                <motion.div
+                                    key={i}
+                                    initial={{ opacity: 0, y: 20 }}
+                                    whileInView={{ opacity: 1, y: 0 }}
+                                    viewport={{ once: true }}
+                                    transition={{ delay: i * 0.15 }}
+                                    className="relative text-center space-y-4"
+                                >
+                                    <div className="relative mx-auto w-20 h-20 rounded-full bg-indigo-50 flex items-center justify-center text-4xl">
+                                        {step.icon}
+                                        <span className="absolute -top-2 -right-2 w-8 h-8 rounded-full bg-indigo-600 text-white text-xs font-bold flex items-center justify-center">
+                                            {step.step}
+                                        </span>
+                                    </div>
+                                    <h3 className="text-lg font-bold">{step.title}</h3>
+                                    <p className="text-slate-600 text-sm leading-relaxed">{step.description}</p>
+                                </motion.div>
+                            ))}
+                        </div>
+                        {!isLoggedIn && (
+                            <div className="text-center">
+                                <Link href="/register">
+                                    <Button className="h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:scale-105">
+                                        今すぐ無料で始める
+                                    </Button>
+                                </Link>
+                            </div>
+                        )}
+                    </div>
+                </section>
+
                 {/* Trust Section */}
-                <section className="px-4 py-24 bg-white">
+                <section className="px-4 py-24 bg-slate-50">
                     <div className="max-w-3xl mx-auto text-center space-y-8">
                         <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-50 text-emerald-600 text-sm font-bold">
                             🔒 家族だけのプライベートな空間
@@ -194,6 +309,33 @@ export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean })
                             招待コードを知っている家族メンバーだけがアクセス可能。
                             赤ちゃんの成長記録は厳重に保護され、いつでも家族全員で振り返ることができます。
                         </p>
+                        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+                            {[
+                                { icon: "🔐", label: "SSLで通信を暗号化" },
+                                { icon: "👨‍👩‍👧", label: "招待制のプライベート空間" },
+                                { icon: "🛡️", label: "ロールベースのアクセス管理" },
+                            ].map((item) => (
+                                <div key={item.label} className="bg-white rounded-2xl p-4 flex flex-col items-center gap-2 shadow-sm">
+                                    <span className="text-2xl">{item.icon}</span>
+                                    <span className="font-medium text-slate-700 text-center">{item.label}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </section>
+
+                {/* FAQ Section */}
+                <section id="faq" className="px-4 py-24 bg-white">
+                    <div className="max-w-3xl mx-auto space-y-12">
+                        <div className="text-center space-y-4">
+                            <h2 className="text-3xl font-bold tracking-tight">よくある質問</h2>
+                            <p className="text-slate-500">ご不明な点はこちらをご覧ください。</p>
+                        </div>
+                        <div className="space-y-4">
+                            {FAQ_ITEMS.map((item, i) => (
+                                <FaqItem key={i} question={item.question} answer={item.answer} />
+                            ))}
+                        </div>
                     </div>
                 </section>
 
@@ -226,14 +368,34 @@ export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean })
             </main>
 
             <footer className="px-4 py-12 bg-white border-t border-slate-100">
-                <div className="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                    <div className="text-indigo-600 font-bold text-lg">Baby App</div>
-                    <div className="text-slate-400 text-sm">
-                        &copy; 2026 Baby App. All rights reserved.
+                <div className="max-w-7xl mx-auto space-y-8">
+                    <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-8">
+                        <div className="space-y-2">
+                            <div className="text-indigo-600 font-bold text-lg">Baby App</div>
+                            <p className="text-slate-400 text-sm max-w-xs">家族で共有する育児記録アプリ。授乳・睡眠・おむつをリアルタイムで記録・共有。</p>
+                        </div>
+                        <div className="grid grid-cols-2 gap-x-12 gap-y-2 text-sm">
+                            <div className="space-y-2">
+                                <p className="font-bold text-slate-700">サービス</p>
+                                <div className="space-y-1">
+                                    <a href="#features" className="block text-slate-500 hover:text-indigo-600 transition-colors">特徴</a>
+                                    <a href="#details" className="block text-slate-500 hover:text-indigo-600 transition-colors">機能一覧</a>
+                                    <a href="#howto" className="block text-slate-500 hover:text-indigo-600 transition-colors">使い方</a>
+                                    <a href="#faq" className="block text-slate-500 hover:text-indigo-600 transition-colors">よくある質問</a>
+                                </div>
+                            </div>
+                            <div className="space-y-2">
+                                <p className="font-bold text-slate-700">情報</p>
+                                <div className="space-y-1">
+                                    <Link href="/about" className="block text-slate-500 hover:text-indigo-600 transition-colors">運営者情報</Link>
+                                    <Link href="/privacy" className="block text-slate-500 hover:text-indigo-600 transition-colors">プライバシーポリシー</Link>
+                                    <Link href="/terms" className="block text-slate-500 hover:text-indigo-600 transition-colors">利用規約</Link>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                    <div className="flex gap-6 text-sm font-medium">
-                        <Link href="/privacy" className="text-slate-500 hover:text-indigo-600 transition-colors">プライバシーポリシー</Link>
-                        <Link href="/terms" className="text-slate-500 hover:text-indigo-600 transition-colors">利用規約</Link>
+                    <div className="border-t border-slate-100 pt-6 text-center text-slate-400 text-sm">
+                        &copy; 2026 Baby App. All rights reserved.
                     </div>
                 </div>
             </footer>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://baby-app-next.onrender.com/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://baby-app-next.onrender.com/</loc>
+    <lastmod>2026-02-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://baby-app-next.onrender.com/about</loc>
+    <lastmod>2026-02-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://baby-app-next.onrender.com/privacy</loc>
+    <lastmod>2026-02-23</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://baby-app-next.onrender.com/terms</loc>
+    <lastmod>2026-02-23</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## 概要

Google AdSense の審査に不合格となったため、審査基準を満たすようにサイト全体を改善しました。

## 変更内容

### 🌐 SEO・クロール基盤
- `html lang` 属性を `en` → `ja` に修正（日本語サイトと一致させる）
- `layout.tsx` のメタデータ（title/description/keywords/OGP）を大幅拡充
- `robots.txt` を新規作成（Googleクローラー向け）
- `sitemap.xml` を新規作成（全公開ページを列挙）

### 📄 法的ページの拡充
- **プライバシーポリシー**: 3節から12節・約2500文字に拡充（個人情報保護法準拠、Cookie・外部サービス・セキュリティ対策等を追記）
- **利用規約**: 3節から12節・約3000文字に拡充（禁止事項・知的財産権・免責事項・準拠法等を追記）

### 🏠 LP・サイト構成の改善
- **About ページ**: LP のまま表示していたものを、独自コンテンツ（サービスの想い・特徴・機能一覧・運営者情報）に刷新
- **LP**: 以下のセクションを追加
  - 「3ステップで始められる」使い方ガイド
  - よくある質問（FAQアコーディオン）
  - セキュリティ信頼セクション（SSL・招待制・RBAC）
- **フッター**: About・FAQ・使い方・プライバシーポリシー・利用規約へのリンクを追加

## 審査改善ポイント

| 問題点 | 改善内容 |
|--------|----------|
| コンテンツ量の不足 | LP に3セクション追加、各法的ページを実質10倍以上に拡充 |
| プライバシーポリシーが不十分 | 12節・個人情報保護法準拠に拡充 |
| 利用規約が不十分 | 12節・免責/知財/準拠法等を追記 |
| 運営者情報ページなし | About ページを独自コンテンツに刷新 |
| html lang が English | `ja` に修正 |
| robots.txt・sitemap.xml なし | 両ファイルを新規作成 |
| メタデータ不足 | 各ページに適切な title/description を設定 |
