### PR TITLE
✍️ Scribe: AI育児日誌生成の仕様書更新（Daily Summary API仕様の実装との同期）

### DIFF
--- a/.specify/specs/ai/ai_daily_summary.md
+++ b/.specify/specs/ai/ai_daily_summary.md
@@ -7,12 +7,36 @@ UI や基本的な CRUD 仕様については `.specify/specs/tracking/daily_dia
 
 ---
 
+## データモデル
+
+### `DailySummary`
+
+AI 生成結果およびユーザー編集内容を保持するモデル。
+
+| カラム名 | 型 | 説明 |
+|---------|----|------|
+| `id` | Integer | PK |
+| `baby_id` | Integer | FK (Babies) |
+| `user_id` | Integer (Nullable) | 生成または最終更新を行ったユーザーの ID |
+| `summary_date` | Date | 日誌の対象日 (JST) |
+| `generated_content` | Text | AI が生成したオリジナルの日誌テキスト（不変） |
+| `edited_content` | Text (Nullable) | ユーザーが手動編集したテキスト。未編集時は Null |
+| `is_edited` | Boolean | ユーザーによる編集が行われたか（`edited_content` が存在するか） |
+| `model_name` | String (Nullable) | 生成に使用したモデル名（例: `gemini-1.5-pro`） |
+| `image_urls` | JSON (Array) | 添付された画像の URL リスト |
+| `created_at` | DateTime | 作成日時 |
+| `updated_at` | DateTime | 更新日時 |
+
+- **ユニーク制約**: `baby_id` + `summary_date`
+
+---
+
 ## 日誌生成プロセス
 
 ### 1. データの集計 (`build_daily_prompt`)
 
 指定した日付の全育児記録を以下の優先順位で抽出し、AI への入力テキストを生成する。
-- **対象データ**: 授乳 (Feeding), 睡眠 (Sleep), おむつ (Diaper), 成長 (Growth), メモ (Note)。
+- **対象データ**: 授乳 (Feeding), 睡眠 (Sleep), おむつ (Diaper), メモ (Note), 成長記録 (Growth)。
 - **時間範囲**: JST 基準の 0:00 〜 23:59。
 
 ### 2. プロンプト構築
@@ -26,8 +50,10 @@ AI に渡すプロンプトは以下の構成とする。
 ### 3. 生成ロジック (`generate_daily_summary`)
 
 - モデル名、パラメーター（Temperature 等）は管理設定に従う。
-- 記録が 0 件の場合は `400 Bad Request`。
-- AI API 障害時は `503 Service Unavailable`。
+- 記録が 0 件の場合は `400 Bad Request`（または `ValueError`）。
+- **安全性フィルター**: 生成結果が安全性フィルター（SAFETY, PROHIBITED_CONTENT 等）によりブロックされた場合、エラーにはせず、以下の定型文を返却する。
+  > "本日の記録を読み込みましたが、内容に健康上の懸念が含まれている可能性があるため、自動生成を控えました。赤ちゃんの状態を直接確認し、必要に応じて専門家にご相談ください。"
+- AI API 障害時（RateLimit 等）は `503 Service Unavailable`。
 
 ---
 
@@ -47,7 +73,8 @@ AI に対し、以下の情報を元に特徴の抽出を依頼する。
 ### 2. 保存
 
 抽出された特徴テキストを `babies` テーブルの `characteristics` カラムに保存する。
-この処理は日誌生成の成功後にバックグラウンド（または同期）で実行される。
+この処理は **日誌生成リクエスト内で同期的** に実行される（API レスポンス返却前に行われる）。
+特徴更新処理自体が失敗しても、日誌生成は成功とみなす（ログ出力のみ）。
 
 ---
 
@@ -61,6 +88,7 @@ AI に対し、以下の情報を元に特徴の抽出を依頼する。
 | `ai_enabled_summary` | 日誌生成機能の有効化 | `true` |
 | `llm_temperature` | 生成時の多様性 | `0.7` |
 | `llm_max_tokens` | 最大出力トークン数 | `600` |
+| `llm_reasoning_effort` | 推論の深さ (Reasoning Effort) | `default` (サポートモデルのみ有効) |
 
 ---
 
@@ -68,8 +96,15 @@ AI に対し、以下の情報を元に特徴の抽出を依頼する。
 
 ### `POST /api/babies/{baby_id}/daily-summary`
 
-**概要**: 指定日の育児日誌を AI 生成（upsert）。
-- **再生成の扱い**: すでに `is_edited=true` のレコードが存在する場合、誤操作防止のため原則として再生成を拒否するか、明示的なフラグが必要。
+**概要**: 指定日の育児日誌を AI 生成（または取得・更新）。
+
+**挙動**:
+1. **未来日付チェック**: 指定日が JST 基準で未来の場合は `400 Bad Request`。
+2. **既存レコードの確認**:
+   - **編集済み (`is_edited=true`) の場合**: 再生成を行わず、既存のレコードをそのまま返す（誤操作防止）。
+   - **未編集 (`is_edited=false`) の場合**: AI 生成を実行し、既存の内容を上書き更新する。
+3. **新規生成**: レコードが存在しない場合は新規作成する。
+4. **通知**: 作成または更新完了時に、家族メンバー（`Family`）に対してアプリ内通知を送信する。
 
 ---
 


### PR DESCRIPTION
- 💡 何を: `.specify/specs/ai/ai_daily_summary.md` を更新。
  - データモデル（`DailySummary`）の定義を追加。
  - 生成対象に「成長記録 (`Growth`)」を追加。
  - 安全性フィルターによるブロック時の挙動を記述。
  - 特徴更新のタイミングを「同期的」に修正。
  - API (`POST`) の再生成スキップロジックと通知機能について記述。
  - `llm_reasoning_effort` 設定の追加。
- 🔍 発見:
  - モデル定義には画像URLや編集履歴のカラムがあるが、仕様書に記載がなかった。
  - 実装では成長記録もAIの入力に使われているが、仕様書から漏れていた。
  - 安全性フィルターのエラーハンドリングや再生成防止ロジックなど、運用の安定性に関わる実装詳細が仕様書に反映されていなかった。
- 🎯 影響:
  - AI機能の挙動（特に再生成やエラー時）に関する開発者の誤解を防ぐ。
  - 将来的なDBスキーマ変更時の影響範囲調査が容易になる。

---
*PR created automatically by Jules for task [10232227773616747280](https://jules.google.com/task/10232227773616747280) started by @eburairu*