### PR TITLE
🧹 Tidy: useQuickRecordフックによるダッシュボードウィジェットの共通化

### DIFF
--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -1,21 +1,17 @@
 "use client"
 import { useMemo, memo } from "react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
-import { usePermissions } from "@/hooks/usePermissions"
 import { api } from "@/lib/api"
 import { formatElapsed, isToday } from "@/lib/ageUtils"
 import { DiaperType } from "@/types/diaper"
-import { useRecordFeedback } from "@/hooks/useRecordFeedback"
 import { WidgetCard } from "./WidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
-import { useAsyncAction } from "@/hooks/useAsyncAction"
 import { WidgetContent } from "./WidgetContent"
 import { WidgetQuickButton } from "./WidgetQuickButton"
+import { useQuickRecord } from "@/hooks/useQuickRecord"
 
 export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isError, mutate, isLoading }: BaseWidgetProps) {
-    const { canWrite } = usePermissions()
-    const { loading, execute } = useAsyncAction()
-    const { triggerFeedback } = useRecordFeedback(babyId)
+    const { canWrite, loading, executeRecord } = useQuickRecord(babyId, { onSuccess: mutate })
 
     const { wetCount, dirtyCount, elapsed } = useMemo(() => {
         const diaperRecords = records?.filter(r => r.type === 'diaper') ?? []
@@ -33,18 +29,15 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
 
         const typeLabel = diaperType === DiaperType.WET ? "おしっこ" : "うんち"
 
-        await execute(async () => {
-            const record = await api.post<{ id: number }>("/diapers/", {
+        await executeRecord(async () => {
+            return api.post<{ id: number }>("/diapers/", {
                 baby_id: Number(babyId),
                 diaper_type: diaperType,
                 change_time: new Date().toISOString(),
             })
-            triggerFeedback("diaper", record.id)
-            if (mutate) mutate()
-            return record
         }, {
-            successMessage: `${typeLabel}を記録しました`,
-            errorMessage: `${typeLabel}の記録に失敗しました`
+            label: typeLabel,
+            feedbackType: "diaper"
         })
     }
 

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -1,20 +1,16 @@
 "use client"
 import { useMemo, memo } from "react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
-import { usePermissions } from "@/hooks/usePermissions"
 import { api } from "@/lib/api"
 import { formatElapsed, isToday } from "@/lib/ageUtils"
-import { useRecordFeedback } from "@/hooks/useRecordFeedback"
 import { WidgetCard } from "./WidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
-import { useAsyncAction } from "@/hooks/useAsyncAction"
 import { WidgetContent } from "./WidgetContent"
 import { WidgetQuickButton } from "./WidgetQuickButton"
+import { useQuickRecord } from "@/hooks/useQuickRecord"
 
 export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isError, mutate, isLoading }: BaseWidgetProps) {
-    const { canWrite } = usePermissions()
-    const { loading, execute } = useAsyncAction()
-    const { triggerFeedback } = useRecordFeedback(babyId)
+    const { canWrite, loading, executeRecord } = useQuickRecord(babyId, { onSuccess: mutate })
 
     const { todayCount, elapsed } = useMemo(() => {
         const feedingRecords = records?.filter(r => r.type === 'feeding') ?? []
@@ -30,18 +26,15 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
 
         const typeLabel = feedingType === "bottle" ? "ミルク" : "母乳"
 
-        await execute(async () => {
-            const record = await api.post<{ id: number }>("/feedings/", {
+        await executeRecord(async () => {
+            return api.post<{ id: number }>("/feedings/", {
                 baby_id: Number(babyId),
                 feeding_type: feedingType.toUpperCase(),
                 feeding_time: new Date().toISOString(),
             })
-            triggerFeedback("feeding", record.id)
-            if (mutate) mutate()
-            return record
         }, {
-            successMessage: `${typeLabel}を記録しました`,
-            errorMessage: `${typeLabel}の記録に失敗しました`
+            label: typeLabel,
+            feedbackType: "feeding"
         })
     }
 

--- a/frontend/hooks/useQuickRecord.ts
+++ b/frontend/hooks/useQuickRecord.ts
@@ -1,0 +1,54 @@
+"use client"
+import { usePermissions } from "@/hooks/usePermissions"
+import { useAsyncAction } from "@/hooks/useAsyncAction"
+import { useRecordFeedback, RecordType } from "@/hooks/useRecordFeedback"
+
+interface UseQuickRecordOptions {
+  onSuccess?: () => void
+}
+
+export function useQuickRecord(babyId: string | number, options: UseQuickRecordOptions = {}) {
+  const { canWrite } = usePermissions()
+  const { loading, execute } = useAsyncAction()
+  const { triggerFeedback } = useRecordFeedback(babyId)
+
+  /**
+   * クイック記録を実行する
+   * @param action 非同期アクション関数 (IDを返す必要がある)
+   * @param config 設定
+   */
+  const executeRecord = async <T extends { id: number }>(
+    action: () => Promise<T>,
+    config: {
+      label?: string // 成功/失敗メッセージ用
+      successMessage?: string
+      errorMessage?: string
+      feedbackType?: RecordType // これがあればフィードバックを実行
+    }
+  ) => {
+    const { label, successMessage, errorMessage, feedbackType } = config
+
+    return execute(async () => {
+      const result = await action()
+
+      if (feedbackType) {
+        triggerFeedback(feedbackType, result.id)
+      }
+
+      if (options.onSuccess) {
+        options.onSuccess()
+      }
+
+      return result
+    }, {
+      successMessage: successMessage ?? (label ? `${label}を記録しました` : undefined),
+      errorMessage: errorMessage ?? (label ? `${label}の記録に失敗しました` : undefined)
+    })
+  }
+
+  return {
+    canWrite,
+    loading,
+    executeRecord
+  }
+}

--- a/frontend/hooks/useRecordFeedback.ts
+++ b/frontend/hooks/useRecordFeedback.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from "react";
 import { api } from "@/lib/api";
 import { useSWRConfig } from "swr";
 
-type RecordType = "feeding" | "diaper" | "growth" | "note";
+export type RecordType = "feeding" | "diaper" | "growth" | "note";
 
 interface FeedbackResponse {
   feedback: string;


### PR DESCRIPTION
**概要:**
ダッシュボードの「授乳」および「おむつ」ウィジェットにおける、レコード記録アクションの重複ロジックを抽出・共通化しました。

**変更点:**
- `frontend/hooks/useQuickRecord.ts` を新規作成し、以下の責務を集約しました。
  - 権限チェック (`usePermissions`)
  - 非同期処理のローディング管理と実行 (`useAsyncAction`)
  - 完了後のAIフィードバックのトリガー (`useRecordFeedback`)
- `FeedingWidget` と `DiaperWidget` から上記ロジックを削除し、`useQuickRecord` を使用するようにリファクタリングしました。
- `frontend/hooks/useRecordFeedback.ts` から `RecordType` をエクスポートし、型安全性を確保しました。

**効果:**
- コンポーネント内の記述量が削減され、UI構造の見通しが良くなりました。
- 「アクション実行 -> フィードバック -> 更新」というフローが一箇所で管理されるようになり、将来的な変更（例：エラーハンドリングの改善など）が容易になりました。
- 型定義の再利用性が向上しました。

**検証:**
- `pnpm lint` で警告がないことを確認しました。
- `pnpm build` でビルドが通ることを確認しました。

---
*PR created automatically by Jules for task [12631316881904675945](https://jules.google.com/task/12631316881904675945) started by @eburairu*