### PR TITLE
🎨 Palette: 家族名編集フォームのアクセシビリティとUXを改善

### DIFF
--- a/frontend/components/settings/FamilyNameForm.tsx
+++ b/frontend/components/settings/FamilyNameForm.tsx
@@ -60,10 +60,11 @@ export function FamilyNameForm({ name, isAdmin, onUpdated }: Props) {
                             size="sm"
                             onClick={handleSave}
                             disabled={saving}
+                            loading={saving}
                             className="bg-indigo-600 hover:bg-indigo-700 text-white"
                         >
-                            <Check className="h-4 w-4 mr-1" />
-                            保存
+                            {!saving && <Check className="h-4 w-4 mr-1" />}
+                            {saving ? "保存中" : "保存"}
                         </Button>
                         <Button size="sm" variant="outline" onClick={handleCancel} disabled={saving}>
                             <X className="h-4 w-4 mr-1" />
@@ -75,7 +76,7 @@ export function FamilyNameForm({ name, isAdmin, onUpdated }: Props) {
                 <div className="flex items-center justify-between">
                     <p className="text-xl font-bold text-gray-900 dark:text-zinc-100">{name}</p>
                     {isAdmin && (
-                        <Button variant="ghost" size="icon" onClick={() => { setValue(name); setEditing(true) }}>
+                        <Button variant="ghost" size="icon" onClick={() => { setValue(name); setEditing(true) }} aria-label="家族名を編集">
                             <Pencil className="h-4 w-4 text-gray-500 dark:text-zinc-400" />
                         </Button>
                     )}


### PR DESCRIPTION
## 💡 何を
- 家族名編集フォーム（`FamilyNameForm.tsx`）の鉛筆アイコンボタンに `aria-label="家族名を編集"` を追加しました。
- 「保存」ボタンにローディング状態を追加しました（スピナーを表示し、テキストを「保存中」に変更）。

## 🎯 なぜ
- アイコンのみのボタンには説明がなく、スクリーンリーダーユーザーにとって操作が困難でした。
- 保存処理が非同期で行われる際、ユーザーに視覚的なフィードバックがなく、処理が完了したかどうかが分かりづらい状態でした。

## ♿ アクセシビリティ
- `aria-label` を追加することで、スクリーンリーダーがボタンの機能を正しく読み上げるようになりました。
- 保存中はボタンを無効化（`disabled`）し、二重送信を防止するとともに、状態変化を明確に伝えられるようになりました。

## 📸 Before/After
（Playwrightによる検証済み。保存ボタンが紫色になり、スピナーが表示されることを確認しました）

---
*PR created automatically by Jules for task [4748820034450363271](https://jules.google.com/task/4748820034450363271) started by @eburairu*