### PR TITLE
🧹 Tidy: SleepWidgetのリファクタリング

### DIFF
--- a/.jules/tidy.md
+++ b/.jules/tidy.md
@@ -131,3 +131,13 @@
 
 アクション:
 - 他のコンポーネントでも時間フォーマットを独自に行っている場所があれば、`ageUtils.ts` の関数に置き換える。
+
+2026-02-23 - [Refactor] SleepWidgetのフック統合
+
+学び:
+- `SleepWidget` が `usePermissions` と `useAsyncAction` を個別に呼び出しており、他のウィジェット（`FeedingWidget`, `DiaperWidget`）で使用されている `useQuickRecord` パターンと異なっていた。
+- `useQuickRecord` を適用することで、権限チェック、ローディング状態管理、API呼び出しのボイラープレートを削減し、コードの一貫性を向上させた。
+- `useQuickRecord` は `feedbackType` がなくても汎用的に使用できることが確認できた。
+
+アクション:
+- 他のウィジェットや機能でも、同様の「権限チェック + 非同期アクション」のパターンがあれば、`useQuickRecord` の適用を検討する。

--- a/frontend/components/dashboard/SleepWidget.tsx
+++ b/frontend/components/dashboard/SleepWidget.tsx
@@ -1,18 +1,16 @@
 "use client"
 import { useMemo, memo } from "react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
-import { usePermissions } from "@/hooks/usePermissions"
+import { useQuickRecord } from "@/hooks/useQuickRecord"
 import { api } from "@/lib/api"
 import { formatElapsed, isToday } from "@/lib/ageUtils"
 import { WidgetCard } from "./WidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
-import { useAsyncAction } from "@/hooks/useAsyncAction"
 import { WidgetContent } from "./WidgetContent"
 import { WidgetQuickButton } from "./WidgetQuickButton"
 
 export const SleepWidget = memo(function SleepWidget({ babyId, records, isError, mutate, isLoading }: BaseWidgetProps) {
-    const { canWrite } = usePermissions()
-    const { loading, execute } = useAsyncAction()
+    const { canWrite, loading, executeRecord } = useQuickRecord(babyId, { onSuccess: mutate })
 
     const { activeSleep, isSleeping, todayTotal, elapsed, lastElapsed } = useMemo(() => {
         const sleepRecords = records?.filter(r => r.type === 'sleep') ?? []
@@ -36,12 +34,11 @@ export const SleepWidget = memo(function SleepWidget({ babyId, records, isError,
     }, [records])
 
     const handleStart = async () => {
-        await execute(async () => {
-            await api.post("/sleeps/", {
+        await executeRecord(async () => {
+            return api.post<{ id: number }>("/sleeps/", {
                 baby_id: Number(babyId),
                 start_time: new Date().toISOString(),
             })
-            if (mutate) mutate()
         }, {
             successMessage: "睡眠を開始しました",
             errorMessage: "睡眠の開始に失敗しました"
@@ -52,11 +49,10 @@ export const SleepWidget = memo(function SleepWidget({ babyId, records, isError,
         if (!activeSleep) return
 
         const sleepId = activeSleep.id
-        await execute(async () => {
-            await api.patch(`/sleeps/${sleepId}`, {
+        await executeRecord(async () => {
+            return api.patch<{ id: number }>(`/sleeps/${sleepId}`, {
                 end_time: new Date().toISOString(),
             })
-            if (mutate) mutate()
         }, {
             successMessage: "睡眠を終了しました",
             errorMessage: "睡眠の終了に失敗しました"


### PR DESCRIPTION
💡 何を: SleepWidget.tsx で usePermissions と useAsyncAction を個別に呼び出していた部分を、useQuickRecord フックに置き換えました。
🎯 なぜ: FeedingWidget や DiaperWidget と同様のパターンを適用することで、コードの一貫性を向上させ、ボイラープレートコード（権限チェックやローディング状態管理）を削減するためです。
🛡️ 安全性: pnpm lint, pnpm build, pnpm test を実行し、既存の機能に影響がないことを確認しました。また、SleepWidget のロジック（開始/終了の切り替え）が維持されていることを確認しました。

---
*PR created automatically by Jules for task [12078401636886227784](https://jules.google.com/task/12078401636886227784) started by @eburairu*