### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure File Upload (MIME Spoofing)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** Several Pydantic schemas (`FeedingCreate`, `SleepCreate`, etc.) lacked `max_length` constraints on free-text fields like `notes`. This could allow attackers to send excessively long strings, potentially causing Denial of Service (DoS) or storage exhaustion.
 **Learning:** Pydantic's default `str` type does not enforce length limits. Explicit validation is necessary for all user-supplied text to prevent abuse.
 **Prevention:** Added `Field(..., max_length=2000)` to all free-text fields in schemas. Always define reasonable upper bounds for string inputs.
+
+## 2026-03-05 - Insecure File Upload (MIME Type Spoofing)
+**Vulnerability:** The file upload endpoint trusted user-provided Content-Type headers and file extensions. Attackers could upload malicious scripts (e.g., PHP, HTML) with image extensions or MIME types, leading to Stored XSS or RCE.
+**Learning:** Never trust client-side input for file types. "Magic bytes" (file signatures) are the only reliable way to determine file content on the server.
+**Prevention:** Implemented strict server-side validation using magic bytes to detect the true MIME type and enforce the correct file extension and Content-Type when saving to storage.

--- a/app/routers/upload.py
+++ b/app/routers/upload.py
@@ -59,6 +59,8 @@ async def upload_image(
     upload_limiter.check(f"user_{current_user.id}")
 
     verify_write_access(db, current_user.id)
+
+    # Check Content-Type header as a preliminary filter, but do not rely on it
     if not file.content_type or not file.content_type.startswith("image/"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -72,24 +74,31 @@ async def upload_image(
             detail=f"ファイルサイズが大きすぎます（上限 5MB）。",
         )
 
-    # Validate magic bytes
-    # JPEG: FF D8 FF
-    # PNG: 89 50 4E 47 0D 0A 1A 0A
-    # GIF: 47 49 46 38
-    # WebP: RIFF ... WEBP
-    if not (
-        content.startswith(b"\xFF\xD8\xFF")
-        or content.startswith(b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A")
-        or content.startswith(b"\x47\x49\x46\x38")
-        or (content.startswith(b"RIFF") and len(content) >= 12 and content[8:12] == b"WEBP")
-    ):
+    # Validate magic bytes and determine correct MIME type and extension
+    # This prevents users from uploading malicious files (e.g., HTML/PHP) with fake extensions
+    detected_mime_type = None
+    detected_extension = None
+
+    if content.startswith(b"\xFF\xD8\xFF"):
+        detected_mime_type = "image/jpeg"
+        detected_extension = ".jpg"
+    elif content.startswith(b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A"):
+        detected_mime_type = "image/png"
+        detected_extension = ".png"
+    elif content.startswith(b"\x47\x49\x46\x38"):
+        detected_mime_type = "image/gif"
+        detected_extension = ".gif"
+    elif content.startswith(b"RIFF") and len(content) >= 12 and content[8:12] == b"WEBP":
+        detected_mime_type = "image/webp"
+        detected_extension = ".webp"
+    else:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="無効な画像ファイル形式です。",
         )
 
-    original_ext = os.path.splitext(file.filename or "")[1].lower() or ".webp"
-    object_key = f"{uuid.uuid4()}{original_ext}"
+    # Use detected extension instead of trusting user input
+    object_key = f"{uuid.uuid4()}{detected_extension}"
 
     bucket_name = os.getenv("R2_BUCKET_NAME", "baby-app-images")
     public_endpoint = os.getenv("R2_PUBLIC_ENDPOINT", "")
@@ -100,7 +109,7 @@ async def upload_image(
             Bucket=bucket_name,
             Key=object_key,
             Body=content,
-            ContentType=file.content_type,
+            ContentType=detected_mime_type,  # Use detected MIME type
         )
     except ClientError as e:
         logger.error("R2 upload failed: %s", e)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -42,3 +42,37 @@ def test_upload_image_invalid_magic_bytes(auth_client):
 
     assert response.status_code == 400
     assert "無効な画像ファイル形式です" in response.json()["detail"]
+
+
+def test_upload_image_extension_override(auth_client):
+    """
+    拡張子が偽装されている場合でも、マジックバイトに基づいて正しい拡張子とContent-Typeが設定されることをテストする
+    """
+    from unittest.mock import MagicMock, patch
+
+    # Mock S3 client
+    mock_s3_client = MagicMock()
+
+    with patch("app.routers.upload._get_r2_client", return_value=mock_s3_client):
+        client = auth_client()
+
+        # Content is JPEG, but filename is .php. Content-Type is image/jpeg to pass initial check.
+        files = {'file': ('malicious.php', b'\xFF\xD8\xFFfake image content', 'image/jpeg')}
+
+        response = client.post("/api/upload/image", files=files)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify that the filename in the response has .jpg extension
+        # Current implementation fails here because it uses .php
+        assert data["filename"].endswith(".jpg")
+        assert not data["filename"].endswith(".php")
+
+        # Verify that put_object was called with correct ContentType and Key
+        mock_s3_client.put_object.assert_called_once()
+        call_kwargs = mock_s3_client.put_object.call_args[1]
+
+        # Even if user sent image/jpeg, we want to ensure our code explicitly sets it based on detection
+        assert call_kwargs["ContentType"] == "image/jpeg"
+        assert call_kwargs["Key"].endswith(".jpg")


### PR DESCRIPTION
🚨 深刻度: HIGH
💡 脆弱性: ファイルアップロード時にユーザーが指定した拡張子やContent-Typeを信頼していたため、偽装されたファイル（例: 画像に見せかけたPHPスクリプト）がアップロードされ、Stored XSSやRCEにつながる可能性がありました。
🎯 影響: 攻撃者が悪意のあるスクリプトを実行したり、ユーザーのブラウザ上で任意のJavaScriptを実行させたりする可能性があります。
🔧 修正: サーバーサイドでファイルのマジックバイト（ファイルシグネチャ）を検証し、その結果に基づいてMIMEタイプと拡張子を強制的に設定するように変更しました。ユーザー入力のContent-Typeとファイル名は無視されます。
✅ 検証: `tests/test_upload.py` に新しいテストケース `test_upload_image_extension_override` を追加し、偽装された拡張子が正しく修正されて保存されることを確認しました。既存のテストもパスしています。

---
*PR created automatically by Jules for task [17006436992208299450](https://jules.google.com/task/17006436992208299450) started by @eburairu*