### PR TITLE
⚡ Bolt: 赤ちゃん・権限検索のインデックス追加

### DIFF
--- a/alembic/versions/5c7e95cda081_merge_heads_and_add_baby_indexes.py
+++ b/alembic/versions/5c7e95cda081_merge_heads_and_add_baby_indexes.py
@@ -1,0 +1,30 @@
+"""merge heads for bolt
+
+Revision ID: 5c7e95cda081
+Revises: 7742386a8a71, e4f5g6h7i8j9
+Create Date: 2026-02-24 05:03:14.071768+09:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5c7e95cda081'
+down_revision: Union[str, Sequence[str], None] = ('7742386a8a71', 'e4f5g6h7i8j9')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index(op.f('ix_babies_family_id'), 'babies', ['family_id'], unique=False)
+    op.create_index(op.f('ix_baby_permissions_user_id'), 'baby_permissions', ['user_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_baby_permissions_user_id'), table_name='baby_permissions')
+    op.drop_index(op.f('ix_babies_family_id'), table_name='babies')

--- a/app/models/baby.py
+++ b/app/models/baby.py
@@ -7,7 +7,7 @@ class Baby(Base):
     __tablename__ = "babies"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
-    family_id = Column(Integer, ForeignKey("families.id"), nullable=False)
+    family_id = Column(Integer, ForeignKey("families.id"), nullable=False, index=True)
     name = Column(String, nullable=False)
     birthday = Column(Date, nullable=True)
     created_at = Column(DateTime, nullable=False, server_default=func.now())
@@ -23,7 +23,7 @@ class BabyPermission(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
     baby_id = Column(Integer, ForeignKey("babies.id", ondelete="CASCADE"), nullable=False)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     record_type = Column(String, nullable=False)
     can_view = Column(Boolean, nullable=False)
 


### PR DESCRIPTION
💡 **何を**: `Baby.family_id` と `BabyPermission.user_id` にデータベースインデックスを追加しました。
🎯 **なぜ**: ダッシュボード表示時 (`get_babies`) に、家族IDやユーザーIDによるフィルタリングが頻繁に行われますが、インデックスがないためフルスキャンが発生する可能性がありました。
📊 **影響**: 検索が O(N) から O(log N) に改善され、ユーザー数やレコード数が増加してもパフォーマンスが維持されます。
🔬 **測定**: `uv run pytest` によりリグレッションがないことを確認しました。また、Alembicのヘッドを統合しました。

---
*PR created automatically by Jules for task [14454227928725566330](https://jules.google.com/task/14454227928725566330) started by @eburairu*