### PR TITLE
🧹 Tidy: 記録履歴のリストUIと削除ロジックを共通化

### DIFF
--- a/frontend/components/diaper/DiaperHistory.tsx
+++ b/frontend/components/diaper/DiaperHistory.tsx
@@ -2,22 +2,13 @@
 import { useState, useEffect, useRef } from "react"
 import { Diaper, DiaperType } from "@/types/diaper"
 import { Button } from "@/components/ui/button"
-import { Trash2, Pencil, User, MessageCircle, Loader2 } from "lucide-react"
+import { Trash2, Pencil, User, MessageCircle } from "lucide-react"
 import { api } from "@/lib/api"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { DiaperEditDialog } from "./DiaperEditDialog"
 import { useUser } from "@/hooks/useAuth"
 import { RecordCommentDialog } from "@/components/records/RecordCommentDialog"
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
+import { useRecordDelete } from "@/hooks/useRecordDelete"
+import { HistoryCard } from "@/components/records/HistoryCard"
 
 // Minimal date formatter if date-fns is missing, or use Intl.DateTimeFormat
 const formatDate = (isoString: string) => {
@@ -28,6 +19,43 @@ const formatDate = (isoString: string) => {
         hour: '2-digit',
         minute: '2-digit'
     }).format(date)
+}
+
+const getStyles = (type: DiaperType) => {
+    switch (type) {
+        case DiaperType.WET:
+            return {
+                bg: "bg-blue-50 dark:bg-blue-950/30",
+                border: "border-blue-100 dark:border-blue-900/50",
+                text: "text-blue-700 dark:text-blue-400",
+                icon: "💧",
+                label: "おしっこ"
+            }
+        case DiaperType.DIRTY:
+            return {
+                bg: "bg-amber-50 dark:bg-amber-950/30",
+                border: "border-amber-100 dark:border-amber-900/50",
+                text: "text-amber-700 dark:text-amber-400",
+                icon: "💩",
+                label: "うんち"
+            }
+        case DiaperType.BOTH:
+            return {
+                bg: "bg-purple-50 dark:bg-purple-950/30",
+                border: "border-purple-100 dark:border-purple-900/50",
+                text: "text-purple-700 dark:text-purple-400",
+                icon: "💧💩",
+                label: "両方"
+            }
+        default:
+            return {
+                bg: "bg-gray-50 dark:bg-zinc-800/50",
+                border: "border-gray-100 dark:border-zinc-700",
+                text: "text-gray-700 dark:text-zinc-400",
+                icon: "?",
+                label: "不明"
+            }
+    }
 }
 
 interface Props {
@@ -41,10 +69,16 @@ export function DiaperHistory({ diapers, onDeleteSuccess, canWrite = true, initi
     const { user } = useUser()
     const [editingDiaper, setEditingDiaper] = useState<Diaper | null>(null)
     const [editOpen, setEditOpen] = useState(false)
-    const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
-    const [isDeleting, setIsDeleting] = useState(false)
     const [commentTarget, setCommentTarget] = useState<{ id: number; title: string } | null>(null)
     const initializedRef = useRef(false)
+
+    const { setDeleteTargetId, ConfirmDeleteDialog } = useRecordDelete({
+        onDelete: async (id) => {
+             await api.delete(`/diapers/${id}`)
+        },
+        onSuccess: onDeleteSuccess,
+        resourceName: "おむつ記録"
+    });
 
     useEffect(() => {
         if (initialCommentRecordId && diapers.length > 0 && !initializedRef.current) {
@@ -52,158 +86,87 @@ export function DiaperHistory({ diapers, onDeleteSuccess, canWrite = true, initi
             if (target) {
                 initializedRef.current = true
                 const style = getStyles(target.diaper_type)
-                setCommentTarget({ id: target.id, title: `${style.label} ${formatDate(target.change_time)}` })
+                // Avoid synchronous state update in effect
+                setTimeout(() => {
+                    setCommentTarget({ id: target.id, title: `${style.label} ${formatDate(target.change_time)}` })
+                }, 0)
             }
         }
     }, [initialCommentRecordId, diapers])
-
-    const handleDelete = async () => {
-        if (deleteTargetId === null) return
-        setIsDeleting(true)
-        try {
-            await api.delete(`/diapers/${deleteTargetId}`)
-            onDeleteSuccess()
-        } catch (e) {
-            console.error(e)
-            alert("削除に失敗しました")
-        } finally {
-            setIsDeleting(false)
-            setDeleteTargetId(null)
-        }
-    }
 
     const handleEdit = (diaper: Diaper) => {
         setEditingDiaper(diaper)
         setEditOpen(true)
     }
 
-    const getStyles = (type: DiaperType) => {
-        switch (type) {
-            case DiaperType.WET:
-                return {
-                    bg: "bg-blue-50 dark:bg-blue-950/30",
-                    border: "border-blue-100 dark:border-blue-900/50",
-                    text: "text-blue-700 dark:text-blue-400",
-                    icon: "💧",
-                    label: "おしっこ"
-                }
-            case DiaperType.DIRTY:
-                return {
-                    bg: "bg-amber-50 dark:bg-amber-950/30",
-                    border: "border-amber-100 dark:border-amber-900/50",
-                    text: "text-amber-700 dark:text-amber-400",
-                    icon: "💩",
-                    label: "うんち"
-                }
-            case DiaperType.BOTH:
-                return {
-                    bg: "bg-purple-50 dark:bg-purple-950/30",
-                    border: "border-purple-100 dark:border-purple-900/50",
-                    text: "text-purple-700 dark:text-purple-400",
-                    icon: "💧💩",
-                    label: "両方"
-                }
-            default:
-                return {
-                    bg: "bg-gray-50 dark:bg-zinc-800/50",
-                    border: "border-gray-100 dark:border-zinc-700",
-                    text: "text-gray-700 dark:text-zinc-400",
-                    icon: "?",
-                    label: "不明"
-                }
-        }
-    }
+    const isEmpty = !diapers || diapers.length === 0;
 
     return (
         <>
-            <Card className="rounded-2xl shadow-sm border-0 transition-colors">
-                <CardHeader className="pb-2">
-                    <CardTitle className="text-sm font-medium text-gray-500 dark:text-zinc-500">最近の記録</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                    {diapers.length === 0 ? <p className="text-sm text-gray-400 dark:text-zinc-500 text-center py-4">記録がありません</p> : null}
-
-                    {diapers.map((diaper) => {
-                        const style = getStyles(diaper.diaper_type)
-                        return (
-                            <div
-                                key={diaper.id}
-                                className={`flex items-center justify-between p-3 rounded-xl border transition-colors ${style.bg} ${style.border}`}
-                            >
-                                <div className="flex items-center gap-3">
-                                    <span className="text-2xl">{style.icon}</span>
-                                    <div>
-                                        <div className={`text-sm font-bold ${style.text}`}>
-                                            {style.label}
-                                            <span className="text-xs font-normal text-gray-500 dark:text-zinc-500 ml-2">
-                                                {formatDate(diaper.change_time)}
-                                            </span>
+            <HistoryCard title="最近の記録" isEmpty={isEmpty} emptyMessage="記録がありません">
+                {(diapers || []).map((diaper) => {
+                    const style = getStyles(diaper.diaper_type)
+                    return (
+                        <div
+                            key={diaper.id}
+                            className={`flex items-center justify-between p-3 rounded-xl border transition-colors ${style.bg} ${style.border}`}
+                        >
+                            <div className="flex items-center gap-3">
+                                <span className="text-2xl">{style.icon}</span>
+                                <div>
+                                    <div className={`text-sm font-bold ${style.text}`}>
+                                        {style.label}
+                                        <span className="text-xs font-normal text-gray-500 dark:text-zinc-500 ml-2">
+                                            {formatDate(diaper.change_time)}
+                                        </span>
+                                    </div>
+                                    {diaper.notes ? (
+                                        <div className="text-xs text-gray-600 dark:text-zinc-400 mt-0.5">{diaper.notes}</div>
+                                    ) : null}
+                                    {diaper.recorded_by_display_name ? (
+                                        <div className="inline-flex items-center gap-0.5 text-xs text-gray-400 dark:text-zinc-500 mt-0.5">
+                                            <User className="w-3 h-3" />
+                                            {diaper.recorded_by_display_name}
                                         </div>
-                                        {diaper.notes ? (
-                                            <div className="text-xs text-gray-600 dark:text-zinc-400 mt-0.5">{diaper.notes}</div>
-                                        ) : null}
-                                        {diaper.recorded_by_display_name ? (
-                                            <div className="inline-flex items-center gap-0.5 text-xs text-gray-400 dark:text-zinc-500 mt-0.5">
-                                                <User className="w-3 h-3" />
-                                                {diaper.recorded_by_display_name}
-                                            </div>
-                                        ) : null}
-                                        <button
-                                            onClick={() => setCommentTarget({ id: diaper.id, title: `${style.label} ${formatDate(diaper.change_time)}` })}
-                                            aria-label={`${style.label} ${formatDate(diaper.change_time)} へのコメント`}
-                                            className="inline-flex items-center gap-0.5 text-xs text-gray-400 dark:text-zinc-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors mt-0.5"
-                                        >
-                                            <MessageCircle className="w-3 h-3" />
-                                            {(diaper.comment_count ?? 0) > 0 && <span>{diaper.comment_count}</span>}
-                                        </button>
-                                    </div>
+                                    ) : null}
+                                    <button
+                                        onClick={() => setCommentTarget({ id: diaper.id, title: `${style.label} ${formatDate(diaper.change_time)}` })}
+                                        aria-label={`${style.label} ${formatDate(diaper.change_time)} へのコメント`}
+                                        className="inline-flex items-center gap-0.5 text-xs text-gray-400 dark:text-zinc-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors mt-0.5"
+                                    >
+                                        <MessageCircle className="w-3 h-3" />
+                                        {(diaper.comment_count ?? 0) > 0 && <span>{diaper.comment_count}</span>}
+                                    </button>
                                 </div>
-                                {canWrite ? (
-                                    <div className="flex gap-1">
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-blue-500 dark:hover:text-blue-400 hover:bg-transparent"
-                                            onClick={() => handleEdit(diaper)}
-                                            aria-label={`${style.label} ${formatDate(diaper.change_time)} を編集`}
-                                        >
-                                            <Pencil className="h-4 w-4" />
-                                        </Button>
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-transparent"
-                                            onClick={() => setDeleteTargetId(diaper.id)}
-                                            aria-label={`${style.label} ${formatDate(diaper.change_time)} を削除`}
-                                        >
-                                            <Trash2 className="h-4 w-4" />
-                                        </Button>
-                                    </div>
-                                ) : null}
                             </div>
-                        )
-                    })}
-                </CardContent>
-            </Card>
+                            {canWrite ? (
+                                <div className="flex gap-1">
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-blue-500 dark:hover:text-blue-400 hover:bg-transparent"
+                                        onClick={() => handleEdit(diaper)}
+                                        aria-label={`${style.label} ${formatDate(diaper.change_time)} を編集`}
+                                    >
+                                        <Pencil className="h-4 w-4" />
+                                    </Button>
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-transparent"
+                                        onClick={() => setDeleteTargetId(diaper.id)}
+                                        aria-label={`${style.label} ${formatDate(diaper.change_time)} を削除`}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            ) : null}
+                        </div>
+                    )
+                })}
+            </HistoryCard>
 
-            {/* 削除確認ダイアログ */}
-            <AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => { if (!open) setDeleteTargetId(null) }}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle data-sentry-unmask>記録の削除</AlertDialogTitle>
-                        <AlertDialogDescription data-sentry-unmask>
-                            このおむつ記録を削除しますか？この操作は取り消せません。
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel disabled={isDeleting} data-sentry-unmask>キャンセル</AlertDialogCancel>
-                        <AlertDialogAction onClick={handleDelete} data-sentry-unmask className="bg-red-600 hover:bg-red-700" disabled={isDeleting}>
-                            {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                            削除
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+            <ConfirmDeleteDialog />
 
             <DiaperEditDialog
                 diaper={editingDiaper}

--- a/frontend/components/feeding/feeding-history.tsx
+++ b/frontend/components/feeding/feeding-history.tsx
@@ -1,34 +1,22 @@
 "use client"
 import { RECORD_TYPES } from '@/types/enums';
-
-
 import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Feeding, FeedingCreate, FeedingUpdate } from "@/types/feeding";
-import { Trash2, Milk, Baby, User, MessageCircle, Loader2, Pencil } from "lucide-react";
-import { toast } from "sonner";
+import { Feeding, FeedingUpdate } from "@/types/feeding";
+import { Trash2, Milk, Baby, User, MessageCircle, Pencil } from "lucide-react";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import { useUser } from "@/hooks/useAuth";
 import { RecordCommentDialog } from "@/components/records/RecordCommentDialog";
 import { FeedingForm } from "./feeding-form";
 import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
-import {
     Dialog,
     DialogContent,
     DialogHeader,
     DialogTitle,
 } from "@/components/ui/dialog"
+import { useRecordDelete } from "@/hooks/useRecordDelete";
+import { HistoryCard } from "@/components/records/HistoryCard";
 
 interface FeedingHistoryProps {
     feedings: Feeding[];
@@ -71,154 +59,112 @@ function BreastDuration({ feeding }: { feeding: Feeding }) {
 
 export function FeedingHistory({ feedings, onDelete, onUpdate, onRefresh, canWrite = true, initialCommentRecordId, babyId }: FeedingHistoryProps) {
     const { user } = useUser();
-    const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
     const [editTarget, setEditTarget] = useState<Feeding | null>(null);
-    const [isDeleting, setIsDeleting] = useState(false);
     const [commentTarget, setCommentTarget] = useState<{ id: number; title: string } | null>(null);
     const initializedRef = useRef(false);
+
+    const { setDeleteTargetId, ConfirmDeleteDialog } = useRecordDelete({
+        onDelete,
+        onSuccess: onRefresh,
+        resourceName: "授乳記録"
+    });
 
     useEffect(() => {
         if (initialCommentRecordId && feedings.length > 0 && !initializedRef.current) {
             const target = feedings.find(f => f.id === initialCommentRecordId);
             if (target) {
                 initializedRef.current = true;
-                setCommentTarget({ id: target.id, title: `授乳 ${format(new Date(target.feeding_time), "HH:mm", { locale: ja })}` });
+                setTimeout(() => {
+                    setCommentTarget({ id: target.id, title: `授乳 ${format(new Date(target.feeding_time), "HH:mm", { locale: ja })}` });
+                }, 0);
             }
         }
     }, [initialCommentRecordId, feedings]);
 
-    const handleDelete = async () => {
-        if (deleteTargetId === null) return;
-        setIsDeleting(true);
-        try {
-            await onDelete(deleteTargetId);
-            toast.success("削除しました");
-            setDeleteTargetId(null);
-        } catch (e) {
-            console.error(e);
-            toast.error("削除に失敗しました");
-        } finally {
-            setIsDeleting(false);
-        }
-    };
-
-    if (!feedings || feedings.length === 0) {
-        return (
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-lg">最近の記録</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <p className="text-muted-foreground text-sm">まだ記録がありません。</p>
-                </CardContent>
-            </Card>
-        );
-    }
+    const isEmpty = !feedings || feedings.length === 0;
 
     return (
         <>
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-lg">最近の記録</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    {feedings.map((feeding) => (
-                        <div
-                            key={feeding.id}
-                            className="flex items-start justify-between border-b pb-4 last:border-0 last:pb-0"
-                        >
-                            <div className="flex items-start space-x-4">
-                                <div className={`p-2 rounded-full shrink-0 mt-0.5 ${feeding.feeding_type === 'BREAST' ? 'bg-pink-100 text-pink-600' : 'bg-blue-100 text-blue-600'}`}>
-                                    {feeding.feeding_type === 'BREAST' ? <Baby className="w-5 h-5" /> : <Milk className="w-5 h-5" />}
+            <HistoryCard title="最近の記録" isEmpty={isEmpty} emptyMessage="まだ記録がありません。">
+                {(feedings || []).map((feeding) => (
+                    <div
+                        key={feeding.id}
+                        className="flex items-start justify-between border-b pb-4 last:border-0 last:pb-0"
+                    >
+                        <div className="flex items-start space-x-4">
+                            <div className={`p-2 rounded-full shrink-0 mt-0.5 ${feeding.feeding_type === 'BREAST' ? 'bg-pink-100 text-pink-600' : 'bg-blue-100 text-blue-600'}`}>
+                                {feeding.feeding_type === 'BREAST' ? <Baby className="w-5 h-5" /> : <Milk className="w-5 h-5" />}
+                            </div>
+                            <div className="space-y-1">
+                                <div className="font-medium">
+                                    {format(new Date(feeding.feeding_time), "HH:mm", { locale: ja })}
+                                    <span className="ml-2 text-sm text-muted-foreground">
+                                        {feeding.feeding_type === 'BREAST' ? '母乳' : feeding.feeding_type === 'BOTTLE' ? 'ミルク' : '混合'}
+                                    </span>
                                 </div>
-                                <div className="space-y-1">
-                                    <div className="font-medium">
-                                        {format(new Date(feeding.feeding_time), "HH:mm", { locale: ja })}
-                                        <span className="ml-2 text-sm text-muted-foreground">
-                                            {feeding.feeding_type === 'BREAST' ? '母乳' : feeding.feeding_type === 'BOTTLE' ? 'ミルク' : '混合'}
+                                <div className="text-sm text-gray-500 dark:text-zinc-400">
+                                    {feeding.feeding_type === 'BREAST' && <BreastDuration feeding={feeding} />}
+                                    {feeding.feeding_type === 'BOTTLE' && feeding.amount_ml && (
+                                        <span>
+                                            {feeding.amount_ml}ml
+                                            {feeding.bottle_content_type && (
+                                                <span className="ml-1 text-xs text-gray-400">
+                                                    ({BOTTLE_CONTENT_LABEL[feeding.bottle_content_type]})
+                                                </span>
+                                            )}
                                         </span>
-                                    </div>
-                                    <div className="text-sm text-gray-500 dark:text-zinc-400">
-                                        {feeding.feeding_type === 'BREAST' && <BreastDuration feeding={feeding} />}
-                                        {feeding.feeding_type === 'BOTTLE' && feeding.amount_ml && (
-                                            <span>
-                                                {feeding.amount_ml}ml
-                                                {feeding.bottle_content_type && (
-                                                    <span className="ml-1 text-xs text-gray-400">
-                                                        ({BOTTLE_CONTENT_LABEL[feeding.bottle_content_type]})
-                                                    </span>
-                                                )}
-                                            </span>
-                                        )}
-                                        {feeding.notes && (
-                                            <span className="ml-2 text-xs text-gray-400">({feeding.notes})</span>
-                                        )}
-                                    </div>
-                                    <div className="flex items-center gap-2 flex-wrap">
-                                        {feeding.feeding_completion && (
-                                            <span className={`inline-block text-[10px] px-2 py-0.5 rounded-full font-medium ${COMPLETION_STYLE[feeding.feeding_completion].className}`}>
-                                                {COMPLETION_STYLE[feeding.feeding_completion].label}
-                                            </span>
-                                        )}
-                                        {feeding.recorded_by_display_name && (
-                                            <span className="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-zinc-500">
-                                                <User className="w-3 h-3" />
-                                                {feeding.recorded_by_display_name}
-                                            </span>
-                                        )}
-                                        <button
-                                            onClick={() => setCommentTarget({ id: feeding.id, title: `授乳 ${format(new Date(feeding.feeding_time), "HH:mm", { locale: ja })}` })}
-                                            className="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-zinc-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors"
-                                        >
-                                            <MessageCircle className="w-3 h-3" />
-                                            {feeding.comment_count > 0 && <span>{feeding.comment_count}</span>}
-                                        </button>
-                                    </div>
+                                    )}
+                                    {feeding.notes && (
+                                        <span className="ml-2 text-xs text-gray-400">({feeding.notes})</span>
+                                    )}
+                                </div>
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    {feeding.feeding_completion && (
+                                        <span className={`inline-block text-[10px] px-2 py-0.5 rounded-full font-medium ${COMPLETION_STYLE[feeding.feeding_completion].className}`}>
+                                            {COMPLETION_STYLE[feeding.feeding_completion].label}
+                                        </span>
+                                    )}
+                                    {feeding.recorded_by_display_name && (
+                                        <span className="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-zinc-500">
+                                            <User className="w-3 h-3" />
+                                            {feeding.recorded_by_display_name}
+                                        </span>
+                                    )}
+                                    <button
+                                        onClick={() => setCommentTarget({ id: feeding.id, title: `授乳 ${format(new Date(feeding.feeding_time), "HH:mm", { locale: ja })}` })}
+                                        className="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-zinc-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors"
+                                    >
+                                        <MessageCircle className="w-3 h-3" />
+                                        {feeding.comment_count > 0 && <span>{feeding.comment_count}</span>}
+                                    </button>
                                 </div>
                             </div>
-                            {canWrite && (
-                                <div className="flex items-center gap-1 shrink-0 ml-4">
-                                    <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="text-gray-400 hover:text-indigo-500"
-                                        onClick={() => setEditTarget(feeding)}
-                                    >
-                                        <Pencil className="w-4 h-4" />
-                                    </Button>
-                                    <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="text-gray-400 hover:text-red-500"
-                                        onClick={() => setDeleteTargetId(feeding.id)}
-                                    >
-                                        <Trash2 className="w-4 h-4" />
-                                    </Button>
-                                </div>
-                            )}
                         </div>
-                    ))}
-                </CardContent>
-            </Card>
+                        {canWrite && (
+                            <div className="flex items-center gap-1 shrink-0 ml-4">
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="text-gray-400 hover:text-indigo-500"
+                                    onClick={() => setEditTarget(feeding)}
+                                >
+                                    <Pencil className="w-4 h-4" />
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="text-gray-400 hover:text-red-500"
+                                    onClick={() => setDeleteTargetId(feeding.id)}
+                                >
+                                    <Trash2 className="w-4 h-4" />
+                                </Button>
+                            </div>
+                        )}
+                    </div>
+                ))}
+            </HistoryCard>
 
-            {/* 削除確認ダイアログ */}
-            <AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => { if (!open) setDeleteTargetId(null) }}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle data-sentry-unmask>記録の削除</AlertDialogTitle>
-                        <AlertDialogDescription data-sentry-unmask>
-                            この授乳記録を削除しますか？この操作は取り消せません。
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel disabled={isDeleting} data-sentry-unmask>キャンセル</AlertDialogCancel>
-                        <AlertDialogAction onClick={handleDelete} data-sentry-unmask className="bg-red-600 hover:bg-red-700" disabled={isDeleting}>
-                            {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                            削除
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+            <ConfirmDeleteDialog />
 
             {/* コメントダイアログ */}
             {commentTarget && (

--- a/frontend/components/records/HistoryCard.tsx
+++ b/frontend/components/records/HistoryCard.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ReactNode } from "react"
+
+interface HistoryCardProps {
+    title?: string
+    isEmpty: boolean
+    emptyMessage?: string
+    children?: ReactNode
+}
+
+export function HistoryCard({
+    title = "最近の記録",
+    isEmpty,
+    emptyMessage = "記録がありません",
+    children
+}: HistoryCardProps) {
+    if (isEmpty) {
+        return (
+            <Card className="rounded-2xl shadow-sm border-0">
+                <CardHeader>
+                    <CardTitle className="text-sm font-medium text-gray-700 dark:text-zinc-300">
+                        {title}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-muted-foreground text-sm text-center py-4">{emptyMessage}</p>
+                </CardContent>
+            </Card>
+        )
+    }
+
+    return (
+        <Card className="rounded-2xl shadow-sm border-0 transition-colors">
+            <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-gray-700 dark:text-zinc-300">
+                    {title}
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+                {children}
+            </CardContent>
+        </Card>
+    )
+}

--- a/frontend/components/sleep/sleep-history.tsx
+++ b/frontend/components/sleep/sleep-history.tsx
@@ -5,25 +5,16 @@ import { useSleeps } from "@/hooks/useData"
 import { api } from "@/lib/api"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
 import { Textarea } from "@/components/ui/textarea"
-import { Pencil, Trash2, Moon, User, MessageCircle, Loader2 } from "lucide-react"
+import { Pencil, Trash2, Moon, User, MessageCircle } from "lucide-react"
 import { formatDuration } from "@/lib/ageUtils"
 import { Sleep } from "@/types/sleep"
 import { useUser } from "@/hooks/useAuth"
 import { RecordCommentDialog } from "@/components/records/RecordCommentDialog"
+import { useRecordDelete } from "@/hooks/useRecordDelete"
+import { HistoryCard } from "@/components/records/HistoryCard"
 
 interface Props {
     babyId: string
@@ -36,10 +27,16 @@ export function SleepHistory({ babyId, canWrite = true, initialCommentRecordId }
     const { sleeps, mutate } = useSleeps(babyId)
     const [editingSleep, setEditingSleep] = useState<Sleep | null>(null)
     const [isEditOpen, setIsEditOpen] = useState(false)
-    const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
-    const [isDeleting, setIsDeleting] = useState(false)
     const [commentTarget, setCommentTarget] = useState<{ id: number; title: string } | null>(null)
     const initializedRef = useRef(false)
+
+    const { setDeleteTargetId, ConfirmDeleteDialog } = useRecordDelete({
+        onDelete: async (id) => {
+            await api.delete(`/sleeps/${id}`)
+        },
+        onSuccess: mutate,
+        resourceName: "睡眠記録"
+    });
 
     const history = useMemo(() => {
         return sleeps?.filter((s) => s.end_time).sort((a, b) => new Date(b.start_time).getTime() - new Date(a.start_time).getTime())
@@ -50,24 +47,12 @@ export function SleepHistory({ babyId, canWrite = true, initialCommentRecordId }
             const target = history.find(s => s.id === initialCommentRecordId)
             if (target) {
                 initializedRef.current = true
-                setCommentTarget({ id: target.id, title: `睡眠 ${format(new Date(target.start_time), "M/d HH:mm", { locale: ja })}` })
+                setTimeout(() => {
+                    setCommentTarget({ id: target.id, title: `睡眠 ${format(new Date(target.start_time), "M/d HH:mm", { locale: ja })}` })
+                }, 0)
             }
         }
     }, [initialCommentRecordId, history])
-
-    const handleDelete = async () => {
-        if (deleteTargetId === null) return
-        setIsDeleting(true)
-        try {
-            await api.delete(`/sleeps/${deleteTargetId}`)
-            mutate()
-        } catch (e) {
-            console.error(e)
-        } finally {
-            setIsDeleting(false)
-            setDeleteTargetId(null)
-        }
-    }
 
     const handleEditSave = async (e: React.FormEvent) => {
         e.preventDefault()
@@ -86,118 +71,84 @@ export function SleepHistory({ babyId, canWrite = true, initialCommentRecordId }
         }
     }
 
-    if (!history || history.length === 0) {
-        return (
-            <Card className="rounded-2xl shadow-sm border-0">
-                <CardHeader>
-                    <CardTitle className="text-sm font-medium text-gray-700 dark:text-zinc-300">最近の睡眠</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <div className="text-center py-8 text-gray-400">
-                        <p>記録はまだありません</p>
-                    </div>
-                </CardContent>
-            </Card>
-        )
-    }
+    const isEmpty = !history || history.length === 0;
 
     return (
         <>
-            <Card className="rounded-2xl shadow-sm border-0 transition-colors">
-                <CardHeader className="pb-2">
-                    <CardTitle className="text-sm font-medium text-gray-700 dark:text-zinc-300">最近の睡眠</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                    {history.map((sleep) => {
-                        const duration = sleep.end_time
-                            ? formatDuration(sleep.start_time, sleep.end_time)
-                            : "睡眠中"
+            <HistoryCard title="最近の睡眠" isEmpty={isEmpty} emptyMessage="記録はまだありません">
+                {(history || []).map((sleep) => {
+                    const duration = sleep.end_time
+                        ? formatDuration(sleep.start_time, sleep.end_time)
+                        : "睡眠中"
 
-                        return (
-                            <div key={sleep.id} className="flex items-center justify-between p-3 rounded-xl border border-gray-100 dark:border-zinc-800 bg-white dark:bg-zinc-900 hover:bg-slate-50 dark:hover:bg-zinc-800 transition-colors">
-                                <div className="flex items-start gap-4">
-                                    <div className="mt-1 bg-indigo-100 dark:bg-indigo-950/40 p-2 rounded-full text-indigo-500 dark:text-indigo-400">
-                                        <Moon className="w-5 h-5" />
-                                    </div>
-                                    <div className="space-y-1">
-                                        <div className="flex items-center gap-2">
-                                            <p className="font-medium text-sm text-gray-900 dark:text-zinc-100">
-                                                {format(new Date(sleep.start_time), "M/d HH:mm", { locale: ja })}
-                                                <span className="text-gray-400 dark:text-zinc-500 mx-2">-</span>
-                                                {sleep.end_time ? format(new Date(sleep.end_time), "HH:mm", { locale: ja }) : "現在"}
-                                            </p>
-                                        </div>
-                                        <div className="flex items-center gap-2 text-[10px] text-gray-500 flex-wrap">
-                                            <span className="px-2 py-0.5 bg-slate-100 dark:bg-zinc-800 rounded text-slate-600 dark:text-zinc-400 font-medium">
-                                                {duration}
-                                            </span>
-                                            {sleep.recorded_by_display_name && (
-                                                <span className="inline-flex items-center gap-0.5 text-gray-400 dark:text-zinc-500">
-                                                    <User className="w-3 h-3" />
-                                                    {sleep.recorded_by_display_name}
-                                                </span>
-                                            )}
-                                            <button
-                                                onClick={() => setCommentTarget({ id: sleep.id, title: `睡眠 ${format(new Date(sleep.start_time), "M/d HH:mm", { locale: ja })}` })}
-                                                className="inline-flex items-center gap-0.5 text-gray-400 dark:text-zinc-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors"
-                                            >
-                                                <MessageCircle className="w-3 h-3" />
-                                                {(sleep.comment_count ?? 0) > 0 && <span>{sleep.comment_count}</span>}
-                                            </button>
-                                        </div>
-                                        {sleep.notes && (
-                                            <p className="text-xs text-gray-500 dark:text-zinc-400 mt-1 line-clamp-1">
-                                                {sleep.notes}
-                                            </p>
-                                        )}
-                                    </div>
+                    return (
+                        <div key={sleep.id} className="flex items-center justify-between p-3 rounded-xl border border-gray-100 dark:border-zinc-800 bg-white dark:bg-zinc-900 hover:bg-slate-50 dark:hover:bg-zinc-800 transition-colors">
+                            <div className="flex items-start gap-4">
+                                <div className="mt-1 bg-indigo-100 dark:bg-indigo-950/40 p-2 rounded-full text-indigo-500 dark:text-indigo-400">
+                                    <Moon className="w-5 h-5" />
                                 </div>
-                                {canWrite && (
-                                    <div className="flex items-center gap-1">
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            className="h-8 w-8 text-gray-400 hover:text-indigo-600"
-                                            onClick={() => {
-                                                setEditingSleep(sleep)
-                                                setIsEditOpen(true)
-                                            }}
-                                        >
-                                            <Pencil className="w-4 h-4" />
-                                        </Button>
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            className="h-8 w-8 text-gray-400 hover:text-red-500"
-                                            onClick={() => setDeleteTargetId(sleep.id)}
-                                        >
-                                            <Trash2 className="w-4 h-4" />
-                                        </Button>
+                                <div className="space-y-1">
+                                    <div className="flex items-center gap-2">
+                                        <p className="font-medium text-sm text-gray-900 dark:text-zinc-100">
+                                            {format(new Date(sleep.start_time), "M/d HH:mm", { locale: ja })}
+                                            <span className="text-gray-400 dark:text-zinc-500 mx-2">-</span>
+                                            {sleep.end_time ? format(new Date(sleep.end_time), "HH:mm", { locale: ja }) : "現在"}
+                                        </p>
                                     </div>
-                                )}
+                                    <div className="flex items-center gap-2 text-[10px] text-gray-500 flex-wrap">
+                                        <span className="px-2 py-0.5 bg-slate-100 dark:bg-zinc-800 rounded text-slate-600 dark:text-zinc-400 font-medium">
+                                            {duration}
+                                        </span>
+                                        {sleep.recorded_by_display_name && (
+                                            <span className="inline-flex items-center gap-0.5 text-gray-400 dark:text-zinc-500">
+                                                <User className="w-3 h-3" />
+                                                {sleep.recorded_by_display_name}
+                                            </span>
+                                        )}
+                                        <button
+                                            onClick={() => setCommentTarget({ id: sleep.id, title: `睡眠 ${format(new Date(sleep.start_time), "M/d HH:mm", { locale: ja })}` })}
+                                            className="inline-flex items-center gap-0.5 text-gray-400 dark:text-zinc-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors"
+                                        >
+                                            <MessageCircle className="w-3 h-3" />
+                                            {(sleep.comment_count ?? 0) > 0 && <span>{sleep.comment_count}</span>}
+                                        </button>
+                                    </div>
+                                    {sleep.notes && (
+                                        <p className="text-xs text-gray-500 dark:text-zinc-400 mt-1 line-clamp-1">
+                                            {sleep.notes}
+                                        </p>
+                                    )}
+                                </div>
                             </div>
-                        )
-                    })}
-                </CardContent>
-            </Card>
+                            {canWrite && (
+                                <div className="flex items-center gap-1">
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-gray-400 hover:text-indigo-600"
+                                        onClick={() => {
+                                            setEditingSleep(sleep)
+                                            setIsEditOpen(true)
+                                        }}
+                                    >
+                                        <Pencil className="w-4 h-4" />
+                                    </Button>
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-gray-400 hover:text-red-500"
+                                        onClick={() => setDeleteTargetId(sleep.id)}
+                                    >
+                                        <Trash2 className="w-4 h-4" />
+                                    </Button>
+                                </div>
+                            )}
+                        </div>
+                    )
+                })}
+            </HistoryCard>
 
-            <AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => { if (!open) setDeleteTargetId(null) }}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle data-sentry-unmask>記録の削除</AlertDialogTitle>
-                        <AlertDialogDescription data-sentry-unmask>
-                            この睡眠記録を削除しますか？この操作は取り消せません。
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel disabled={isDeleting} data-sentry-unmask>キャンセル</AlertDialogCancel>
-                        <AlertDialogAction onClick={handleDelete} data-sentry-unmask className="bg-red-600 hover:bg-red-700" disabled={isDeleting}>
-                            {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                            削除
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+            <ConfirmDeleteDialog />
 
             {commentTarget && (
                 <RecordCommentDialog

--- a/frontend/hooks/useRecordDelete.tsx
+++ b/frontend/hooks/useRecordDelete.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Loader2 } from "lucide-react"
+
+interface UseRecordDeleteProps {
+    onDelete: (id: number) => Promise<void>
+    onSuccess?: () => void
+    resourceName: string
+}
+
+export function useRecordDelete({ onDelete, onSuccess, resourceName }: UseRecordDeleteProps) {
+    const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
+    const [isDeleting, setIsDeleting] = useState(false)
+
+    const handleDelete = async () => {
+        if (deleteTargetId === null) return
+        setIsDeleting(true)
+        try {
+            await onDelete(deleteTargetId)
+            toast.success("削除しました")
+            if (onSuccess) onSuccess()
+            setDeleteTargetId(null)
+        } catch (e) {
+            console.error(e)
+            toast.error("削除に失敗しました")
+        } finally {
+            setIsDeleting(false)
+        }
+    }
+
+    const ConfirmDeleteDialog = () => (
+        <AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => { if (!open) setDeleteTargetId(null) }}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle data-sentry-unmask>記録の削除</AlertDialogTitle>
+                    <AlertDialogDescription data-sentry-unmask>
+                        この{resourceName}を削除しますか？この操作は取り消せません。
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel disabled={isDeleting} data-sentry-unmask>キャンセル</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleDelete} data-sentry-unmask className="bg-red-600 hover:bg-red-700" disabled={isDeleting}>
+                        {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        削除
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    )
+
+    return {
+        deleteTargetId,
+        setDeleteTargetId,
+        isDeleting,
+        handleDelete,
+        ConfirmDeleteDialog
+    }
+}


### PR DESCRIPTION
- **何を**: `HistoryCard` コンポーネントと `useRecordDelete` フックを作成し、`FeedingHistory`, `DiaperHistory`, `SleepHistory` の共通部分を抽出・置換しました。
- **なぜ**: 各履歴コンポーネントで重複していた削除ロジック（状態管理、APIコール、ダイアログ表示）と、リスト表示のボイラープレート（カード、データなし時の表示）を削減し、一貫性を向上させるため。
- **安全性**:
  - `pnpm lint` で構文エラーがないことを確認済み。
  - `pnpm build` でビルドが通ることを確認済み。
  - `pnpm test` で既存のテストがパスすることを確認済み。
  - `useEffect` 内の状態更新に関する警告に対して、`setTimeout` を使用して解決済み。

---
*PR created automatically by Jules for task [13012383238552501182](https://jules.google.com/task/13012383238552501182) started by @eburairu*