### PR TITLE
🧹 Tidy: 授乳統計ロジックの共通化

### DIFF
--- a/.jules/tidy.md
+++ b/.jules/tidy.md
@@ -176,3 +176,13 @@
 
 アクション:
 - 授乳（Feeding）や睡眠（Sleep）など、他の記録タイプでも同様の「ウィジェット vs 詳細ページ」の重複パターンがあるため、この正規化アダプターパターンを適用してリファクタリングを進める。
+
+2026-02-24 - [共通化] 授乳統計ロジックの正規化と共通化
+
+学び:
+- `FeedingWidget` と `useFeeding` フックで、授乳データの統計計算ロジック（今日の回数、経過時間など）が重複しており、データの型も異なっていた（`BabyRecord` vs `Feeding`）。
+- `diaperUtils` のパターンに倣い、`NormalizedFeeding` 型と正規化関数（`normalizeFeedingFromRecord`, `normalizeFeedingFromEntity`）を導入することで、異なる入力ソースから同一の統計ロジック（`calculateFeedingStats`）を利用できるようになった。
+- `FeedingStats` コンポーネントのプロップスを `snake_case` から `camelCase` に変更することで、TypeScript/JavaScript の標準的な命名規則に準拠させ、可読性を向上させた。
+
+アクション:
+- まだ `Growth` や `Sleep` に同様の重複が残っている可能性があるため、順次この「正規化アダプターパターン」を適用していく。

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -5,21 +5,20 @@ import { useMemo, memo } from "react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
 import { useQuickRecord } from "@/hooks/useQuickRecord"
 import { api } from "@/lib/api"
-import { formatElapsed, isToday } from "@/lib/ageUtils"
 import { WidgetCard } from "./WidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
 import { WidgetContent } from "./WidgetContent"
 import { WidgetQuickButton } from "./WidgetQuickButton"
+import { normalizeFeedingFromRecord, calculateFeedingStats, NormalizedFeeding } from "@/lib/feedingUtils"
 
 export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isError, mutate, isLoading }: BaseWidgetProps) {
     const { canWrite, loading, executeRecord } = useQuickRecord(babyId, { onSuccess: mutate })
 
-    const { todayCount, elapsed } = useMemo(() => {
-        const feedingRecords = records?.filter(r => r.type === 'feeding') ?? []
-        return {
-            todayCount: feedingRecords.filter((f) => isToday(f.timestamp)).length,
-            elapsed: feedingRecords[0] ? formatElapsed(feedingRecords[0].timestamp) : null,
-        }
+    const { todayCount, lastElapsed } = useMemo(() => {
+        const feedingRecords = records
+            ?.map(normalizeFeedingFromRecord)
+            .filter((f): f is NormalizedFeeding => f !== null) ?? []
+        return calculateFeedingStats(feedingRecords)
     }, [records])
 
     const handleQuickRecord = async (feedingType: string) => {
@@ -48,7 +47,7 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
             <WidgetContent
                 isLoading={isLoading}
                 loadingColorClass="text-rose-400"
-                elapsed={elapsed}
+                elapsed={lastElapsed}
                 subContent={`今日: ${todayCount}回`}
             />
             {canWrite ? (

--- a/frontend/components/feeding/feeding-stats.tsx
+++ b/frontend/components/feeding/feeding-stats.tsx
@@ -1,12 +1,12 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { FeedingSummary } from "@/types/feeding";
+import { FeedingStatsResult } from "@/lib/feedingUtils";
 import { Clock, Baby } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { ja } from "date-fns/locale";
 import { StatsBlock } from "@/components/ui/stats-block";
 
 interface FeedingStatsProps {
-    summary: FeedingSummary;
+    summary: FeedingStatsResult;
 }
 
 const BREAST_SIDE_LABEL: Record<string, string> = {
@@ -22,14 +22,14 @@ const NEXT_SIDE_GUIDE: Record<string, string> = {
 };
 
 export function FeedingStats({ summary }: FeedingStatsProps) {
-    const timeSinceLast = summary.last_feeding_time
-        ? formatDistanceToNow(new Date(summary.last_feeding_time), {
+    const timeSinceLast = summary.lastFeedingTime
+        ? formatDistanceToNow(new Date(summary.lastFeedingTime), {
             addSuffix: true,
             locale: ja,
         })
         : "記録なし";
 
-    const hasLeftRight = summary.today_left_duration > 0 || summary.today_right_duration > 0;
+    const hasLeftRight = summary.todayLeftDuration > 0 || summary.todayRightDuration > 0;
 
     return (
         <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 mb-6 transition-colors">
@@ -39,20 +39,20 @@ export function FeedingStats({ summary }: FeedingStatsProps) {
                     <StatsBlock
                         icon={Baby}
                         label="今日"
-                        value={`${summary.today_count}回`}
+                        value={`${summary.todayCount}回`}
                         color="rose"
                     >
                         <div className="text-[10px] text-gray-500 dark:text-zinc-500 space-y-0.5 mt-0.5">
-                            {summary.today_duration > 0 && (
-                                <p>母乳 {summary.today_duration}分</p>
+                            {summary.todayDuration > 0 && (
+                                <p>母乳 {summary.todayDuration}分</p>
                             )}
                             {hasLeftRight && (
                                 <p className="text-rose-500 dark:text-rose-400">
-                                    └ 左{summary.today_left_duration}分 / 右{summary.today_right_duration}分
+                                    └ 左{summary.todayLeftDuration}分 / 右{summary.todayRightDuration}分
                                 </p>
                             )}
-                            {summary.today_amount > 0 && (
-                                <p>ミルク {summary.today_amount}ml</p>
+                            {summary.todayAmount > 0 && (
+                                <p>ミルク {summary.todayAmount}ml</p>
                             )}
                         </div>
                     </StatsBlock>
@@ -66,16 +66,16 @@ export function FeedingStats({ summary }: FeedingStatsProps) {
                     >
                         <div className="text-[10px] text-gray-500 dark:text-zinc-500 space-y-0.5 mt-0.5">
                             <p>
-                                {summary.last_feeding_type === "BREAST" ? "母乳" : null}
-                                {summary.last_feeding_type === "BOTTLE" ? "ミルク" : null}
-                                {summary.last_feeding_type === "MIXED" ? "混合" : null}
-                                {summary.last_breast_side && summary.last_feeding_type !== "BOTTLE" ? (
-                                    <span className="ml-1">({BREAST_SIDE_LABEL[summary.last_breast_side]}から)</span>
+                                {summary.lastFeedingType === "BREAST" ? "母乳" : null}
+                                {summary.lastFeedingType === "BOTTLE" ? "ミルク" : null}
+                                {summary.lastFeedingType === "MIXED" ? "混合" : null}
+                                {summary.lastBreastSide && summary.lastFeedingType !== "BOTTLE" ? (
+                                    <span className="ml-1">({BREAST_SIDE_LABEL[summary.lastBreastSide]}から)</span>
                                 ) : null}
                             </p>
-                            {summary.last_breast_side && summary.last_breast_side !== "BOTH" && (
+                            {summary.lastBreastSide && summary.lastBreastSide !== "BOTH" && (
                                 <p className="text-rose-500 dark:text-rose-400 font-medium">
-                                    💡 {NEXT_SIDE_GUIDE[summary.last_breast_side]}
+                                    💡 {NEXT_SIDE_GUIDE[summary.lastBreastSide]}
                                 </p>
                             )}
                         </div>

--- a/frontend/hooks/useFeeding.ts
+++ b/frontend/hooks/useFeeding.ts
@@ -1,7 +1,8 @@
 import useSWR from 'swr';
 import { client, throwOnError } from '@/lib/api-client';
-import { Feeding, FeedingCreate, FeedingUpdate, FeedingSummary } from '@/types/feeding';
+import { Feeding, FeedingCreate, FeedingUpdate } from '@/types/feeding';
 import { useMemo } from 'react';
+import { normalizeFeedingFromEntity, calculateFeedingStats, FeedingStatsResult } from '@/lib/feedingUtils';
 
 export function useFeeding(babyId: number | null) {
     const { data: feedings, error, mutate } = useSWR(
@@ -14,74 +15,9 @@ export function useFeeding(babyId: number | null) {
 
     const loading = !feedings && !error;
 
-    const summary: FeedingSummary = useMemo(() => {
-        if (!feedings || feedings.length === 0) {
-            return {
-                today_count: 0,
-                today_duration: 0,
-                today_amount: 0,
-                last_feeding_time: null,
-                last_feeding_type: null,
-                last_breast_side: null,
-                today_left_duration: 0,
-                today_right_duration: 0,
-                last_milk_amount: null,
-            };
-        }
-
-        const now = new Date();
-        const todayYear = now.getFullYear();
-        const todayMonth = now.getMonth();
-        const todayDate = now.getDate();
-
-        let todayCount = 0;
-        let todayDuration = 0;
-        let todayAmount = 0;
-        let todayLeftDuration = 0;
-        let todayRightDuration = 0;
-
-        for (const f of feedings) {
-            const d = new Date(f.feeding_time);
-            if (d.getDate() === todayDate && d.getMonth() === todayMonth && d.getFullYear() === todayYear) {
-                todayCount++;
-
-                const type = f.feeding_type;
-                if (type === 'BREAST' || type === 'MIXED') {
-                    todayDuration += (f.duration_minutes || 0);
-                    todayLeftDuration += (f.left_breast_minutes || 0);
-                    todayRightDuration += (f.right_breast_minutes || 0);
-                }
-                if (type === 'BOTTLE' || type === 'MIXED') {
-                    todayAmount += (f.amount_ml || 0);
-                }
-            }
-        }
-
-        // 直近の母乳記録から最終授乳側を取得
-        const lastBreastFeeding = feedings.find(
-            f => f.feeding_type === 'BREAST' || f.feeding_type === 'MIXED'
-        );
-        const lastBreastSide = lastBreastFeeding?.last_breast_side ?? null;
-
-        // 直近のミルク記録から前回量を取得
-        const lastMilkFeeding = feedings.find(
-            f => (f.feeding_type === 'BOTTLE' || f.feeding_type === 'MIXED') && f.amount_ml !== null
-        );
-        const lastMilkAmount = lastMilkFeeding?.amount_ml ?? null;
-
-        const lastFeeding = feedings[0];
-
-        return {
-            today_count: todayCount,
-            today_duration: todayDuration,
-            today_amount: todayAmount,
-            last_feeding_time: lastFeeding?.feeding_time ?? null,
-            last_feeding_type: lastFeeding?.feeding_type ?? null,
-            last_breast_side: lastBreastSide,
-            today_left_duration: todayLeftDuration,
-            today_right_duration: todayRightDuration,
-            last_milk_amount: lastMilkAmount,
-        };
+    const summary: FeedingStatsResult = useMemo(() => {
+        const normalizedFeedings = feedings?.map(normalizeFeedingFromEntity) ?? [];
+        return calculateFeedingStats(normalizedFeedings);
     }, [feedings]);
 
     const addFeeding = async (data: FeedingCreate): Promise<Feeding | undefined> => {

--- a/frontend/lib/feedingUtils.ts
+++ b/frontend/lib/feedingUtils.ts
@@ -1,0 +1,112 @@
+import { BabyRecord } from "@/types/record"
+import { Feeding, FeedingType, BreastSide } from "@/types/feeding"
+import { isToday, formatElapsed } from "@/lib/ageUtils"
+
+export interface NormalizedFeeding {
+    id: number
+    timestamp: string // ISO
+    type: FeedingType
+    amount: number
+    duration: number
+    leftDuration: number
+    rightDuration: number
+    lastBreastSide: BreastSide | null
+}
+
+interface FeedingDetails {
+    feeding_type?: string
+    amount_ml?: number
+    duration_minutes?: number
+}
+
+export function normalizeFeedingFromRecord(record: BabyRecord): NormalizedFeeding | null {
+    if (record.type !== 'feeding') return null
+
+    const details = record.details as unknown as FeedingDetails
+
+    // feeding_type がない場合はデフォルトで BOTTLE にするなどの安全策
+    const type = (details.feeding_type as FeedingType) || 'BOTTLE'
+    return {
+        id: record.id,
+        timestamp: record.timestamp,
+        type: type,
+        amount: details.amount_ml || 0,
+        duration: details.duration_minutes || 0,
+        leftDuration: 0, // レコードAPIからは取得不可
+        rightDuration: 0, // レコードAPIからは取得不可
+        lastBreastSide: null // レコードAPIからは取得不可
+    }
+}
+
+export function normalizeFeedingFromEntity(feeding: Feeding): NormalizedFeeding {
+    return {
+        id: feeding.id,
+        timestamp: feeding.feeding_time,
+        type: feeding.feeding_type,
+        amount: feeding.amount_ml || 0,
+        duration: feeding.duration_minutes || 0,
+        leftDuration: feeding.left_breast_minutes || 0,
+        rightDuration: feeding.right_breast_minutes || 0,
+        lastBreastSide: feeding.last_breast_side || null
+    }
+}
+
+export interface FeedingStatsResult {
+    todayCount: number
+    todayDuration: number
+    todayAmount: number
+    todayLeftDuration: number
+    todayRightDuration: number
+    lastFeedingTime: string | null
+    lastFeedingType: FeedingType | null
+    lastBreastSide: BreastSide | null
+    lastMilkAmount: number | null
+    lastElapsed: string | null
+}
+
+export function calculateFeedingStats(feedings: NormalizedFeeding[]): FeedingStatsResult {
+    const todayFeedings = feedings.filter((f) => isToday(f.timestamp))
+
+    let todayDuration = 0
+    let todayAmount = 0
+    let todayLeftDuration = 0
+    let todayRightDuration = 0
+
+    for (const f of todayFeedings) {
+        if (f.type === 'BREAST' || f.type === 'MIXED') {
+            todayDuration += f.duration
+            todayLeftDuration += f.leftDuration
+            todayRightDuration += f.rightDuration
+        }
+        if (f.type === 'BOTTLE' || f.type === 'MIXED') {
+            todayAmount += f.amount
+        }
+    }
+
+    const lastFeeding = feedings[0]
+
+    // 直近の母乳記録から最終授乳側を取得
+    const lastBreastFeeding = feedings.find(
+        f => f.type === 'BREAST' || f.type === 'MIXED'
+    )
+    const lastBreastSide = lastBreastFeeding?.lastBreastSide ?? null
+
+    // 直近のミルク記録から前回量を取得
+    const lastMilkFeeding = feedings.find(
+        f => (f.type === 'BOTTLE' || f.type === 'MIXED') && f.amount > 0
+    )
+    const lastMilkAmount = lastMilkFeeding?.amount ?? null
+
+    return {
+        todayCount: todayFeedings.length,
+        todayDuration,
+        todayAmount,
+        todayLeftDuration,
+        todayRightDuration,
+        lastFeedingTime: lastFeeding ? lastFeeding.timestamp : null,
+        lastFeedingType: lastFeeding ? lastFeeding.type : null,
+        lastBreastSide,
+        lastMilkAmount,
+        lastElapsed: lastFeeding ? formatElapsed(lastFeeding.timestamp) : null
+    }
+}

--- a/frontend/types/feeding.ts
+++ b/frontend/types/feeding.ts
@@ -8,7 +8,9 @@ export type Feeding = components["schemas"]["FeedingResponse"]
 export type FeedingCreate = components["schemas"]["FeedingCreate"]
 export type FeedingUpdate = components["schemas"]["FeedingUpdate"]
 
-// フロントエンド固有の計算型（手動管理）
+/**
+ * @deprecated Use FeedingStatsResult from @/lib/feedingUtils instead
+ */
 export interface FeedingSummary {
     today_count: number
     today_duration: number // minutes (母乳合計)


### PR DESCRIPTION
💡 何を:
- `FeedingWidget` と `useFeeding` フックで重複していた統計計算ロジック（今日の授乳回数、母乳・ミルクの合計、左右の内訳など）を `frontend/lib/feedingUtils.ts` に抽出・共通化した。
- `NormalizedFeeding` 型と `normalizeFeedingFromRecord`, `normalizeFeedingFromEntity` アダプター関数を導入し、`BabyRecord`（ウィジェット用）と `Feeding` エンティティ（詳細ページ用）の両方から同じ統計ロジックを利用できるようにした。
- `FeedingStats` コンポーネントのプロップスを `snake_case` から `camelCase` に変更し、TypeScriptの命名規則に合わせた。

🎯 なぜ:
- ウィジェットと詳細ページで数値のズレが発生するリスクを排除するため。
- 将来的な統計項目の追加や修正を1箇所で行えるようにするため。
- コードの可読性と一貫性を向上させるため。

🛡️ 安全性:
- `pnpm lint`, `pnpm build`, `pnpm test` を実行し、既存の機能に影響がないことを確認した。
- 型定義の変更に伴うコンパイルエラーを修正し、`FeedingSummary` を `deprecated` としてマークした。

---
*PR created automatically by Jules for task [2926484431039250992](https://jules.google.com/task/2926484431039250992) started by @eburairu*