### PR TITLE
fix: 管理者ダッシュボードの家族一覧でデータが表示されないバグを修正

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -82,7 +82,7 @@ def get_admin_families(
     families = db.query(Family).offset(skip).limit(limit).all()
     result = []
     for f in families:
-        member_count = db.query(func.count(FamilyUser.id)).filter(FamilyUser.family_id == f.id).scalar()
+        member_count = db.query(func.count(FamilyUser.user_id)).filter(FamilyUser.family_id == f.id).scalar()
         result.append(FamilyAdminResponse(
             id=f.id,
             name=f.name,


### PR DESCRIPTION
## 概要
管理者ダッシュボードの家族一覧画面（`/admin/families`）で、データが表示されない不具合を修正しました。

## 原因
家族メンバー数を取得する `db.query(func.count(FamilyUser.id))` において、`FamilyUser` テーブルは複合プライマリキー（`family_id` と `user_id`）であり、単一の `id` カラムを持たないため、`AttributeError` になり 500 エラーが発生していました。

## 修正内容
`FamilyUser.id` を、複合プライマリキーの一部である `FamilyUser.user_id` を使用するように変更しました。

Closes #XXX