### PR TITLE
feat: ダッシュボードの赤ちゃんの特徴を収納・展開可能に変更

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -37,7 +37,7 @@ class FamilyAdminResponse(BaseModel):
     member_count: int
     created_at: datetime
 
-class FamilyMemberResponse(BaseModel):
+class AdminFamilyMemberResponse(BaseModel):
     user_id: int
     username: str
     display_name: Optional[str] = None
@@ -56,7 +56,7 @@ class FamilyDetailResponse(BaseModel):
     name: str
     member_count: int
     created_at: datetime
-    members: List[FamilyMemberResponse]
+    members: List[AdminFamilyMemberResponse]
     babies: List[BabyAdminResponse]
 
 class UserAdminResponse(UserResponse):
@@ -137,7 +137,7 @@ def get_admin_family_detail(
         .all()
     )
     members = [
-        FamilyMemberResponse(
+        AdminFamilyMemberResponse(
             user_id=fu.user.id,
             username=fu.user.username,
             display_name=fu.user.display_name,

--- a/frontend/components/dashboard/BabyProfileCard.tsx
+++ b/frontend/components/dashboard/BabyProfileCard.tsx
@@ -1,6 +1,6 @@
 "use client"
-import React from "react"
-import { Sparkles } from "lucide-react"
+import React, { useState } from "react"
+import { Sparkles, ChevronDown } from "lucide-react"
 import { calcAge } from "@/lib/ageUtils"
 import { getPrenatalLabel } from "@/lib/babyUtils"
 
@@ -21,6 +21,7 @@ export const BabyProfileCard = React.memo(function BabyProfileCard({ babies, sel
     const selected = babies.find((b) => b.id === selectedBabyId)
     const age = selected?.birthday ? calcAge(selected.birthday) : null
     const prenatalLabel = !selected?.birthday ? getPrenatalLabel(selected?.due_date) : null
+    const [isCharacteristicsExpanded, setIsCharacteristicsExpanded] = useState(false)
 
     return (
         <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 transition-colors">
@@ -38,15 +39,33 @@ export const BabyProfileCard = React.memo(function BabyProfileCard({ babies, sel
 
                 {selected?.characteristics && (
                     <div className="mt-1 pt-3 border-t border-gray-50 dark:border-zinc-800">
-                        <div className="flex items-center gap-1.5 mb-2 px-1">
-                            <Sparkles className="w-3.5 h-3.5 text-amber-500 dark:text-amber-400 fill-amber-500/10" />
-                            <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-zinc-500">
-                                赤ちゃんの特徴
-                            </span>
+                        <button
+                            onClick={() => setIsCharacteristicsExpanded(!isCharacteristicsExpanded)}
+                            className="flex items-center justify-between w-full mb-2 px-1 py-1 -mx-1 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 transition-colors hover:bg-gray-50 dark:hover:bg-zinc-800/50"
+                        >
+                            <div className="flex items-center gap-1.5">
+                                <Sparkles className="w-3.5 h-3.5 text-amber-500 dark:text-amber-400 fill-amber-500/10" />
+                                <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-zinc-500">
+                                    赤ちゃんの特徴
+                                </span>
+                            </div>
+                            <ChevronDown
+                                className={`w-4 h-4 text-gray-400 transition-transform duration-200 ${
+                                    isCharacteristicsExpanded ? "rotate-180" : ""
+                                }`}
+                            />
+                        </button>
+                        <div
+                            className={`grid transition-all duration-300 ease-in-out ${
+                                isCharacteristicsExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+                            }`}
+                        >
+                            <div className="overflow-hidden">
+                                <p className="text-sm text-gray-700 dark:text-zinc-300 leading-relaxed bg-amber-50/30 dark:bg-amber-950/10 p-3.5 rounded-xl border border-amber-100/50 dark:border-amber-900/20 whitespace-pre-wrap">
+                                    {selected.characteristics}
+                                </p>
+                            </div>
                         </div>
-                        <p className="text-sm text-gray-700 dark:text-zinc-300 leading-relaxed bg-amber-50/30 dark:bg-amber-950/10 p-3.5 rounded-xl border border-amber-100/50 dark:border-amber-900/20 whitespace-pre-wrap">
-                            {selected.characteristics}
-                        </p>
                     </div>
                 )}
             </div>

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -64,6 +64,46 @@
         "title": "AISettingsSummary",
         "type": "object"
       },
+      "AdminFamilyMemberResponse": {
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "joined_at": {
+            "format": "date-time",
+            "title": "Joined At",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "username",
+          "role",
+          "joined_at"
+        ],
+        "title": "AdminFamilyMemberResponse",
+        "type": "object"
+      },
       "AdminStats": {
         "properties": {
           "active_users_last_24h": {
@@ -1168,7 +1208,7 @@
           },
           "members": {
             "items": {
-              "$ref": "#/components/schemas/app__routers__admin__FamilyMemberResponse"
+              "$ref": "#/components/schemas/AdminFamilyMemberResponse"
             },
             "title": "Members",
             "type": "array"
@@ -1187,6 +1227,45 @@
           "babies"
         ],
         "title": "FamilyDetailResponse",
+        "type": "object"
+      },
+      "FamilyMemberResponse": {
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "joined_at": {
+            "format": "date-time",
+            "title": "Joined At",
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/UserRole"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "username",
+          "role",
+          "joined_at"
+        ],
+        "title": "FamilyMemberResponse",
         "type": "object"
       },
       "FamilyResponse": {
@@ -2900,85 +2979,6 @@
           "version"
         ],
         "title": "VersionResponse",
-        "type": "object"
-      },
-      "app__routers__admin__FamilyMemberResponse": {
-        "properties": {
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "joined_at": {
-            "format": "date-time",
-            "title": "Joined At",
-            "type": "string"
-          },
-          "role": {
-            "title": "Role",
-            "type": "string"
-          },
-          "user_id": {
-            "title": "User Id",
-            "type": "integer"
-          },
-          "username": {
-            "title": "Username",
-            "type": "string"
-          }
-        },
-        "required": [
-          "user_id",
-          "username",
-          "role",
-          "joined_at"
-        ],
-        "title": "FamilyMemberResponse",
-        "type": "object"
-      },
-      "app__schemas__family__FamilyMemberResponse": {
-        "properties": {
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "joined_at": {
-            "format": "date-time",
-            "title": "Joined At",
-            "type": "string"
-          },
-          "role": {
-            "$ref": "#/components/schemas/UserRole"
-          },
-          "user_id": {
-            "title": "User Id",
-            "type": "integer"
-          },
-          "username": {
-            "title": "Username",
-            "type": "string"
-          }
-        },
-        "required": [
-          "user_id",
-          "username",
-          "role",
-          "joined_at"
-        ],
-        "title": "FamilyMemberResponse",
         "type": "object"
       }
     }
@@ -4824,7 +4824,7 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/app__schemas__family__FamilyMemberResponse"
+                    "$ref": "#/components/schemas/FamilyMemberResponse"
                   },
                   "title": "Response Get Family Members Api Family Members Get",
                   "type": "array"
@@ -4946,7 +4946,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/app__schemas__family__FamilyMemberResponse"
+                  "$ref": "#/components/schemas/FamilyMemberResponse"
                 }
               }
             },

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -21,6 +21,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/families/{family_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Admin Family Detail */
+        get: operations["get_admin_family_detail_api_admin_families__family_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/stats": {
         parameters: {
             query?: never;
@@ -1005,6 +1022,22 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** AdminFamilyMemberResponse */
+        AdminFamilyMemberResponse: {
+            /** Display Name */
+            display_name?: string | null;
+            /**
+             * Joined At
+             * Format: date-time
+             */
+            joined_at: string;
+            /** Role */
+            role: string;
+            /** User Id */
+            user_id: number;
+            /** Username */
+            username: string;
+        };
         /** AdminStats */
         AdminStats: {
             /** Active Users Last 24H */
@@ -1034,6 +1067,22 @@ export interface components {
             type: components["schemas"]["NotificationType"];
             /** Url */
             url?: string | null;
+        };
+        /** BabyAdminResponse */
+        BabyAdminResponse: {
+            /** Birthday */
+            birthday?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Gender */
+            gender?: string | null;
+            /** Id */
+            id: number;
+            /** Name */
+            name: string;
         };
         /** BabyCreate */
         BabyCreate: {
@@ -1342,6 +1391,24 @@ export interface components {
             password: string;
             /** Username */
             username: string;
+        };
+        /** FamilyDetailResponse */
+        FamilyDetailResponse: {
+            /** Babies */
+            babies: components["schemas"]["BabyAdminResponse"][];
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Id */
+            id: number;
+            /** Member Count */
+            member_count: number;
+            /** Members */
+            members: components["schemas"]["AdminFamilyMemberResponse"][];
+            /** Name */
+            name: string;
         };
         /** FamilyMemberResponse */
         FamilyMemberResponse: {
@@ -1938,6 +2005,7 @@ export interface operations {
             query?: {
                 skip?: number;
                 limit?: number;
+                search?: string | null;
             };
             header?: never;
             path?: never;
@@ -1952,6 +2020,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FamilyAdminResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_admin_family_detail_api_admin_families__family_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                family_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FamilyDetailResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## 概要
ダッシュボード（BabyProfileCard）に表示される赤ちゃんの特徴を収納し、展開できるように変更しました。

## 変更内容
- \`BabyProfileCard.tsx\` において、特徴の表示部分に \`useState\` を導入し、展開/収納のトグルボタンを追加。
- OpenAPIスキーマの型競合を解消するため \`app/routers/admin.py\` 内の \`FamilyMemberResponse\` を \`AdminFamilyMemberResponse\` にリネーム。

