### PR TITLE
test: 睡眠・おむつ・成長記録のバックエンドテストを追加

### DIFF
--- a/tests/test_diaper.py
+++ b/tests/test_diaper.py
@@ -1,0 +1,169 @@
+import pytest
+from fastapi.testclient import TestClient
+from datetime import datetime, timedelta
+from app.models.diaper import Diaper
+from app.models.baby import Baby
+
+def test_get_diapers_unauthorized(client: TestClient):
+    response = client.get("/api/diapers/?baby_id=1")
+    assert response.status_code == 401
+
+def test_get_diapers_missing_baby_id(client: TestClient, auth_client):
+    client = auth_client()
+    response = client.get("/api/diapers/")
+    assert response.status_code == 422
+
+def test_create_diaper(client: TestClient, auth_client):
+    client = auth_client()
+    
+    # 赤ちゃんを登録
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    assert baby_res.status_code == 200
+    baby_id = baby_res.json()["id"]
+
+    # WET (おしっこ) の作成
+    resp_wet = client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now().isoformat(),
+            "diaper_type": "WET",
+            "notes": "おしっこ多め"
+        }
+    )
+    assert resp_wet.status_code == 200
+    assert resp_wet.json()["diaper_type"] == "WET"
+    assert resp_wet.json()["notes"] == "おしっこ多め"
+
+    # DIRTY (うんち) の作成
+    resp_dirty = client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now().isoformat(),
+            "diaper_type": "DIRTY"
+        }
+    )
+    assert resp_dirty.status_code == 200
+    assert resp_dirty.json()["diaper_type"] == "DIRTY"
+
+    # BOTH (両方) の作成
+    resp_both = client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now().isoformat(),
+            "diaper_type": "BOTH"
+        }
+    )
+    assert resp_both.status_code == 200
+    assert resp_both.json()["diaper_type"] == "BOTH"
+
+def test_get_diapers_list(client: TestClient, auth_client):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    # 記録を1つ作成
+    client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": (datetime.now() - timedelta(hours=1)).isoformat(),
+            "diaper_type": "WET"
+        }
+    )
+
+    # 一覧取得
+    response = client.get(f"/api/diapers/?baby_id={baby_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    assert "recorded_by_display_name" in data[0]
+    assert "comment_count" in data[0]
+
+def test_update_diaper(client: TestClient, auth_client):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    # 作成
+    resp = client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now().isoformat(),
+            "diaper_type": "WET"
+        }
+    )
+    diaper_id = resp.json()["id"]
+
+    # 更新
+    new_time = (datetime.now() - timedelta(minutes=30)).isoformat()
+    response = client.put(
+        f"/api/diapers/{diaper_id}",
+        json={
+            "diaper_type": "BOTH",
+            "notes": "更新後のメモ",
+            "change_time": new_time
+        }
+    )
+    assert response.status_code == 200
+    assert response.json()["diaper_type"] == "BOTH"
+    assert response.json()["notes"] == "更新後のメモ"
+
+def test_delete_diaper(client: TestClient, auth_client, db):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    # 作成
+    resp = client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now().isoformat(),
+            "diaper_type": "WET"
+        }
+    )
+    diaper_id = resp.json()["id"]
+
+    # 削除
+    response = client.delete(f"/api/diapers/{diaper_id}")
+    assert response.status_code == 200
+    
+    # データベースに存在しないことを確認
+    assert db.query(Diaper).filter(Diaper.id == diaper_id).first() is None
+
+def test_diaper_access_control(client: TestClient, auth_client):
+    # ユーザー1が赤ちゃんを登録
+    client1 = auth_client(username="user1", family_name="Family1")
+    baby_res = client1.post("/api/babies/", json={"name": "赤ちゃん1", "gender": "girl"})
+    baby_id = baby_res.json()["id"]
+    
+    # ユーザー1が記録を作成
+    diaper_res = client1.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now().isoformat(),
+            "diaper_type": "WET"
+        }
+    )
+    diaper_id = diaper_res.json()["id"]
+
+    # ユーザー2（別の家族）がログイン
+    client2 = auth_client(username="user2", family_name="Family2")
+    
+    # 他の家族の赤ちゃんの一覧を取得しようとする -> 403
+    resp_get = client2.get(f"/api/diapers/?baby_id={baby_id}")
+    assert resp_get.status_code == 403
+    
+    # 他の家族の記録を更新しようとする -> 403
+    resp_put = client2.put(f"/api/diapers/{diaper_id}", json={"notes": "不正アクセス"})
+    assert resp_put.status_code == 403
+    
+    # 他の家族の記録を削除しようとする -> 403
+    resp_del = client2.delete(f"/api/diapers/{diaper_id}")
+    assert resp_del.status_code == 403

--- a/tests/test_growth.py
+++ b/tests/test_growth.py
@@ -1,0 +1,116 @@
+import pytest
+from fastapi.testclient import TestClient
+from datetime import date
+from app.models.growth import Growth
+from app.models.baby import Baby
+
+def test_get_growths_unauthenticated(client: TestClient):
+    response = client.get("/api/growths/?baby_id=1")
+    assert response.status_code == 401
+
+def test_get_growths_missing_baby_id(client: TestClient, auth_client):
+    client = auth_client()
+    response = client.get("/api/growths/")
+    assert response.status_code == 422
+
+def test_create_growth_success(client: TestClient, auth_client):
+    client = auth_client()
+    # 赤ちゃんを作成
+    baby_res = client.post("/api/babies/", json={"name": "成長テスト", "gender": "girl"})
+    baby_id = baby_res.json()["id"]
+
+    payload = {
+        "baby_id": baby_id,
+        "date": date.today().isoformat(),
+        "weight": 3500,
+        "height": 51.5,
+        "head_circumference": 34.0,
+        "notes": "順調です"
+    }
+    response = client.post("/api/growths/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["weight"] == 3500
+    assert data["height"] == 51.5
+    assert data["recorded_by_display_name"] == "testuser"
+
+def test_get_growths_list(client: TestClient, auth_client):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "リストテスト", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    # 2件作成
+    for i in range(2):
+        client.post("/api/growths/", json={
+            "baby_id": baby_id,
+            "date": date.today().isoformat(),
+            "weight": 3000 + i,
+            "height": 50.0 + i
+        })
+
+    response = client.get(f"/api/growths/?baby_id={baby_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+
+def test_update_growth(client: TestClient, auth_client):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "更新テスト", "gender": "girl"})
+    baby_id = baby_res.json()["id"]
+
+    # 作成
+    create_res = client.post("/api/growths/", json={
+        "baby_id": baby_id,
+        "date": date.today().isoformat(),
+        "weight": 4000
+    })
+    growth_id = create_res.json()["id"]
+
+    # 更新
+    update_payload = {"weight": 4100, "notes": "修正しました"}
+    response = client.put(f"/api/growths/{growth_id}", json=update_payload)
+    assert response.status_code == 200
+    assert response.json()["weight"] == 4100
+    assert response.json()["notes"] == "修正しました"
+
+def test_delete_growth(client: TestClient, auth_client, db):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "削除テスト", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    # 作成
+    create_res = client.post("/api/growths/", json={
+        "baby_id": baby_id,
+        "date": date.today().isoformat(),
+        "weight": 5000
+    })
+    growth_id = create_res.json()["id"]
+
+    # 削除
+    response = client.delete(f"/api/growths/{growth_id}")
+    assert response.status_code == 200
+    
+    # DB確認
+    record = db.query(Growth).filter(Growth.id == growth_id).first()
+    assert record is None
+
+def test_access_other_family_baby(client: TestClient, auth_client):
+    # 家族Aのユーザーで赤ちゃんAを作成
+    client_a = auth_client(username="user_a", family_name="Family A")
+    baby_a_res = client_a.post("/api/babies/", json={"name": "Baby A", "gender": "boy"})
+    baby_a_id = baby_a_res.json()["id"]
+
+    # 家族Bのユーザーでログイン
+    client_b = auth_client(username="user_b", family_name="Family B")
+
+    # 家族Bが赤ちゃんAのデータを取得しようとする -> 403
+    response = client_b.get(f"/api/growths/?baby_id={baby_a_id}")
+    assert response.status_code == 403
+
+    # 家族Bが赤ちゃんAに記録しようとする -> 403
+    response = client_b.post("/api/growths/", json={
+        "baby_id": baby_a_id,
+        "date": date.today().isoformat(),
+        "weight": 3000
+    })
+    assert response.status_code == 403

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -1,0 +1,112 @@
+import pytest
+from fastapi.testclient import TestClient
+from datetime import datetime, timedelta
+from app.models.sleep import Sleep
+from app.models.baby import Baby
+
+def test_get_sleeps_missing_baby_id(client: TestClient, auth_client):
+    client = auth_client()
+    response = client.get("/api/sleeps/")
+    # Query parameter baby_id is required
+    assert response.status_code == 422
+
+def test_get_sleeps_unauthorized(client: TestClient):
+    response = client.get("/api/sleeps/?baby_id=1")
+    assert response.status_code == 401
+
+def test_create_sleep_success(client: TestClient, auth_client):
+    client = auth_client()
+    
+    # Create a baby first
+    baby_res = client.post("/api/babies/", json={"name": "Sleepy Baby", "gender": "girl"})
+    baby_id = baby_res.json()["id"]
+    
+    start_time = datetime.now().isoformat()
+    response = client.post(
+        "/api/sleeps/",
+        json={
+            "baby_id": baby_id,
+            "start_time": start_time,
+            "notes": "お昼寝開始"
+        }
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["baby_id"] == baby_id
+    assert data["notes"] == "お昼寝開始"
+    assert data["end_time"] is None
+    assert "recorded_by_display_name" in data
+
+def test_get_sleeps_list(client: TestClient, auth_client):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "Sleepy Baby", "gender": "girl"})
+    baby_id = baby_res.json()["id"]
+    
+    # Create a record
+    client.post(
+        "/api/sleeps/",
+        json={"baby_id": baby_id, "start_time": datetime.now().isoformat()}
+    )
+    
+    response = client.get(f"/api/sleeps/?baby_id={baby_id}")
+    assert response.status_code == 200
+    assert len(response.json()) >= 1
+
+def test_access_other_family_baby(client: TestClient, auth_client):
+    # Family A creates a baby
+    client_a = auth_client(username="user_a", family_name="Family A")
+    baby_res = client_a.post("/api/babies/", json={"name": "Baby A", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+    
+    # Family B tries to access Baby A
+    client_b = auth_client(username="user_b", family_name="Family B")
+    
+    # GET
+    resp_get = client_b.get(f"/api/sleeps/?baby_id={baby_id}")
+    assert resp_get.status_code == 403
+    
+    # POST
+    resp_post = client_b.post(
+        "/api/sleeps/",
+        json={"baby_id": baby_id, "start_time": datetime.now().isoformat()}
+    )
+    assert resp_post.status_code == 403
+
+def test_update_sleep(client: TestClient, auth_client):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "Sleepy Baby", "gender": "girl"})
+    baby_id = baby_res.json()["id"]
+    
+    # Start sleep
+    start_resp = client.post(
+        "/api/sleeps/",
+        json={"baby_id": baby_id, "start_time": (datetime.now() - timedelta(hours=1)).isoformat()}
+    )
+    sleep_id = start_resp.json()["id"]
+    
+    # Stop sleep (update end_time)
+    end_time = datetime.now().isoformat()
+    response = client.patch(
+        f"/api/sleeps/{sleep_id}",
+        json={"end_time": end_time, "notes": "スッキリ起きた"}
+    )
+    assert response.status_code == 200
+    assert response.json()["notes"] == "スッキリ起きた"
+    assert response.json()["end_time"] is not None
+
+def test_delete_sleep(client: TestClient, auth_client, db):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "Sleepy Baby", "gender": "girl"})
+    baby_id = baby_res.json()["id"]
+    
+    resp = client.post(
+        "/api/sleeps/",
+        json={"baby_id": baby_id, "start_time": datetime.now().isoformat()}
+    )
+    sleep_id = resp.json()["id"]
+    
+    response = client.delete(f"/api/sleeps/{sleep_id}")
+    assert response.status_code == 200
+    
+    # Verify deletion
+    assert db.query(Sleep).filter(Sleep.id == sleep_id).first() is None


### PR DESCRIPTION
## 概要

TDDワークフローに則っていなかった3機能（睡眠記録・おむつ記録・成長記録）のバックエンドテストを追加。

仕様書（`.specify/specs/tracking/`）のACを抽出し、新規テストファイルを作成。既存実装が仕様を満たしていることを134件のテスト（全Green）で確認した。

## 追加ファイル

| ファイル | テスト数 | 対象機能 |
|---------|---------|---------|
| `tests/test_sleep.py` | 7 | 睡眠記録 CRUD・認証・アクセス制御 |
| `tests/test_diaper.py` | 7 | おむつ記録 CRUD・種別（WET/DIRTY/BOTH）・アクセス制御 |
| `tests/test_growth.py` | 7 | 成長記録 CRUD・認証・アクセス制御 |

## テスト観点

- 未認証アクセス → 401
- `baby_id` なし GET → 422
- 正常 CRUD（作成・一覧取得・更新・削除）
- 他ファミリーの赤ちゃんへのアクセス → 403
- DB整合性確認（削除後にレコードが存在しないこと）

## 検証

- `npm run test:backend`: 134 passed（全Green）
- `sh scripts/verify_all.sh`: 全チェックパス