### PR TITLE
fix: DNDおやすみモードの時刻判定をJSTに修正

### DIFF
--- a/app/utils/notifications.py
+++ b/app/utils/notifications.py
@@ -4,7 +4,9 @@ import logging
 from pywebpush import webpush, WebPushException
 from sqlalchemy.orm import Session
 from app.models.notification import AppNotification, PushSubscription, NotificationSetting
-from datetime import datetime, time
+from datetime import datetime, time, timezone, timedelta
+
+JST = timezone(timedelta(hours=9))
 from fastapi import BackgroundTasks
 from app.database import SessionLocal
 
@@ -19,7 +21,7 @@ def is_within_dnd(settings: NotificationSetting) -> bool:
     if not settings.dnd_start_time or not settings.dnd_end_time:
         return False
 
-    now = datetime.now().time()
+    now = datetime.now(JST).time()
     start = settings.dnd_start_time
     end = settings.dnd_end_time
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -3,7 +3,10 @@ import pytest
 from unittest.mock import patch, MagicMock
 from app.utils.notifications import send_push_notification, notify_user, notify_family_members, is_within_dnd
 from app.models.notification import PushSubscription, NotificationSetting
-from datetime import time
+from datetime import time, datetime, timezone, timedelta
+
+
+JST = timezone(timedelta(hours=9))
 
 
 class TestIsWithinDnd:
@@ -18,6 +21,35 @@ class TestIsWithinDnd:
         settings.dnd_start_time = time(22, 0)
         settings.dnd_end_time = None
         assert is_within_dnd(settings) is False
+
+    def test_dnd_uses_jst_not_utc(self):
+        """DND判定はJST時刻で行う（UTC時刻で判定するバグの回帰テスト）"""
+        settings = MagicMock(spec=NotificationSetting)
+        # ユーザーがJSTで「夜21時〜朝8時」をDNDに設定
+        settings.dnd_start_time = time(21, 0)
+        settings.dnd_end_time = time(8, 0)
+
+        # UTC 03:00 = JST 12:00（昼）→ DND外のはず
+        utc_03 = datetime(2026, 1, 1, 3, 0, 0, tzinfo=timezone.utc)
+        jst_time = utc_03.astimezone(JST)
+        with patch("app.utils.notifications.datetime") as mock_dt:
+            mock_dt.now.return_value = jst_time
+            result = is_within_dnd(settings)
+        assert result is False, "JST 12:00（昼）はDND外のはず（UTC 03:00 を誤ってDNDと判定するバグの確認）"
+
+    def test_dnd_active_at_night_jst(self):
+        """JSTの夜22時はDND内と判定される"""
+        settings = MagicMock(spec=NotificationSetting)
+        settings.dnd_start_time = time(21, 0)
+        settings.dnd_end_time = time(8, 0)
+
+        # UTC 13:00 = JST 22:00（夜）→ DND内
+        utc_13 = datetime(2026, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+        jst_time = utc_13.astimezone(JST)
+        with patch("app.utils.notifications.datetime") as mock_dt:
+            mock_dt.now.return_value = jst_time
+            result = is_within_dnd(settings)
+        assert result is True, "JST 22:00（夜）はDND内のはず"
 
 
 class TestSendPushNotification:


### PR DESCRIPTION
## 問題

サーバー（Render）はUTCで動作しているため、`datetime.now().time()`がUTC時刻を返していた。

ユーザーがJSTで「夜21時〜朝8時」をおやすみモードに設定した場合、実際にはUTC 21時〜8時（= JST 翌6時〜17時）がDND時間帯と判定されていた。その結果、日中（JST 朝6時〜夕方17時）の育児記録に対してプッシュ通知がスキップされていた。

メンバーユーザーはDNDを設定していないため通知が届いており、adminユーザーのみ通知が届かない状態だった。

## 修正

`datetime.now()` → `datetime.now(JST)` に変更し、JST時刻でDNDを判定するよう修正。

## テスト

- UTC 03:00（= JST 12:00）のとき、DND（21:00〜08:00 JST設定）はFalseであることを確認（バグ回帰テスト）
- UTC 13:00（= JST 22:00）のとき、DNDはTrueであることを確認