### PR TITLE
feat: おやすみモードの有効/無効トグルを追加

### DIFF
--- a/frontend/app/(dashboard)/settings/notifications/page.tsx
+++ b/frontend/app/(dashboard)/settings/notifications/page.tsx
@@ -23,6 +23,7 @@ export default function NotificationsPage() {
   const { permission, requestPermission, subscribeUser, sendSubscriptionToBackend } = usePushNotification();
   const [settings, setSettings] = useState<NotificationSettings | null>(null);
   const [loading, setLoading] = useState(true);
+  const [dndEnabled, setDndEnabled] = useState(false);
 
   useEffect(() => {
     fetchSettings();
@@ -34,11 +35,49 @@ export default function NotificationsPage() {
       if (response.ok) {
         const data = await response.json();
         setSettings(data);
+        setDndEnabled(!!(data.dnd_start_time || data.dnd_end_time));
       }
     } catch (error) {
       console.error("Failed to fetch settings:", error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleDndToggle = async (enabled: boolean) => {
+    setDndEnabled(enabled);
+    if (!enabled) {
+      const newSettings = { ...settings!, dnd_start_time: null, dnd_end_time: null };
+      setSettings(newSettings);
+      try {
+        const res = await fetch("/api/notifications/settings", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ dnd_start_time: null, dnd_end_time: null }),
+        });
+        if (!res.ok) throw new Error();
+        toast.success("おやすみモードを無効にしました");
+      } catch {
+        toast.error("設定の更新に失敗しました");
+        fetchSettings();
+      }
+    } else {
+      const defaultStart = "21:00";
+      const defaultEnd = "08:00";
+      const newSettings = { ...settings!, dnd_start_time: defaultStart, dnd_end_time: defaultEnd };
+      setSettings(newSettings);
+      try {
+        const res = await fetch("/api/notifications/settings", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ dnd_start_time: defaultStart, dnd_end_time: defaultEnd }),
+        });
+        if (!res.ok) throw new Error();
+        toast.success("おやすみモードを有効にしました");
+      } catch {
+        toast.error("設定の更新に失敗しました");
+        fetchSettings();
+      }
     }
   };
 
@@ -235,34 +274,42 @@ export default function NotificationsPage() {
 
         <Card className="dark:bg-zinc-900 dark:border-zinc-800">
           <CardHeader>
-            <CardTitle className="text-lg flex items-center gap-2">
-              <Clock className="h-5 w-5 text-indigo-500" />
-              おやすみモード
-            </CardTitle>
-            <CardDescription>指定した時間帯は通知を送信しません</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <label className="text-xs font-medium text-muted-foreground">開始時間</label>
-                <input
-                  type="time"
-                  className="w-full p-2 rounded-md border dark:bg-zinc-800 dark:border-zinc-700 text-sm"
-                  value={settings?.dnd_start_time || ""}
-                  onChange={(e) => updateSetting("dnd_start_time", e.target.value || null)}
-                />
-              </div>
-              <div className="space-y-2">
-                <label className="text-xs font-medium text-muted-foreground">終了時間</label>
-                <input
-                  type="time"
-                  className="w-full p-2 rounded-md border dark:bg-zinc-800 dark:border-zinc-700 text-sm"
-                  value={settings?.dnd_end_time || ""}
-                  onChange={(e) => updateSetting("dnd_end_time", e.target.value || null)}
-                />
-              </div>
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-lg flex items-center gap-2">
+                <Clock className="h-5 w-5 text-indigo-500" />
+                おやすみモード
+              </CardTitle>
+              <Switch
+                checked={dndEnabled}
+                onCheckedChange={handleDndToggle}
+              />
             </div>
-          </CardContent>
+            <CardDescription>指定した時間帯はプッシュ通知を送信しません</CardDescription>
+          </CardHeader>
+          {dndEnabled && (
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-muted-foreground">開始時間</label>
+                  <input
+                    type="time"
+                    className="w-full p-2 rounded-md border dark:bg-zinc-800 dark:border-zinc-700 text-sm"
+                    value={settings?.dnd_start_time || ""}
+                    onChange={(e) => updateSetting("dnd_start_time", e.target.value || null)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-muted-foreground">終了時間</label>
+                  <input
+                    type="time"
+                    className="w-full p-2 rounded-md border dark:bg-zinc-800 dark:border-zinc-700 text-sm"
+                    value={settings?.dnd_end_time || ""}
+                    onChange={(e) => updateSetting("dnd_end_time", e.target.value || null)}
+                  />
+                </div>
+              </div>
+            </CardContent>
+          )}
         </Card>
       </div>
     </div>


### PR DESCRIPTION
## 変更内容

おやすみモード設定にトグルスイッチを追加し、無効化できるようにしました。

## UI変更

- おやすみモードカードのヘッダーにトグルスイッチを追加
- **トグルOFF**: `dnd_start_time / dnd_end_time` をnullにして保存。時刻入力欄は非表示
- **トグルON**: デフォルト値（21:00〜08:00）を設定。時刻入力欄を表示

## 実装詳細

バックエンドの変更なし。既存のPATCH APIに `{dnd_start_time: null, dnd_end_time: null}` を送信することで無効化しています。

初期表示時は `dnd_start_time` が非nullであればトグルON状態で表示します。