### PR TITLE
fix(landing): 絵文字アイコンをLucide SVGに置き換え、インタラクション改善

### DIFF
--- a/frontend/components/landing/LandingDetailedFeatures.tsx
+++ b/frontend/components/landing/LandingDetailedFeatures.tsx
@@ -1,16 +1,16 @@
 "use client"
 
 import { motion } from "framer-motion"
+import { Baby, Moon, Droplets, TrendingUp, MessageCircle, Bell } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
-import { cn } from "@/lib/utils"
 
 const DETAILED_FEATURES = [
-    { label: "授乳・ミルク記録", icon: "🤱", color: "text-rose-500" },
-    { label: "睡眠記録", icon: "💤", color: "text-indigo-500" },
-    { label: "おむつ・健康状態", icon: "💩", color: "text-amber-500" },
-    { label: "成長グラフ", icon: "📈", color: "text-emerald-500" },
-    { label: "応援コメント機能", icon: "💬", color: "text-blue-500" },
-    { label: "プッシュ通知", icon: "🔔", color: "text-purple-500" }
+    { label: "授乳・ミルク記録", icon: Baby, bgColor: "bg-rose-50", iconColor: "text-rose-500" },
+    { label: "睡眠記録", icon: Moon, bgColor: "bg-indigo-50", iconColor: "text-indigo-500" },
+    { label: "おむつ・健康状態", icon: Droplets, bgColor: "bg-amber-50", iconColor: "text-amber-500" },
+    { label: "成長グラフ", icon: TrendingUp, bgColor: "bg-emerald-50", iconColor: "text-emerald-500" },
+    { label: "応援コメント機能", icon: MessageCircle, bgColor: "bg-blue-50", iconColor: "text-blue-500" },
+    { label: "プッシュ通知", icon: Bell, bgColor: "bg-purple-50", iconColor: "text-purple-500" },
 ]
 
 export function LandingDetailedFeatures() {
@@ -22,22 +22,27 @@ export function LandingDetailedFeatures() {
                     <p className="text-slate-500">必要な機能はすべて揃っています。</p>
                 </div>
                 <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-                    {DETAILED_FEATURES.map((feature, i) => (
-                        <motion.div
-                            key={feature.label}
-                            initial={{ opacity: 0, scale: 0.9 }}
-                            whileInView={{ opacity: 1, scale: 1 }}
-                            viewport={{ once: true }}
-                            transition={{ delay: i * 0.1 }}
-                        >
-                            <Card className="border-0 shadow-sm hover:shadow-md transition-shadow text-center h-full">
-                                <CardContent className="p-6 space-y-3 flex flex-col items-center justify-center h-full">
-                                    <span className={cn("text-4xl", feature.color)}>{feature.icon}</span>
-                                    <span className="font-bold text-sm text-slate-700">{feature.label}</span>
-                                </CardContent>
-                            </Card>
-                        </motion.div>
-                    ))}
+                    {DETAILED_FEATURES.map((feature, i) => {
+                        const Icon = feature.icon
+                        return (
+                            <motion.div
+                                key={feature.label}
+                                initial={{ opacity: 0, scale: 0.9 }}
+                                whileInView={{ opacity: 1, scale: 1 }}
+                                viewport={{ once: true }}
+                                transition={{ delay: i * 0.1 }}
+                            >
+                                <Card className="border-0 shadow-sm hover:shadow-md transition-shadow text-center h-full">
+                                    <CardContent className="p-6 space-y-3 flex flex-col items-center justify-center h-full">
+                                        <div className={`w-12 h-12 rounded-2xl ${feature.bgColor} flex items-center justify-center`}>
+                                            <Icon className={`h-6 w-6 ${feature.iconColor}`} />
+                                        </div>
+                                        <span className="font-bold text-sm text-slate-700">{feature.label}</span>
+                                    </CardContent>
+                                </Card>
+                            </motion.div>
+                        )
+                    })}
                 </div>
             </div>
         </section>

--- a/frontend/components/landing/LandingFAQ.tsx
+++ b/frontend/components/landing/LandingFAQ.tsx
@@ -36,7 +36,7 @@ function FaqItem({ question, answer }: { question: string; answer: string }) {
         <div className="border border-slate-100 rounded-2xl overflow-hidden">
             <button
                 onClick={() => setOpen(!open)}
-                className="w-full flex items-center justify-between p-6 text-left hover:bg-slate-50 transition-colors"
+                className="w-full flex items-center justify-between p-6 text-left hover:bg-slate-50 transition-colors cursor-pointer"
             >
                 <span className="font-bold text-slate-800">{question}</span>
                 {open ? (

--- a/frontend/components/landing/LandingHero.tsx
+++ b/frontend/components/landing/LandingHero.tsx
@@ -34,7 +34,7 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                     <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start items-center sm:items-start">
                         {isLoggedIn ? (
                             <Link href="/dashboard">
-                                <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:scale-105">
+                                <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:shadow-indigo-200">
                                     ダッシュボードに戻る
                                 </Button>
                             </Link>
@@ -42,7 +42,7 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                             <>
                                 <div className="flex flex-col gap-2 w-full sm:w-auto items-center sm:items-start">
                                     <Link href="/register" className="w-full sm:w-auto">
-                                        <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:scale-105">
+                                        <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:shadow-indigo-200">
                                             無料で育児記録を始める
                                             <ArrowRight className="ml-2 h-5 w-5" />
                                         </Button>
@@ -67,7 +67,7 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                     <div className="flex items-center gap-1 bg-slate-100 rounded-full p-1 border border-slate-200">
                         <button
                             onClick={() => setActiveView("desktop")}
-                            className={`flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-all ${
+                            className={`flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-all cursor-pointer ${
                                 activeView === "desktop"
                                     ? "bg-white text-slate-800 shadow-sm"
                                     : "text-slate-500 hover:text-slate-700"
@@ -78,7 +78,7 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                         </button>
                         <button
                             onClick={() => setActiveView("mobile")}
-                            className={`flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-all ${
+                            className={`flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-all cursor-pointer ${
                                 activeView === "mobile"
                                     ? "bg-white text-slate-800 shadow-sm"
                                     : "text-slate-500 hover:text-slate-700"

--- a/frontend/components/landing/LandingHowTo.tsx
+++ b/frontend/components/landing/LandingHowTo.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion"
 import Link from "next/link"
+import { UserPlus, Users, Smartphone } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
 const HOW_TO_STEPS = [
@@ -9,19 +10,19 @@ const HOW_TO_STEPS = [
         step: "01",
         title: "アカウントを作成",
         description: "メールアドレスだけで簡単登録。クレジットカードは不要、完全無料で始められます。",
-        icon: "📝",
+        icon: UserPlus,
     },
     {
         step: "02",
         title: "家族を招待",
         description: "発行された招待コードをパートナーや祖父母に共有。家族全員でつながりましょう。",
-        icon: "👨‍👩‍👧",
+        icon: Users,
     },
     {
         step: "03",
         title: "一緒に記録・共有",
         description: "授乳、睡眠、おむつをリアルタイムで記録。全員がいつでも最新状態を確認できます。",
-        icon: "📱",
+        icon: Smartphone,
     },
 ]
 
@@ -47,8 +48,8 @@ export function LandingHowTo({ isLoggedIn = false }: LandingHowToProps) {
                             transition={{ delay: i * 0.15 }}
                             className="relative text-center space-y-4"
                         >
-                            <div className="relative mx-auto w-20 h-20 rounded-full bg-indigo-50 flex items-center justify-center text-4xl">
-                                {step.icon}
+                            <div className="relative mx-auto w-20 h-20 rounded-full bg-indigo-50 flex items-center justify-center">
+                                <step.icon className="h-8 w-8 text-indigo-500" />
                                 <span className="absolute -top-2 -right-2 w-8 h-8 rounded-full bg-indigo-600 text-white text-xs font-bold flex items-center justify-center">
                                     {step.step}
                                 </span>
@@ -61,7 +62,7 @@ export function LandingHowTo({ isLoggedIn = false }: LandingHowToProps) {
                 {!isLoggedIn && (
                     <div className="text-center">
                         <Link href="/register">
-                            <Button className="h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:scale-105">
+                            <Button className="h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:shadow-indigo-200">
                                 今すぐ無料で始める
                             </Button>
                         </Link>

--- a/frontend/components/landing/LandingTestimonials.tsx
+++ b/frontend/components/landing/LandingTestimonials.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { motion } from "framer-motion"
+import { Star } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 
 const TESTIMONIALS = [
@@ -40,15 +41,18 @@ export function LandingTestimonials() {
                         >
                             <Card className="h-full rounded-2xl border-slate-100 shadow-sm bg-white hover:shadow-md transition-shadow">
                                 <CardContent className="p-8 space-y-6">
-                                    <div className="flex gap-1 text-amber-400">
+                                    <div className="flex gap-0.5">
                                         {[...Array(5)].map((_, j) => (
-                                            <span key={j} className={j < item.rating ? "text-amber-400" : "text-slate-200"}>★</span>
+                                            <Star
+                                                key={j}
+                                                className={`h-4 w-4 ${j < item.rating ? "text-amber-400 fill-amber-400" : "text-slate-200 fill-slate-200"}`}
+                                            />
                                         ))}
                                     </div>
                                     <p className="text-slate-600 leading-relaxed text-sm italic">
                                         &quot;{item.comment}&quot;
                                     </p>
-                                    <div className="pt-4 border-t border-slate-50">
+                                    <div className="pt-4 border-t border-slate-100">
                                         <p className="font-bold text-sm text-slate-800">{item.name}</p>
                                     </div>
                                 </CardContent>

--- a/frontend/components/landing/LandingTrust.tsx
+++ b/frontend/components/landing/LandingTrust.tsx
@@ -1,11 +1,20 @@
 "use client"
 
+import { Lock, ShieldCheck, Users, Shield } from "lucide-react"
+
+const TRUST_ITEMS = [
+    { icon: ShieldCheck, label: "SSLで通信を暗号化", bgColor: "bg-emerald-50", iconColor: "text-emerald-600" },
+    { icon: Users, label: "招待制のプライベート空間", bgColor: "bg-indigo-50", iconColor: "text-indigo-600" },
+    { icon: Shield, label: "ロールベースのアクセス管理", bgColor: "bg-blue-50", iconColor: "text-blue-600" },
+]
+
 export function LandingTrust() {
     return (
         <section className="px-4 py-24 bg-white">
             <div className="max-w-3xl mx-auto text-center space-y-8">
                 <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-50 text-emerald-600 text-sm font-bold">
-                    🔒 家族だけのプライベートな空間
+                    <Lock className="h-4 w-4" />
+                    家族だけのプライベートな空間
                 </div>
                 <h2 className="text-3xl font-bold">安心・安全なデータ管理</h2>
                 <p className="text-slate-600 leading-relaxed">
@@ -13,16 +22,17 @@ export function LandingTrust() {
                     赤ちゃんの成長記録は厳重に保護され、いつでも家族全員で振り返ることができます。
                 </p>
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
-                    {[
-                        { icon: "🔐", label: "SSLで通信を暗号化" },
-                        { icon: "👨‍👩‍👧", label: "招待制のプライベート空間" },
-                        { icon: "🛡️", label: "ロールベースのアクセス管理" },
-                    ].map((item) => (
-                        <div key={item.label} className="bg-white rounded-2xl p-4 flex flex-col items-center gap-2 shadow-sm">
-                            <span className="text-2xl">{item.icon}</span>
-                            <span className="font-medium text-slate-700 text-center">{item.label}</span>
-                        </div>
-                    ))}
+                    {TRUST_ITEMS.map((item) => {
+                        const Icon = item.icon
+                        return (
+                            <div key={item.label} className="bg-white rounded-2xl p-4 flex flex-col items-center gap-3 shadow-sm border border-slate-100">
+                                <div className={`w-10 h-10 rounded-xl ${item.bgColor} flex items-center justify-center`}>
+                                    <Icon className={`h-5 w-5 ${item.iconColor}`} />
+                                </div>
+                                <span className="font-medium text-slate-700 text-center">{item.label}</span>
+                            </div>
+                        )
+                    })}
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## 概要

UI/UX Pro Max チェックリストに基づき、ランディングページの視覚的・インタラクション品質を改善しました。

## 変更内容

### 絵文字アイコン → Lucide SVGアイコン（Critical）
- **LandingDetailedFeatures**: 🤱💤💩📈💬🔔 → Baby/Moon/Droplets/TrendingUp/MessageCircle/Bell
- **LandingHowTo**: 📝👨‍👩‍👧📱 → UserPlus/Users/Smartphone
- **LandingTrust**: 🔒🔐👨‍👩‍👧🛡️ → Lock/ShieldCheck/Users/Shield

### インタラクション修正
- **LandingHero/LandingHowTo**: `hover:scale-105` を廃止（レイアウトシフトの原因）→ `hover:shadow` に変更
- **LandingHero**: デスクトップ/モバイル切り替えボタンに `cursor-pointer` を追加
- **LandingFAQ**: FAQアコーディオンボタンに `cursor-pointer` を追加

### コントラスト修正
- **LandingTestimonials**: ★文字 → Lucide `Star` SVG（`fill-amber-400`）
- **LandingTestimonials**: `border-slate-50`（ほぼ不可視）→ `border-slate-100` に修正
- **LandingTrust**: カードに `border border-slate-100` を追加してライトモードでの視認性を向上

## チェックリスト
- [x] 絵文字アイコン廃止（Lucide SVG使用）
- [x] hover:scale による layout shift 廃止
- [x] cursor-pointer が全クリッカブル要素に適用
- [x] ボーダーのコントラストを修正
- [x] pnpm build 成功確認