### PR TITLE
feat: splashページのカラーをUI v2（Claymorphism）に対応

### DIFF
--- a/frontend/components/ui/splash-screen.tsx
+++ b/frontend/components/ui/splash-screen.tsx
@@ -4,9 +4,12 @@ import { useState, useEffect } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { BabyBottleLoading } from "./baby-bottle-loading"
 import { useUser } from "@/hooks/useAuth"
+import { useUIVersion } from "@/components/ui-version-provider"
+import { cn } from "@/lib/utils"
 
 export function SplashScreen() {
     const { isLoading } = useUser()
+    const { isV2 } = useUIVersion()
     const [isVisible, setIsVisible] = useState(true)
     const [isMounted, setIsMounted] = useState(false)
 
@@ -53,10 +56,21 @@ export function SplashScreen() {
                         transition={{ duration: 0.6, ease: "easeOut" }}
                     >
                         <div className="relative">
-                            <div className="absolute inset-0 bg-indigo-400 blur-2xl opacity-20 rounded-full animate-pulse" />
-                            <BabyBottleLoading className="w-28 h-28 text-indigo-500 dark:text-indigo-400 relative z-10" />
+                            <div className={cn(
+                                "absolute inset-0 blur-2xl opacity-20 rounded-full animate-pulse",
+                                isV2 ? "bg-primary" : "bg-indigo-400"
+                            )} />
+                            <BabyBottleLoading className={cn(
+                                "w-28 h-28 relative z-10",
+                                isV2 ? "text-primary" : "text-indigo-500 dark:text-indigo-400"
+                            )} />
                         </div>
-                        <h1 className="text-3xl font-extrabold tracking-tight bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 bg-clip-text text-transparent mt-2 font-geist-sans drop-shadow-sm">
+                        <h1 className={cn(
+                            "text-3xl font-extrabold tracking-tight bg-clip-text text-transparent mt-2 drop-shadow-sm font-sans",
+                            isV2
+                                ? "bg-gradient-to-r from-pink-400 via-rose-400 to-fuchsia-400"
+                                : "bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500"
+                        )}>
                             Botoro
                         </h1>
                     </motion.div>


### PR DESCRIPTION
## 概要

UI v2（Claymorphism + パステルピンク）有効時に、splashページのカラーをv2デザインシステムに合わせて切り替えるようにした。

## 変更内容

- useUIVersionフックでv2の有無を判定
- グローエフェクト: bg-indigo-400 → bg-primary（CSS変数、v2でピンク）
- ボトルアイコン: text-indigo-500 → text-primary（同上）
- タイトルグラジェント: indigo→purple→pink → pink-400→rose-400→fuchsia-400
- フォント: font-geist-sans（固定）→ font-sans（v2ではNunitoに自動切替）

v1では従来のindigoカラーを維持。

## テスト

- verify_all.sh 通過（137 backend tests pass、frontend build OK）