### PR TITLE
feat: Landing Page（LP）をダークモードに対応

### DIFF
--- a/frontend/components/landing/LandingCTA.tsx
+++ b/frontend/components/landing/LandingCTA.tsx
@@ -9,24 +9,24 @@ interface LandingCTAProps {
 
 export function LandingCTA({ isLoggedIn = false }: LandingCTAProps) {
     return (
-        <section className="px-4 py-24 bg-indigo-600 text-white">
+        <section className="px-4 py-24 bg-indigo-600 dark:bg-indigo-950/40 dark:border-y dark:border-indigo-900/50 text-white transition-colors duration-300">
             <div className="max-w-7xl mx-auto text-center space-y-12">
                 <div className="space-y-4">
                     <h2 className="text-4xl font-extrabold tracking-tight">もう、育児の記録で迷わない。</h2>
-                    <p className="text-indigo-100 text-lg">
+                    <p className="text-indigo-100 dark:text-indigo-200 text-lg">
                         今日から家族みんなでシェアして、余裕のある時間を。
                     </p>
                 </div>
                 <div className="flex flex-col sm:flex-row gap-4 justify-center">
                     {isLoggedIn ? (
                         <Link href="/dashboard">
-                            <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-white text-indigo-600 hover:bg-indigo-50 rounded-2xl shadow-xl transition-all">
+                            <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-white dark:bg-indigo-600 text-indigo-600 dark:text-white hover:bg-indigo-50 dark:hover:bg-indigo-700 rounded-2xl shadow-xl dark:shadow-none transition-all">
                                 ダッシュボードに戻る
                             </Button>
                         </Link>
                     ) : (
                         <Link href="/register">
-                            <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-white text-indigo-600 hover:bg-indigo-50 rounded-2xl shadow-xl transition-all">
+                            <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-white dark:bg-indigo-600 text-indigo-600 dark:text-white hover:bg-indigo-50 dark:hover:bg-indigo-700 rounded-2xl shadow-xl dark:shadow-none transition-all">
                                 今すぐ無料で始める
                             </Button>
                         </Link>

--- a/frontend/components/landing/LandingContent.tsx
+++ b/frontend/components/landing/LandingContent.tsx
@@ -13,7 +13,7 @@ import { LandingFooter } from "./LandingFooter"
 
 export function LandingContent({ isLoggedIn = false }: { isLoggedIn?: boolean }) {
     return (
-        <div className="min-h-screen bg-slate-50 text-slate-900 font-sans overflow-x-hidden">
+        <div className="min-h-screen bg-background text-foreground font-sans overflow-x-hidden transition-colors duration-300">
             <LandingHeader isLoggedIn={isLoggedIn} />
 
             <main className="pt-16">

--- a/frontend/components/landing/LandingDetailedFeatures.tsx
+++ b/frontend/components/landing/LandingDetailedFeatures.tsx
@@ -5,21 +5,21 @@ import { Baby, Moon, Droplets, TrendingUp, MessageCircle, Bell } from "lucide-re
 import { Card, CardContent } from "@/components/ui/card"
 
 const DETAILED_FEATURES = [
-    { label: "授乳・ミルク記録", icon: Baby, bgColor: "bg-rose-50", iconColor: "text-rose-500" },
-    { label: "睡眠記録", icon: Moon, bgColor: "bg-indigo-50", iconColor: "text-indigo-500" },
-    { label: "おむつ・健康状態", icon: Droplets, bgColor: "bg-amber-50", iconColor: "text-amber-500" },
-    { label: "成長グラフ", icon: TrendingUp, bgColor: "bg-emerald-50", iconColor: "text-emerald-500" },
-    { label: "応援コメント機能", icon: MessageCircle, bgColor: "bg-blue-50", iconColor: "text-blue-500" },
-    { label: "プッシュ通知", icon: Bell, bgColor: "bg-purple-50", iconColor: "text-purple-500" },
+    { label: "授乳・ミルク記録", icon: Baby, bgColor: "bg-rose-50 dark:bg-rose-950/20", iconColor: "text-rose-500 dark:text-rose-400" },
+    { label: "睡眠記録", icon: Moon, bgColor: "bg-indigo-50 dark:bg-indigo-950/20", iconColor: "text-indigo-500 dark:text-indigo-400" },
+    { label: "おむつ・健康状態", icon: Droplets, bgColor: "bg-amber-50 dark:bg-amber-950/20", iconColor: "text-amber-500 dark:text-amber-400" },
+    { label: "成長グラフ", icon: TrendingUp, bgColor: "bg-emerald-50 dark:bg-emerald-950/20", iconColor: "text-emerald-500 dark:text-emerald-400" },
+    { label: "応援コメント機能", icon: MessageCircle, bgColor: "bg-blue-50 dark:bg-blue-950/20", iconColor: "text-blue-500 dark:text-blue-400" },
+    { label: "プッシュ通知", icon: Bell, bgColor: "bg-purple-50 dark:bg-purple-950/20", iconColor: "text-purple-500 dark:text-purple-400" },
 ]
 
 export function LandingDetailedFeatures() {
     return (
-        <section id="details" className="px-4 py-24 bg-slate-50">
+        <section id="details" className="px-4 py-24 bg-slate-50 dark:bg-zinc-900/50 transition-colors duration-300">
             <div className="max-w-7xl mx-auto space-y-16">
                 <div className="text-center space-y-4">
                     <h2 className="text-3xl font-bold tracking-tight">充実の機能</h2>
-                    <p className="text-slate-500">必要な機能はすべて揃っています。</p>
+                    <p className="text-slate-500 dark:text-slate-400">必要な機能はすべて揃っています。</p>
                 </div>
                 <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
                     {DETAILED_FEATURES.map((feature, i) => {
@@ -32,12 +32,12 @@ export function LandingDetailedFeatures() {
                                 viewport={{ once: true }}
                                 transition={{ delay: i * 0.1 }}
                             >
-                                <Card className="border-0 shadow-sm hover:shadow-md transition-shadow text-center h-full">
+                                <Card className="border-0 dark:border dark:border-zinc-800 shadow-sm hover:shadow-md dark:shadow-none transition-all text-center h-full bg-white dark:bg-zinc-900">
                                     <CardContent className="p-6 space-y-3 flex flex-col items-center justify-center h-full">
                                         <div className={`w-12 h-12 rounded-2xl ${feature.bgColor} flex items-center justify-center`}>
                                             <Icon className={`h-6 w-6 ${feature.iconColor}`} />
                                         </div>
-                                        <span className="font-bold text-sm text-slate-700">{feature.label}</span>
+                                        <span className="font-bold text-sm text-slate-700 dark:text-slate-200">{feature.label}</span>
                                     </CardContent>
                                 </Card>
                             </motion.div>

--- a/frontend/components/landing/LandingFAQ.tsx
+++ b/frontend/components/landing/LandingFAQ.tsx
@@ -33,12 +33,12 @@ const FAQ_ITEMS = [
 function FaqItem({ question, answer }: { question: string; answer: string }) {
     const [open, setOpen] = useState(false)
     return (
-        <div className="border border-slate-100 rounded-2xl overflow-hidden">
+        <div className="border border-slate-100 dark:border-zinc-800 rounded-2xl overflow-hidden bg-white dark:bg-zinc-900/50 transition-colors">
             <button
                 onClick={() => setOpen(!open)}
-                className="w-full flex items-center justify-between p-6 text-left hover:bg-slate-50 transition-colors cursor-pointer"
+                className="w-full flex items-center justify-between p-6 text-left hover:bg-slate-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
             >
-                <span className="font-bold text-slate-800">{question}</span>
+                <span className="font-bold text-slate-800 dark:text-slate-200">{question}</span>
                 {open ? (
                     <ChevronUp className="h-5 w-5 text-slate-400 shrink-0" />
                 ) : (
@@ -46,7 +46,7 @@ function FaqItem({ question, answer }: { question: string; answer: string }) {
                 )}
             </button>
             {open && (
-                <div className="px-6 pb-6 text-slate-600 leading-relaxed text-sm border-t border-slate-100 pt-4">
+                <div className="px-6 pb-6 text-slate-600 dark:text-slate-400 leading-relaxed text-sm border-t border-slate-100 dark:border-zinc-800 pt-4">
                     {answer}
                 </div>
             )}
@@ -56,11 +56,11 @@ function FaqItem({ question, answer }: { question: string; answer: string }) {
 
 export function LandingFAQ() {
     return (
-        <section id="faq" className="px-4 py-24 bg-slate-50">
+        <section id="faq" className="px-4 py-24 bg-slate-50 dark:bg-zinc-900/50 transition-colors duration-300">
             <div className="max-w-3xl mx-auto space-y-12">
                 <div className="text-center space-y-4">
                     <h2 className="text-3xl font-bold tracking-tight">よくある質問</h2>
-                    <p className="text-slate-500">ご不明な点はこちらをご覧ください。</p>
+                    <p className="text-slate-500 dark:text-slate-400">ご不明な点はこちらをご覧ください。</p>
                 </div>
                 <div className="space-y-4">
                     {FAQ_ITEMS.map((item, i) => (

--- a/frontend/components/landing/LandingFeatures.tsx
+++ b/frontend/components/landing/LandingFeatures.tsx
@@ -8,30 +8,30 @@ const FEATURES = [
     {
         title: "リアルタイム共有",
         description: "パパが記録、ママが確認。職場からでも赤ちゃんの様子がわかります。家族全員で成長を見守りましょう。",
-        icon: <Baby className="h-6 w-6 text-rose-500" />,
-        color: "bg-rose-50"
+        icon: <Baby className="h-6 w-6 text-rose-500 dark:text-rose-400" />,
+        color: "bg-rose-50 dark:bg-rose-950/30"
     },
     {
         title: "AI サマリー",
         description: "毎日の記録をAIが分析。授乳リズムや睡眠パターンを要約してアドバイス。育児の「コツ」が見えてきます。",
-        icon: <MessageSquare className="h-6 w-6 text-indigo-500" />,
-        color: "bg-indigo-50"
+        icon: <MessageSquare className="h-6 w-6 text-indigo-500 dark:text-indigo-400" />,
+        color: "bg-indigo-50 dark:bg-indigo-950/30"
     },
     {
         title: "シンプル操作",
         description: "授乳タイマーやおむつ記録など、片手で操作できるUI。忙しい育児の合間でもストレスなく記録できます。",
-        icon: <Smile className="h-6 w-6 text-amber-500" />,
-        color: "bg-amber-50"
+        icon: <Smile className="h-6 w-6 text-amber-500 dark:text-amber-400" />,
+        color: "bg-amber-50 dark:bg-amber-950/30"
     }
 ]
 
 export function LandingFeatures() {
     return (
-        <section id="features" className="px-4 py-24 bg-white">
+        <section id="features" className="px-4 py-24 bg-white dark:bg-zinc-950 transition-colors duration-300">
             <div className="max-w-7xl mx-auto space-y-16">
                 <div className="text-center space-y-4">
                     <h2 className="text-3xl font-bold tracking-tight">3つの特徴</h2>
-                    <p className="text-slate-500">毎日の育児をもっと楽しく、もっと楽に。</p>
+                    <p className="text-slate-500 dark:text-slate-400">毎日の育児をもっと楽しく、もっと楽に。</p>
                 </div>
                 <div className="grid md:grid-cols-3 gap-8">
                     {FEATURES.map((feature, i) => (
@@ -42,13 +42,13 @@ export function LandingFeatures() {
                             viewport={{ once: true }}
                             transition={{ delay: i * 0.2 }}
                         >
-                            <Card className="border-0 shadow-lg shadow-slate-100 h-full">
+                            <Card className="border-0 dark:border dark:border-zinc-800 shadow-lg shadow-slate-100 dark:shadow-none bg-white dark:bg-zinc-900/50 h-full">
                                 <CardContent className="p-8 space-y-4 text-center">
                                     <div className={`mx-auto w-14 h-14 rounded-2xl ${feature.color} flex items-center justify-center mb-6`}>
                                         {feature.icon}
                                     </div>
                                     <h3 className="text-xl font-bold">{feature.title}</h3>
-                                    <p className="text-slate-600 leading-relaxed text-sm">
+                                    <p className="text-slate-600 dark:text-slate-400 leading-relaxed text-sm">
                                         {feature.description}
                                     </p>
                                 </CardContent>

--- a/frontend/components/landing/LandingFooter.tsx
+++ b/frontend/components/landing/LandingFooter.tsx
@@ -4,35 +4,35 @@ import Link from "next/link"
 
 export function LandingFooter() {
     return (
-        <footer className="px-4 py-12 bg-white border-t border-slate-100">
+        <footer className="px-4 py-12 bg-white dark:bg-zinc-950 border-t border-slate-100 dark:border-zinc-800 transition-colors duration-300">
             <div className="max-w-7xl mx-auto space-y-8">
                 <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-8">
                     <div className="space-y-2">
-                        <div className="text-indigo-600 font-bold text-lg">Botoro</div>
-                        <p className="text-slate-400 text-sm max-w-xs">家族で共有する育児記録アプリ。授乳・睡眠・おむつをリアルタイムで記録・共有。</p>
+                        <div className="text-indigo-600 dark:text-indigo-400 font-bold text-lg">Botoro</div>
+                        <p className="text-slate-400 dark:text-slate-500 text-sm max-w-xs">家族で共有する育児記録アプリ。授乳・睡眠・おむつをリアルタイムで記録・共有。</p>
                     </div>
                     <div className="grid grid-cols-2 gap-x-12 gap-y-2 text-sm">
                         <div className="space-y-2">
-                            <p className="font-bold text-slate-700">サービス</p>
+                            <p className="font-bold text-slate-700 dark:text-slate-200">サービス</p>
                             <div className="space-y-1">
-                                <a href="#features" className="block text-slate-500 hover:text-indigo-600 transition-colors">特徴</a>
-                                <a href="#details" className="block text-slate-500 hover:text-indigo-600 transition-colors">機能一覧</a>
-                                <a href="#howto" className="block text-slate-500 hover:text-indigo-600 transition-colors">使い方</a>
-                                <a href="#faq" className="block text-slate-500 hover:text-indigo-600 transition-colors">よくある質問</a>
+                                <a href="#features" className="block text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">特徴</a>
+                                <a href="#details" className="block text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">機能一覧</a>
+                                <a href="#howto" className="block text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">使い方</a>
+                                <a href="#faq" className="block text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">よくある質問</a>
                             </div>
                         </div>
                         <div className="space-y-2">
-                            <p className="font-bold text-slate-700">情報</p>
+                            <p className="font-bold text-slate-700 dark:text-slate-200">情報</p>
                             <div className="space-y-1">
-                                <Link href="/about" className="block text-slate-500 hover:text-indigo-600 transition-colors">運営者情報</Link>
-                                <Link href="/privacy" className="block text-slate-500 hover:text-indigo-600 transition-colors">プライバシーポリシー</Link>
-                                <Link href="/terms" className="block text-slate-500 hover:text-indigo-600 transition-colors">利用規約</Link>
-                                <Link href="/contact" className="block text-slate-500 hover:text-indigo-600 transition-colors">お問い合わせ</Link>
+                                <Link href="/about" className="block text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">運営者情報</Link>
+                                <Link href="/privacy" className="block text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">プライバシーポリシー</Link>
+                                <Link href="/terms" className="block text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">利用規約</Link>
+                                <Link href="/contact" className="block text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">お問い合わせ</Link>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-slate-100 pt-6 text-center text-slate-400 text-sm">
+                <div className="border-t border-slate-100 dark:border-zinc-800 pt-6 text-center text-slate-400 dark:text-slate-500 text-sm">
                     &copy; 2026 Botoro. All rights reserved.
                 </div>
             </div>

--- a/frontend/components/landing/LandingHeader.tsx
+++ b/frontend/components/landing/LandingHeader.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { ThemeToggle } from "@/components/theme-toggle"
 
 interface LandingHeaderProps {
     isLoggedIn?: boolean
@@ -9,25 +10,26 @@ interface LandingHeaderProps {
 
 export function LandingHeader({ isLoggedIn = false }: LandingHeaderProps) {
     return (
-        <header className="fixed top-0 w-full z-50 bg-white/80 backdrop-blur-md border-b border-slate-100 shadow-sm">
+        <header className="fixed top-0 w-full z-50 bg-white/80 dark:bg-zinc-950/80 backdrop-blur-md border-b border-slate-100 dark:border-zinc-800 shadow-sm transition-colors duration-300">
             <div className="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                    <span className="text-xl font-bold tracking-tight text-indigo-600">Botoro</span>
+                    <span className="text-xl font-bold tracking-tight text-indigo-600 dark:text-indigo-400">Botoro</span>
                 </div>
                 <nav className="hidden md:flex items-center gap-8">
-                    <a href="#features" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">特徴</a>
-                    <a href="#details" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">機能</a>
-                    <a href="#howto" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">使い方</a>
-                    <a href="#faq" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">よくある質問</a>
+                    <a href="#features" className="text-sm font-medium text-slate-600 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">特徴</a>
+                    <a href="#details" className="text-sm font-medium text-slate-600 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">機能</a>
+                    <a href="#howto" className="text-sm font-medium text-slate-600 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">使い方</a>
+                    <a href="#faq" className="text-sm font-medium text-slate-600 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">よくある質問</a>
                 </nav>
-                <div>
+                <div className="flex items-center gap-4">
+                    <ThemeToggle />
                     {isLoggedIn ? (
                         <Link href="/dashboard">
-                            <Button variant="ghost" className="text-sm font-medium text-indigo-600">ダッシュボード</Button>
+                            <Button variant="ghost" className="text-sm font-medium text-indigo-600 dark:text-indigo-400">ダッシュボード</Button>
                         </Link>
                     ) : (
                         <Link href="/login">
-                            <Button variant="ghost" className="text-sm font-medium text-slate-600">ログイン</Button>
+                            <Button variant="ghost" className="text-sm font-medium text-slate-600 dark:text-slate-400">ログイン</Button>
                         </Link>
                     )}
                 </div>

--- a/frontend/components/landing/LandingHero.tsx
+++ b/frontend/components/landing/LandingHero.tsx
@@ -27,14 +27,14 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                         その確認、もう不要です。<br />
                         <span className="text-indigo-600">夫婦で共有する育児記録</span>で、<br className="hidden lg:block" />毎日の不安と手間をゼロに。
                     </h1>
-                    <p className="text-lg text-slate-600 max-w-lg mx-auto lg:mx-0">
+                    <p className="text-lg text-slate-600 dark:text-slate-400 max-w-lg mx-auto lg:mx-0">
                         授乳、睡眠、おむつ交換。スマホでタップするだけで、パートナーに即通知。
                         AIアドバイスで、初めての育児も安心サポート。
                     </p>
                     <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start items-center sm:items-start">
                         {isLoggedIn ? (
                             <Link href="/dashboard">
-                                <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:shadow-indigo-200">
+                                <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 dark:shadow-indigo-900/20 transition-all hover:shadow-indigo-200 dark:hover:shadow-indigo-900/30">
                                     ダッシュボードに戻る
                                 </Button>
                             </Link>
@@ -42,15 +42,15 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                             <>
                                 <div className="flex flex-col gap-2 w-full sm:w-auto items-center sm:items-start">
                                     <Link href="/register" className="w-full sm:w-auto">
-                                        <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:shadow-indigo-200">
+                                        <Button className="w-full sm:w-auto h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 dark:shadow-indigo-900/20 transition-all hover:shadow-indigo-200 dark:hover:shadow-indigo-900/30">
                                             無料で育児記録を始める
                                             <ArrowRight className="ml-2 h-5 w-5" />
                                         </Button>
                                     </Link>
-                                    <div className="text-xs font-bold mt-2 flex flex-col sm:flex-row items-center gap-1 sm:gap-2 text-slate-500">
+                                    <div className="text-xs font-bold mt-2 flex flex-col sm:flex-row items-center gap-1 sm:gap-2 text-slate-500 dark:text-slate-400">
                                         <span>✨ 1分で簡単スタート ・ 夫婦で共有OK</span>
-                                        <span className="hidden sm:inline text-slate-300">|</span>
-                                        <span className="text-indigo-600">完全無料</span>
+                                        <span className="hidden sm:inline text-slate-300 dark:text-slate-700">|</span>
+                                        <span className="text-indigo-600 dark:text-indigo-400">完全無料</span>
                                     </div>
                                 </div>
                             </>
@@ -64,13 +64,13 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                     className="relative mx-auto lg:mx-0 flex flex-col items-center gap-4"
                 >
                     {/* 切り替えタブ */}
-                    <div className="flex items-center gap-1 bg-slate-100 rounded-full p-1 border border-slate-200">
+                    <div className="flex items-center gap-1 bg-slate-100 dark:bg-zinc-900 rounded-full p-1 border border-slate-200 dark:border-zinc-800">
                         <button
                             onClick={() => setActiveView("desktop")}
                             className={`flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-all cursor-pointer ${
                                 activeView === "desktop"
-                                    ? "bg-white text-slate-800 shadow-sm"
-                                    : "text-slate-500 hover:text-slate-700"
+                                    ? "bg-white dark:bg-zinc-800 text-slate-800 dark:text-slate-100 shadow-sm"
+                                    : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
                             }`}
                         >
                             <Monitor className="w-3.5 h-3.5" />
@@ -80,8 +80,8 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                             onClick={() => setActiveView("mobile")}
                             className={`flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-all cursor-pointer ${
                                 activeView === "mobile"
-                                    ? "bg-white text-slate-800 shadow-sm"
-                                    : "text-slate-500 hover:text-slate-700"
+                                    ? "bg-white dark:bg-zinc-800 text-slate-800 dark:text-slate-100 shadow-sm"
+                                    : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
                             }`}
                         >
                             <Smartphone className="w-3.5 h-3.5" />
@@ -89,7 +89,7 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                         </button>
                     </div>
 
-                    <div className="absolute inset-0 bg-gradient-to-tr from-indigo-100 to-rose-50 rounded-3xl blur-3xl opacity-50 -z-10" />
+                    <div className="absolute inset-0 bg-gradient-to-tr from-indigo-100 dark:from-indigo-900/20 to-rose-50 dark:to-rose-900/10 rounded-3xl blur-3xl opacity-50 dark:opacity-30 -z-10" />
 
                     {/* デスクトップモックアップ */}
                     {activeView === "desktop" && (
@@ -98,20 +98,20 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                             initial={{ opacity: 0, scale: 0.97 }}
                             animate={{ opacity: 1, scale: 1 }}
                             transition={{ duration: 0.25 }}
-                            className="relative rounded-xl overflow-hidden shadow-2xl border border-slate-200 bg-white w-full"
+                            className="relative rounded-xl overflow-hidden shadow-2xl border border-slate-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 w-full"
                         >
-                            <div className="flex items-center gap-1.5 px-4 py-2.5 bg-slate-100 border-b border-slate-200">
+                            <div className="flex items-center gap-1.5 px-4 py-2.5 bg-slate-100 dark:bg-zinc-900 border-b border-slate-200 dark:border-zinc-800">
                                 <div className="w-3 h-3 rounded-full bg-red-400" />
                                 <div className="w-3 h-3 rounded-full bg-yellow-400" />
                                 <div className="w-3 h-3 rounded-full bg-green-400" />
-                                <div className="flex-1 mx-3 py-1 px-3 rounded-md bg-white text-xs text-slate-400 text-center border border-slate-200">
+                                <div className="flex-1 mx-3 py-1 px-3 rounded-md bg-white dark:bg-zinc-950 text-xs text-slate-400 dark:text-slate-500 text-center border border-slate-200 dark:border-zinc-800">
                                     baby-app.example.com/dashboard
                                 </div>
                             </div>
                             <img
                                 src="/screenshots/dashboard.png"
                                 alt="ダッシュボードのスクリーンショット（デスクトップ）"
-                                className="w-full"
+                                className="w-full opacity-90 dark:opacity-100"
                             />
                         </motion.div>
                     )}
@@ -126,13 +126,13 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                             className="relative mx-auto"
                             style={{ width: 260 }}
                         >
-                            <div className="relative rounded-[2.5rem] overflow-hidden shadow-2xl border-[6px] border-slate-800 bg-slate-800">
+                            <div className="relative rounded-[2.5rem] overflow-hidden shadow-2xl border-[6px] border-slate-800 dark:border-zinc-800 bg-slate-800 dark:bg-zinc-900">
                                 {/* パンチホール */}
-                                <div className="absolute top-3 left-1/2 -translate-x-1/2 w-16 h-5 bg-slate-800 rounded-full z-10" />
+                                <div className="absolute top-3 left-1/2 -translate-x-1/2 w-16 h-5 bg-slate-800 dark:bg-zinc-900 rounded-full z-10" />
                                 <img
                                     src="/screenshots/dashboard-mobile.png"
                                     alt="ダッシュボードのスクリーンショット（モバイル）"
-                                    className="w-full"
+                                    className="w-full opacity-90 dark:opacity-100"
                                 />
                             </div>
                         </motion.div>

--- a/frontend/components/landing/LandingHowTo.tsx
+++ b/frontend/components/landing/LandingHowTo.tsx
@@ -32,11 +32,11 @@ interface LandingHowToProps {
 
 export function LandingHowTo({ isLoggedIn = false }: LandingHowToProps) {
     return (
-        <section id="howto" className="px-4 py-24 bg-slate-50">
+        <section id="howto" className="px-4 py-24 bg-slate-50 dark:bg-zinc-900/50 transition-colors duration-300">
             <div className="max-w-7xl mx-auto space-y-16">
                 <div className="text-center space-y-4">
                     <h2 className="text-3xl font-bold tracking-tight">3ステップで始められる</h2>
-                    <p className="text-slate-500">難しい設定は不要。すぐに家族と育児を共有できます。</p>
+                    <p className="text-slate-500 dark:text-slate-400">難しい設定は不要。すぐに家族と育児を共有できます。</p>
                 </div>
                 <div className="grid md:grid-cols-3 gap-8">
                     {HOW_TO_STEPS.map((step, i) => (
@@ -48,21 +48,21 @@ export function LandingHowTo({ isLoggedIn = false }: LandingHowToProps) {
                             transition={{ delay: i * 0.15 }}
                             className="relative text-center space-y-4"
                         >
-                            <div className="relative mx-auto w-20 h-20 rounded-full bg-indigo-50 flex items-center justify-center">
-                                <step.icon className="h-8 w-8 text-indigo-500" />
-                                <span className="absolute -top-2 -right-2 w-8 h-8 rounded-full bg-indigo-600 text-white text-xs font-bold flex items-center justify-center">
+                            <div className="relative mx-auto w-20 h-20 rounded-full bg-indigo-50 dark:bg-indigo-950/30 flex items-center justify-center">
+                                <step.icon className="h-8 w-8 text-indigo-500 dark:text-indigo-400" />
+                                <span className="absolute -top-2 -right-2 w-8 h-8 rounded-full bg-indigo-600 dark:bg-indigo-500 text-white text-xs font-bold flex items-center justify-center">
                                     {step.step}
                                 </span>
                             </div>
                             <h3 className="text-lg font-bold">{step.title}</h3>
-                            <p className="text-slate-600 text-sm leading-relaxed">{step.description}</p>
+                            <p className="text-slate-600 dark:text-slate-400 text-sm leading-relaxed">{step.description}</p>
                         </motion.div>
                     ))}
                 </div>
                 {!isLoggedIn && (
                     <div className="text-center">
                         <Link href="/register">
-                            <Button className="h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 transition-all hover:shadow-indigo-200">
+                            <Button className="h-14 px-12 text-lg font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl shadow-lg shadow-indigo-100 dark:shadow-indigo-900/20 transition-all hover:shadow-indigo-200 dark:hover:shadow-indigo-900/30">
                                 今すぐ無料で始める
                             </Button>
                         </Link>

--- a/frontend/components/landing/LandingTestimonials.tsx
+++ b/frontend/components/landing/LandingTestimonials.tsx
@@ -24,11 +24,11 @@ const TESTIMONIALS = [
 
 export function LandingTestimonials() {
     return (
-        <section className="px-4 py-24 bg-white overflow-hidden">
+        <section className="px-4 py-24 bg-white dark:bg-zinc-950 overflow-hidden transition-colors duration-300">
             <div className="max-w-7xl mx-auto space-y-16">
                 <div className="text-center space-y-4">
                     <h2 className="text-3xl font-bold tracking-tight">ユーザーの声</h2>
-                    <p className="text-slate-500">たくさんのパパ・ママに利用されています。</p>
+                    <p className="text-slate-500 dark:text-slate-400">たくさんのパパ・ママに利用されています。</p>
                 </div>
                 <div className="grid md:grid-cols-3 gap-8">
                     {TESTIMONIALS.map((item, i) => (
@@ -39,21 +39,21 @@ export function LandingTestimonials() {
                             viewport={{ once: true }}
                             transition={{ delay: i * 0.2 }}
                         >
-                            <Card className="h-full rounded-2xl border-slate-100 shadow-sm bg-white hover:shadow-md transition-shadow">
+                            <Card className="h-full rounded-2xl border-slate-100 dark:border-zinc-800 shadow-sm dark:shadow-none bg-white dark:bg-zinc-900/50 hover:shadow-md dark:hover:bg-zinc-900 transition-all">
                                 <CardContent className="p-8 space-y-6">
                                     <div className="flex gap-0.5">
                                         {[...Array(5)].map((_, j) => (
                                             <Star
                                                 key={j}
-                                                className={`h-4 w-4 ${j < item.rating ? "text-amber-400 fill-amber-400" : "text-slate-200 fill-slate-200"}`}
+                                                className={`h-4 w-4 ${j < item.rating ? "text-amber-400 fill-amber-400" : "text-slate-200 dark:text-slate-800 fill-slate-200 dark:fill-slate-800"}`}
                                             />
                                         ))}
                                     </div>
-                                    <p className="text-slate-600 leading-relaxed text-sm italic">
+                                    <p className="text-slate-600 dark:text-slate-400 leading-relaxed text-sm italic">
                                         &quot;{item.comment}&quot;
                                     </p>
-                                    <div className="pt-4 border-t border-slate-100">
-                                        <p className="font-bold text-sm text-slate-800">{item.name}</p>
+                                    <div className="pt-4 border-t border-slate-100 dark:border-zinc-800">
+                                        <p className="font-bold text-sm text-slate-800 dark:text-slate-200">{item.name}</p>
                                     </div>
                                 </CardContent>
                             </Card>

--- a/frontend/components/landing/LandingTrust.tsx
+++ b/frontend/components/landing/LandingTrust.tsx
@@ -3,21 +3,21 @@
 import { Lock, ShieldCheck, Users, Shield } from "lucide-react"
 
 const TRUST_ITEMS = [
-    { icon: ShieldCheck, label: "SSLで通信を暗号化", bgColor: "bg-emerald-50", iconColor: "text-emerald-600" },
-    { icon: Users, label: "招待制のプライベート空間", bgColor: "bg-indigo-50", iconColor: "text-indigo-600" },
-    { icon: Shield, label: "ロールベースのアクセス管理", bgColor: "bg-blue-50", iconColor: "text-blue-600" },
+    { icon: ShieldCheck, label: "SSLで通信を暗号化", bgColor: "bg-emerald-50 dark:bg-emerald-950/20", iconColor: "text-emerald-600 dark:text-emerald-400" },
+    { icon: Users, label: "招待制のプライベート空間", bgColor: "bg-indigo-50 dark:bg-indigo-950/20", iconColor: "text-indigo-600 dark:text-indigo-400" },
+    { icon: Shield, label: "ロールベースのアクセス管理", bgColor: "bg-blue-50 dark:bg-blue-950/20", iconColor: "text-blue-600 dark:text-blue-400" },
 ]
 
 export function LandingTrust() {
     return (
-        <section className="px-4 py-24 bg-white">
+        <section className="px-4 py-24 bg-white dark:bg-zinc-950 transition-colors duration-300">
             <div className="max-w-3xl mx-auto text-center space-y-8">
-                <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-50 text-emerald-600 text-sm font-bold">
+                <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-50 dark:bg-emerald-950/30 text-emerald-600 dark:text-emerald-400 text-sm font-bold">
                     <Lock className="h-4 w-4" />
                     家族だけのプライベートな空間
                 </div>
                 <h2 className="text-3xl font-bold">安心・安全なデータ管理</h2>
-                <p className="text-slate-600 leading-relaxed">
+                <p className="text-slate-600 dark:text-slate-400 leading-relaxed">
                     招待コードを知っている家族メンバーだけがアクセス可能。
                     赤ちゃんの成長記録は厳重に保護され、いつでも家族全員で振り返ることができます。
                 </p>
@@ -25,11 +25,11 @@ export function LandingTrust() {
                     {TRUST_ITEMS.map((item) => {
                         const Icon = item.icon
                         return (
-                            <div key={item.label} className="bg-white rounded-2xl p-4 flex flex-col items-center gap-3 shadow-sm border border-slate-100">
+                            <div key={item.label} className="bg-white dark:bg-zinc-900 rounded-2xl p-4 flex flex-col items-center gap-3 shadow-sm dark:shadow-none border border-slate-100 dark:border-zinc-800">
                                 <div className={`w-10 h-10 rounded-xl ${item.bgColor} flex items-center justify-center`}>
                                     <Icon className={`h-5 w-5 ${item.iconColor}`} />
                                 </div>
-                                <span className="font-medium text-slate-700 text-center">{item.label}</span>
+                                <span className="font-medium text-slate-700 dark:text-slate-200 text-center">{item.label}</span>
                             </div>
                         )
                     })}


### PR DESCRIPTION
## 概要
Landing Page (LP) の全コンポーネントをダークモードに対応させました。

### 変更点
- **ヘッダーにテーマ切り替えボタンを追加**: ユーザーが手動でライト/ダーク/システム設定を切り替えられるようにしました。
- **背景とテキストカラーの最適化**: `bg-slate-50` や `bg-white` などのハードコードされた色を `bg-background` やテーマ変数（`dark:bg-zinc-950` など）に置き換えました。
- **コンポーネントごとの調整**: Hero, Features, FAQ などの各セクションにおいて、ダークモード時でも視認性が高く、モダンな外観になるよう微調整を行いました。
- **スムーズな遷移**: テーマ切り替え時に色が滑らかに変化するよう `transition-colors duration-300` を追加しました。

### 確認事項
- [x] `sh scripts/verify_all.sh` がパスすることを確認
- [x] ビルド (`pnpm build`) が正常に完了することを確認
- [x] 既存のテストがパスすることを確認
