### PR TITLE
✍️ Scribe: 陣痛タイマー仕様書の実装同期 (useContractionActions)

### DIFF
--- a/.specify/specs/tracking/contraction_timer.md
+++ b/.specify/specs/tracking/contraction_timer.md
@@ -173,6 +173,18 @@ interface ContractionTimerState {
 }
 ```
 
+### アクション管理 (Custom Hook)
+
+- `useContractionActions` カスタムフックで、削除・編集・コメント追加などのアクションを管理する。
+- **コールバック分離**: 以前の単一 `onSuccess` コールバックを廃止し、操作ごとのコールバック (`onDeleted`, `onUpdated`) を採用することで、SWRの再検証やUI更新を適切にトリガーし、イベントの衝突を防ぐ。
+
+```typescript
+interface UseContractionActionsOptions {
+    onDeleted?: () => void // 削除完了時のコールバック
+    onUpdated?: () => void // 更新完了時のコールバック
+}
+```
+
 ### データ取得 (SWR)
 
 - `useContractions(babyId)` カスタムフックで陣痛記録を取得


### PR DESCRIPTION
💡 何を:
`.specify/specs/tracking/contraction_timer.md` の技術設計セクションに「アクション管理 (Custom Hook)」を追加しました。

🔍 発見:
`frontend/hooks/useContractionActions.ts` の実装では、削除や更新の完了時に `onDeleted` や `onUpdated` といった個別のコールバックを受け取る設計になっていますが、仕様書にはその記述がなく、単一の `onSuccess` のような古い概念（あるいは記述漏れ）がありました。

🎯 影響:
この更新により、開発者はフックの正しいインターフェースを理解し、SWRの再検証やUIの更新ロジックを適切に実装できるようになります。特に、複数の操作（削除・更新）が競合しないように設計されている意図が明確になります。

---
*PR created automatically by Jules for task [3747909437487726049](https://jules.google.com/task/3747909437487726049) started by @eburairu*