### PR TITLE
fix: 正六角形の描画精度とハニカムレイアウトの再調整

### DIFF
--- a/frontend/components/dashboard/QuickActionBar.tsx
+++ b/frontend/components/dashboard/QuickActionBar.tsx
@@ -80,30 +80,30 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
         <div className="fixed bottom-[calc(2rem+env(safe-area-inset-bottom))] md:bottom-10 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2 pointer-events-none">
             <div className="flex flex-col items-center pointer-events-auto">
                 {/* Honeycomb Row 1 */}
-                <div className="flex justify-center -mb-4">
+                <div className="flex justify-center -mb-3">
                     <HexagonButton
                         icon={<Droplets className="h-6 w-6" />}
                         label="ミルク"
                         size={72}
                         onClick={() => handleQuickRecord("feeding_bottle")}
                         loading={loadingAction === "feeding_bottle"}
-                        className="mx-[-6px]"
+                        className="mx-[-2px]"
                     />
                     <HexagonButton
                         icon={activeSleep ? <Bed className="h-6 w-6" /> : <Moon className="h-6 w-6" />}
                         label={activeSleep ? "起きた" : "寝た"}
-                        size={76}
+                        size={72}
                         active={!!activeSleep}
                         onClick={() => handleQuickRecord("sleep")}
                         loading={loadingAction === "sleep"}
-                        className="mx-[-6px] z-10"
+                        className="mx-[-2px] z-10"
                     />
                     <HexagonButton
                         icon={<StickyNote className="h-6 w-6" />}
                         label="メモ"
                         size={72}
                         onClick={() => setNoteDialogOpen(true)}
-                        className="mx-[-6px]"
+                        className="mx-[-2px]"
                     />
                 </div>
                 
@@ -115,7 +115,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                         size={72}
                         onClick={() => handleQuickRecord("diaper_wet")}
                         loading={loadingAction === "diaper_wet"}
-                        className="mx-[-6px]"
+                        className="mx-[-2px]"
                     />
                     <HexagonButton
                         icon={<Biohazard className="h-6 w-6" />}
@@ -123,7 +123,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                         size={72}
                         onClick={() => handleQuickRecord("diaper_dirty")}
                         loading={loadingAction === "diaper_dirty"}
-                        className="mx-[-6px]"
+                        className="mx-[-2px]"
                     />
                 </div>
             </div>

--- a/frontend/components/ui/hexagon.tsx
+++ b/frontend/components/ui/hexagon.tsx
@@ -20,30 +20,30 @@ export function Hexagon({
   rounded = true,
   ...props
 }: HexagonProps) {
-  // 正六角形のパス（角を丸めるための調整を含む）
-  // 頂点が上下にくるタイプ (Pointy-topped)
-  // viewBox="0 0 100 116" (100 * sqrt(3)/2 = 86.6 -> 100:116)
+  // 正六角形の正確な比率は 1 : 1.1547 (2/sqrt(3))
+  // viewBox="0 0 100 115.47"
   
+  // 角を丸めるためのパス（ベジェ曲線を使用）
   const path = rounded
-    ? "M50 3.5 L91.3 27.5 C94.5 29.3 96.5 32.8 96.5 36.5 L96.5 79.5 C96.5 83.2 94.5 86.7 91.3 88.5 L50 112.5 C46.8 114.3 43.2 114.3 40 112.5 L8.7 88.5 C5.5 86.7 3.5 83.2 3.5 79.5 L3.5 36.5 C3.5 32.8 5.5 29.3 8.7 27.5 L40 3.5 C43.2 1.7 46.8 1.7 50 3.5 Z"
-    : "M50 0 L100 28.8 L100 87.2 L50 116 L0 87.2 L0 28.8 Z"
+    ? "M50 2 C53.5 2 56.5 3.5 58.5 5 L91.5 24 C94.5 26 96.5 29.5 96.5 33 L96.5 82.5 C96.5 86 94.5 89.5 91.5 91.5 L58.5 110.5 C56.5 112 53.5 113.5 50 113.5 C46.5 113.5 43.5 112 41.5 110.5 L8.5 91.5 C5.5 89.5 3.5 86 3.5 82.5 L3.5 33 C3.5 29.5 5.5 26 8.5 24 L41.5 5 C43.5 3.5 46.5 2 50 2 Z"
+    : "M50 0 L100 28.87 L100 86.6 L50 115.47 L0 86.6 L0 28.87 Z"
 
   return (
     <div
       className={cn("relative flex items-center justify-center", className)}
-      style={{ width: size, height: "auto", aspectRatio: "100/116" }}
+      style={{ width: size, height: "auto", aspectRatio: "100/115.47" }}
       {...props}
     >
       <svg
-        viewBox="0 0 100 116"
+        viewBox="0 0 100 115.47"
         className="absolute inset-0 w-full h-full drop-shadow-sm transition-all duration-300"
-        style={{ filter: "drop-shadow(0 4px 6px rgba(0, 0, 0, 0.05))" }}
       >
         <path
           d={path}
           fill={color}
           stroke={borderColor}
           strokeWidth={borderWidth}
+          strokeLinejoin="round"
           className="transition-colors duration-300"
         />
       </svg>


### PR DESCRIPTION
## 概要
前のPR (#424) でマージされた六角形デザインの描画精度を数学的に正確な比率に修正し、ハニカムレイアウトの重なりを最適化しました。

## 変更内容
- **描画精度の向上**: `Hexagon` コンポーネントのアスペクト比を、理論値である `1 : 1.1547` に厳密に合わせました。
- **SVGパス의最適化**: 精密な計算に基づき、角の丸みが自然かつ正六角形の形状を維持するようにベジェ曲線を再定義しました。
- **レイアウトの微調整**: `QuickActionBar` において、ボタン間のネガティブマージン（-mb-3）とサイズ（72px）を調整し、歪みのないハニカム構造を実現しました。

## 確認事項
- [x] `sh scripts/verify_all.sh` がパスすることを確認

Co-Authored-By: Gemini <gemini@google.com>
