### PR TITLE
fix: 六角形のサイズ調整とボタンのアイコン化

### DIFF
--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -10,7 +10,7 @@ import { BaseWidgetProps } from "@/types/widget"
 import { WidgetContent } from "./WidgetContent"
 import { WidgetQuickButton } from "./WidgetQuickButton"
 import { normalizeFeedingFromRecord, calculateFeedingStats, NormalizedFeeding } from "@/lib/feedingUtils"
-import { Milk } from "lucide-react"
+import { Milk, Droplets, Waves } from "lucide-react"
 
 export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isError, mutate, isLoading }: BaseWidgetProps) {
     const { canWrite, loading, executeRecord } = useQuickRecord(babyId, { onSuccess: mutate })
@@ -59,8 +59,9 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
                         disabled={loading}
                         onClick={() => handleQuickRecord("bottle")}
                         className="flex-1"
+                        title="ミルクを記録"
                     >
-                        ミルク
+                        <Droplets className="w-5 h-5" />
                     </WidgetQuickButton>
                     <WidgetQuickButton
                         color="rose"
@@ -68,8 +69,9 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
                         disabled={loading}
                         onClick={() => handleQuickRecord("breast")}
                         className="flex-1"
+                        title="母乳を記録"
                     >
-                        母乳
+                        <Waves className="w-5 h-5" />
                     </WidgetQuickButton>
                 </div>
             ) : null}

--- a/frontend/components/dashboard/QuickActionBar.tsx
+++ b/frontend/components/dashboard/QuickActionBar.tsx
@@ -80,30 +80,27 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
         <div className="fixed bottom-[calc(2rem+env(safe-area-inset-bottom))] md:bottom-10 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2 pointer-events-none">
             <div className="flex flex-col items-center pointer-events-auto">
                 {/* Honeycomb Row 1 */}
-                <div className="flex justify-center -mb-4">
+                <div className="flex justify-center -mb-2">
                     <HexagonButton
                         icon={<Droplets className="h-6 w-6" />}
-                        label="ミルク"
-                        size={72}
+                        size={60}
                         onClick={() => handleQuickRecord("feeding_bottle")}
                         loading={loadingAction === "feeding_bottle"}
-                        className="mx-[-2px]"
+                        className="mx-[-1px]"
                     />
                     <HexagonButton
                         icon={activeSleep ? <Bed className="h-6 w-6" /> : <Moon className="h-6 w-6" />}
-                        label={activeSleep ? "起きた" : "寝た"}
-                        size={76}
+                        size={64}
                         active={!!activeSleep}
                         onClick={() => handleQuickRecord("sleep")}
                         loading={loadingAction === "sleep"}
-                        className="mx-[-2px] z-10"
+                        className="mx-[-1px] z-10"
                     />
                     <HexagonButton
                         icon={<StickyNote className="h-6 w-6" />}
-                        label="メモ"
-                        size={72}
+                        size={60}
                         onClick={() => setNoteDialogOpen(true)}
-                        className="mx-[-2px]"
+                        className="mx-[-1px]"
                     />
                 </div>
                 
@@ -111,19 +108,17 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                 <div className="flex justify-center">
                     <HexagonButton
                         icon={<Baby className="h-6 w-6" />}
-                        label="おしっこ"
-                        size={72}
+                        size={60}
                         onClick={() => handleQuickRecord("diaper_wet")}
                         loading={loadingAction === "diaper_wet"}
-                        className="mx-[-2px]"
+                        className="mx-[-1px]"
                     />
                     <HexagonButton
                         icon={<Biohazard className="h-6 w-6" />}
-                        label="うんち"
-                        size={72}
+                        size={60}
                         onClick={() => handleQuickRecord("diaper_dirty")}
                         loading={loadingAction === "diaper_dirty"}
-                        className="mx-[-2px]"
+                        className="mx-[-1px]"
                     />
                 </div>
             </div>

--- a/frontend/components/dashboard/SleepWidget.tsx
+++ b/frontend/components/dashboard/SleepWidget.tsx
@@ -8,7 +8,7 @@ import { BaseWidgetProps } from "@/types/widget"
 import { WidgetContent } from "./WidgetContent"
 import { WidgetQuickButton } from "./WidgetQuickButton"
 import { calculateSleepStats } from "@/lib/sleepUtils"
-import { Moon } from "lucide-react"
+import { Moon, Sun } from "lucide-react"
 
 export const SleepWidget = memo(function SleepWidget({ babyId, records, isError, mutate, isLoading }: BaseWidgetProps) {
     const { canWrite, loading, executeRecord } = useQuickRecord(babyId, { onSuccess: mutate })
@@ -78,8 +78,9 @@ export const SleepWidget = memo(function SleepWidget({ babyId, records, isError,
                     disabled={loading}
                     onClick={isSleeping ? handleEnd : handleStart}
                     className="w-full"
+                    title={isSleeping ? "起きた記録をする" : "寝た記録をする"}
                 >
-                    {isSleeping ? "睡眠終了" : "睡眠開始"}
+                    {isSleeping ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
                 </WidgetQuickButton>
             ) : null}
         </WidgetCard>


### PR DESCRIPTION
## 概要
六角形ボタンのサイズ調整、クイックアクションのラベル削除、およびダッシュボードウィジェットのボタンをアイコン化しました。

## 変更内容
- **サイズ調整**: `QuickActionBar` の六角形サイズを `72px` から `60px` (`sleep` は `64px`) に縮小し、よりコンパクトにしました。
- **ラベル削除**: `QuickActionBar` からテキストラベルを削除し、視覚的なノイズを減らしました。
- **アイコン化**: `FeedingWidget` と `SleepWidget` のクイックボタンをテキストから Lucide アイコンに変更しました。
  - ミルク: `Droplets`
  - 母乳: `Waves`
  - 睡眠: `Moon` / `Sun`

## 確認事項
- [x] `sh scripts/verify_all.sh` がパスすることを確認

Co-Authored-By: Gemini <gemini@google.com>
