### PR TITLE
fix: HoneycombGrid の中央揃えとオーバーフロー修正

### DIFF
--- a/frontend/components/ui/honeycomb-grid.tsx
+++ b/frontend/components/ui/honeycomb-grid.tsx
@@ -60,7 +60,7 @@ export function HoneycombGrid({
               return (
                 <div 
                   key={childIndex}
-                  className="relative"
+                  className="relative flex items-center justify-center overflow-visible"
                   style={{
                     width: width,
                     height: height,


### PR DESCRIPTION
## 概要
`HoneycombGrid` のセル内で子要素が中央に配置されるようにし、また基準サイズをわずかに超える要素（強調表示されたボタンなど）が隣接要素を押し出すことなく描画されるように修正しました。

## 変更内容
- **レイアウトの安定化**: セルコンテナに `flex items-center justify-center` を適用。
- **オーバーフローの許容**: `overflow-visible` を追加し、`QuickActionBar` の睡眠ボタン（size=68 vs grid=64）などが歪みなく表示されるように修正。

## 確認事項
- [x] `sh scripts/verify_all.sh` がパスすることを確認

Co-Authored-By: Gemini <gemini@google.com>
