### PR TITLE
fix: プッシュ通知デバッグ強化・購読同期修正

### DIFF
--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -202,7 +202,7 @@ def send_test_notification(
 
     results = []
     for sub in subscriptions:
-        success = send_push_notification(
+        result = send_push_notification(
             sub,
             title="テスト通知 🔔",
             body="プッシュ通知が正常に動作しています！",
@@ -212,7 +212,9 @@ def send_test_notification(
         results.append({
             "subscription_id": sub.id,
             "endpoint_preview": sub.endpoint[:60] + "...",
-            "success": success
+            "success": result["success"],
+            "status_code": result.get("status_code"),
+            "error": result.get("error"),
         })
 
     all_success = all(r["success"] for r in results)

--- a/app/utils/notifications.py
+++ b/app/utils/notifications.py
@@ -30,11 +30,11 @@ def is_within_dnd(settings: NotificationSetting) -> bool:
     else: # 日を跨ぐ場合 (例: 22:00 - 07:00)
         return now >= start or now <= end
 
-def send_push_notification(subscription: PushSubscription, title: str, body: str, url: str = "/", db: Session | None = None):
+def send_push_notification(subscription: PushSubscription, title: str, body: str, url: str = "/", db: Session | None = None) -> dict:
     """特定の購読に対してプッシュ通知を送信する"""
     if not VAPID_PRIVATE_KEY or not VAPID_PUBLIC_KEY:
         logger.warning("VAPID keys not configured. Skipping push notification.")
-        return False
+        return {"success": False, "status_code": None, "error": "VAPID keys not configured"}
 
     try:
         payload = {
@@ -60,7 +60,7 @@ def send_push_notification(subscription: PushSubscription, title: str, body: str
             }
         )
         logger.info(f"Push notification sent successfully to subscription id={subscription.id}")
-        return True
+        return {"success": True, "status_code": None, "error": None}
     except WebPushException as ex:
         status_code = None
         response_body = None
@@ -83,10 +83,11 @@ def send_push_notification(subscription: PushSubscription, title: str, body: str
             except Exception as delete_ex:
                 logger.error(f"Failed to delete invalid subscription: {delete_ex}")
                 db.rollback()
-        return False
+        return {"success": False, "status_code": status_code, "error": str(ex)}
     except Exception as ex:
-        logger.error(f"Unexpected error sending push to subscription id={subscription.id}: {type(ex).__name__}: {ex}")
-        return False
+        error_msg = f"{type(ex).__name__}: {ex}"
+        logger.error(f"Unexpected error sending push to subscription id={subscription.id}: {error_msg}")
+        return {"success": False, "status_code": None, "error": error_msg}
 
 
 # category → notification_settings カラムのマッピング
@@ -153,6 +154,7 @@ def notify_user(db: Session, user_id: int, title: str, body: str, url: str = "/"
     subscriptions = db.query(PushSubscription).filter(PushSubscription.user_id == user_id).all()
     logger.info(f"Sending {category} push to user {user_id}: {len(subscriptions)} subscription(s)")
     for sub in subscriptions:
+        # 戻り値を無視して続行（副作用のみのため）
         send_push_notification(sub, title, body, url, db=db)
 
 

--- a/frontend/app/(dashboard)/settings/notifications/page.tsx
+++ b/frontend/app/(dashboard)/settings/notifications/page.tsx
@@ -190,10 +190,23 @@ export default function NotificationsPage() {
                     try {
                       const res = await fetch("/api/notifications/test", { method: "POST" });
                       const data = await res.json();
-                      if (data.success) {
-                        toast.success("テスト通知を送信しました");
+                      if (data.subscription_count === 0) {
+                        toast.error(data.message);
                       } else {
-                        toast.error(data.message || "テスト通知の送信に失敗しました");
+                        const failures = data.results?.filter((r: { success: boolean }) => !r.success) || [];
+                        if (failures.length > 0) {
+                          const groups: Record<string, string[]> = {};
+                          (failures as { subscription_id: number; error: string | null }[]).forEach((f) => {
+                            const msg = f.error || "不明なエラー";
+                            groups[msg] = [...(groups[msg] || []), `sub#${f.subscription_id}`];
+                          });
+                          const errorDetails = Object.entries(groups)
+                            .map(([msg, subs]) => `${msg} (${subs.join(", ")})`)
+                            .join(", ");
+                          toast.error(`送信失敗: ${errorDetails}`);
+                        } else {
+                          toast.success("テスト通知を送信しました");
+                        }
                       }
                     } catch {
                       toast.error("テスト通知の送信に失敗しました");

--- a/frontend/hooks/usePushNotification.ts
+++ b/frontend/hooks/usePushNotification.ts
@@ -59,6 +59,7 @@ export function usePushNotification() {
       const existingSubscription = await registration.pushManager.getSubscription();
 
       if (existingSubscription) {
+        await sendSubscriptionToBackend(existingSubscription);
         return existingSubscription;
       }
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -64,8 +64,8 @@ class TestSendPushNotification:
         
         sub = MagicMock(spec=PushSubscription)
         result = send_push_notification(sub, "Test", "Body")
-        assert result is False
-        
+        assert result == {"success": False, "status_code": None, "error": "VAPID keys not configured"}
+
         notifications.VAPID_PRIVATE_KEY = old_priv
         notifications.VAPID_PUBLIC_KEY = old_pub
 
@@ -85,7 +85,7 @@ class TestSendPushNotification:
         sub.auth = "test_auth"
         
         result = send_push_notification(sub, "Test Title", "Test Body")
-        assert result is True
+        assert result["success"] is True
         mock_webpush.assert_called_once()
         
         notifications.VAPID_PRIVATE_KEY = old_priv
@@ -118,7 +118,8 @@ class TestSendPushNotification:
         db = MagicMock()
         result = send_push_notification(sub, "Test", "Body", db=db)
         
-        assert result is False
+        assert result["success"] is False
+        assert result["status_code"] == 410
         db.delete.assert_called_once_with(sub)
         db.commit.assert_called_once()
         


### PR DESCRIPTION
## 問題

ユーザー eburairu への PWA プッシュ通知（テスト通知含む）が届かない。

## 調査結果

### ログ分析（提供ログから）

```
07:00:37 POST /api/notifications/test 200 OK
07:00:38 GET /icons/icon-192x192.png 200 OK  ← 210.194.188.188（iPhoneのIP）
```

**通知はiPhoneに届いている**（Service Workerが`push`イベントを受けて`showNotification`を呼んだためアイコンフェッチが発生）。しかし**通知バナーが表示されていない**。

### 根本原因：PNGアイコンが存在しない

- `worker-1e999a0f776a11db.js`（Service Worker）が `/icons/icon-192x192.png` を参照
- しかし `public/icons/` には SVG しか存在しない（PNG がなかった）
- FastAPI はファイルが見つからない場合 `index.html`（HTML）をフォールバックとして返す（200 OK）
- Service Worker がアイコンとして **HTML** を受け取る → iOS Safari はこの状態では通知を表示しない
- また `worker/index.ts`（ソース）は `.svg` を参照していて、ビルド済みの JS と不整合

## 変更内容

### アイコン修正（メインの修正）
- `public/icons/*.png` を新規追加（SVG を `sips` で 192x192/512x512 に変換）
- `worker/index.ts` のアイコン参照を `.svg` → `.png` に統一
- `manifest.json` に PNG アイコンエントリを追加（SVG も維持）

### バックエンド（デバッグ用）
- `send_push_notification` の戻り値を `bool` → `dict{success, status_code, error}` に変更
- テスト通知 API のレスポンスに各購読の `status_code` と `error` を追加
- テスト通知失敗時に購読ごとのエラー内容をトーストで表示

### フロントエンド（副次修正）
- `subscribeUser` で既存購読がある場合もバックエンドへ同期（410削除後の再登録問題を修正）

### テスト
- 新しい戻り値型（dict）に対応

## 確認手順

1. マージ・デプロイ後、設定 → 通知設定 → テスト通知を送信
2. iPhoneへの通知が表示されることを確認
3. 引き続き届かない場合はトーストに表示されるエラー詳細を確認