### PR TITLE
fix: ダッシュボードウィジェットの六角形ボタン配置を統一

### DIFF
--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -51,13 +51,13 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
                 subContent={<span className="flex items-center gap-1">今日: <Droplets className="w-3 h-3 inline-block" />{wetCount} / <Biohazard className="w-3 h-3 inline-block" />{dirtyCount}</span>}
             />
             {canWrite ? (
-                <div className="flex gap-2">
+                <div className="flex gap-2 justify-center">
                     <WidgetQuickButton
                         color="amber"
                         loading={loading}
                         disabled={loading}
                         onClick={() => handleQuickRecord(DiaperType.WET)}
-                        className="flex-1"
+                        size={48}
                         aria-label="おしっこ"
                     >
                         <Droplets className="w-5 h-5" />
@@ -67,7 +67,7 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
                         loading={loading}
                         disabled={loading}
                         onClick={() => handleQuickRecord(DiaperType.DIRTY)}
-                        className="flex-1"
+                        size={48}
                         aria-label="うんち"
                     >
                         <Biohazard className="w-5 h-5" />

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -52,7 +52,7 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
                 subContent={`今日: ${todayCount}回`}
             />
             {canWrite ? (
-                <div className="flex gap-4 justify-center">
+                <div className="flex gap-2 justify-center">
                     <WidgetQuickButton
                         color="rose"
                         loading={loading}

--- a/frontend/components/dashboard/SleepWidget.tsx
+++ b/frontend/components/dashboard/SleepWidget.tsx
@@ -78,7 +78,7 @@ export const SleepWidget = memo(function SleepWidget({ babyId, records, isError,
                         loading={loading}
                         disabled={loading}
                         onClick={isSleeping ? handleEnd : handleStart}
-                        size={52}
+                        size={48}
                         title={isSleeping ? "起きた記録をする" : "寝た記録をする"}
                         aria-label={isSleeping ? "起きた記録をする" : "寝た記録をする"}
                     >


### PR DESCRIPTION
## 問題

ウィジェットによって六角形ボタンの配置スタイルがバラバラだった。

| ウィジェット | コンテナ | size |
|---|---|---|
| FeedingWidget | `flex gap-4 justify-center` | 48 |
| SleepWidget | `flex justify-center` | **52**（他と違う） |
| DiaperWidget | `flex gap-2`（justify-centerなし） | なし・flex-1指定 |

## 変更内容

統一基準:
- 1ボタン: `flex justify-center` + `size={48}`
- 2ボタン: `flex gap-2 justify-center` + `size={48}`

| ファイル | 変更 |
|---|---|
| FeedingWidget.tsx | gap-4 → gap-2 |
| SleepWidget.tsx | size={52} → size={48} |
| DiaperWidget.tsx | justify-centerを追加、flex-1を削除しsize={48}を追加 |

## テスト計画

- [ ] ダッシュボードで授乳・睡眠・おむつウィジェットのボタンが同一サイズで中央揃えになっていることを目視確認