### PR TITLE
fix: ダッシュボードの残りの絵文字を Lucide アイコンに置き換え

### DIFF
--- a/frontend/components/dashboard/ActivityItem.tsx
+++ b/frontend/components/dashboard/ActivityItem.tsx
@@ -2,7 +2,7 @@
 import React from "react"
 import { BabyRecord } from "@/types/record"
 import { formatElapsed } from "@/lib/ageUtils"
-import { MessageCircle, User } from "lucide-react"
+import { MessageCircle, User, StickyNote } from "lucide-react"
 import { RECORD_TYPE_LABELS, RECORD_TYPE_LUCIDE_ICONS } from "@/constants/ui"
 
 interface ActivityItemProps {
@@ -24,7 +24,7 @@ export const ActivityItem = React.memo(function ActivityItem({ record, onClick }
             >
                 {LucideIcon
                     ? <LucideIcon className="h-5 w-5 text-muted-foreground shrink-0" aria-hidden="true" />
-                    : <span className="text-xl" aria-hidden="true">📝</span>
+                    : <StickyNote className="h-5 w-5 text-muted-foreground shrink-0" aria-hidden="true" />
                 }
                 <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-gray-800 dark:text-zinc-200">

--- a/frontend/components/dashboard/BirthRegistrationDialog.tsx
+++ b/frontend/components/dashboard/BirthRegistrationDialog.tsx
@@ -3,16 +3,9 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
-} from "@/components/ui/dialog"
+import { DialogTrigger, DialogTitle, DialogDescription, DialogFooter, DialogHeader, DialogContent, Dialog } from "@/components/ui/dialog"
 import { api, isApiError } from "@/lib/api"
+import { PartyPopper } from "lucide-react"
 
 interface Props {
     babyId: string
@@ -54,12 +47,14 @@ export function BirthRegistrationDialog({ babyId, babyName, onSuccess }: Props) 
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
                 <button className="w-full h-14 rounded-2xl bg-gradient-to-r from-pink-500 to-rose-400 hover:from-pink-600 hover:to-rose-500 dark:from-pink-600 dark:to-rose-500 dark:hover:from-pink-700 dark:hover:to-rose-600 text-white font-bold text-lg shadow-md hover:shadow-lg transition-all flex items-center justify-center gap-2">
-                    🎉 生まれた！
+                    <PartyPopper className="w-6 h-6" /> 生まれた！
                 </button>
             </DialogTrigger>
             <DialogContent className="sm:max-w-md dark:bg-zinc-900 dark:border-zinc-800">
                 <DialogHeader>
-                    <DialogTitle className="dark:text-zinc-100">🎉 おめでとうございます！</DialogTitle>
+                    <DialogTitle className="dark:text-zinc-100 flex items-center gap-2">
+                        <PartyPopper className="w-6 h-6 text-pink-500" /> おめでとうございます！
+                    </DialogTitle>
                     <DialogDescription className="dark:text-zinc-400">
                         {babyName}の誕生日を登録しましょう。
                     </DialogDescription>


### PR DESCRIPTION
## 概要
ダッシュボード上の残りの絵文字アイコンを `lucide-react` のアイコンに置き換え、UIの一貫性を向上させました。

## 変更内容
- `ActivityItem`: 種類が不明な場合のフォールバックアイコンを `📝` から `StickyNote` に変更
- `BirthRegistrationDialog`: 「生まれた！」ボタンとお祝いメッセージの `🎉` を `PartyPopper` に変更

※ `GrowthWidget` の絵文字 (`📏`) 修正は既に `develop` に反映されていたため、このPRには含まれていません。

## 確認事項
- [x] `sh scripts/verify_all.sh` がパスすること
- [x] ビルドエラーがないこと
