### PR TITLE
fix: 成長記録のアイコンを Ruler に統一し絵文字を排除

### DIFF
--- a/frontend/app/(dashboard)/growth/page.tsx
+++ b/frontend/app/(dashboard)/growth/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { useGrowths } from "@/hooks/useData"
 import { useRecordPage } from "@/hooks/useRecordPage"
 import { Button } from "@/components/ui/button"
-import { Plus, TrendingUp } from "lucide-react"
+import { Plus, Ruler } from "lucide-react"
 import { GrowthChart } from "@/components/growth/GrowthChart"
 import { GrowthHistoryList } from "@/components/growth/GrowthHistoryList"
 import { GrowthRecordForm } from "@/components/growth/GrowthRecordForm"
@@ -51,7 +51,7 @@ export default function GrowthPage() {
     return (
         <RecordPageLayout
             title="成長記録"
-            icon={TrendingUp}
+            icon={Ruler}
             iconColorClass="text-emerald-500 dark:text-emerald-400"
             isLoading={babiesLoading}
             isDataLoading={growthsLoading}

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -11,7 +11,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Check, ChevronDown, ChevronLeft, Settings, Menu, Home, Milk, Moon, Baby, TrendingUp, StickyNote, BookOpen, Timer } from "lucide-react"
+import { Check, ChevronDown, ChevronLeft, Settings, Menu, Home, Milk, Moon, Baby, Ruler, StickyNote, BookOpen, Timer } from "lucide-react"
 import { useSelectedBaby } from "@/hooks/useSelectedBaby"
 import { cn, getDisplayName } from "@/lib/utils"
 import { isBorn } from "@/lib/babyUtils"
@@ -42,7 +42,7 @@ const ALL_NAV_ITEMS: {
     { label: "授乳",         href: "/feeding",     Icon: Milk,       color: "text-pink-500",    prenatal: false, postnatal: true  },
     { label: "睡眠",         href: "/sleep",       Icon: Moon,       color: "text-violet-500",  prenatal: false, postnatal: true  },
     { label: "おむつ",       href: "/diaper",      Icon: Baby,       color: "text-amber-500",   prenatal: false, postnatal: true  },
-    { label: "成長",         href: "/growth",      Icon: TrendingUp, color: "text-emerald-500", prenatal: false, postnatal: true  },
+    { label: "成長",         href: "/growth",      Icon: Ruler,      color: "text-emerald-500", prenatal: false, postnatal: true  },
     { label: "メモ",         href: "/note",        Icon: StickyNote, color: "text-orange-400",  prenatal: false, postnatal: true  },
     { label: "日誌",         href: "/diary",       Icon: BookOpen,   color: "text-indigo-400",  prenatal: false, postnatal: true  },
     { label: "陣痛タイマー", href: "/contraction", Icon: Timer,      color: "text-red-500",     prenatal: true,  postnatal: false },
@@ -58,7 +58,7 @@ const BOTTOM_NAV_ITEMS: {
     { label: "授乳",     href: "/feeding",   Icon: Milk,       color: "text-pink-500" },
     { label: "睡眠",     href: "/sleep",     Icon: Moon,       color: "text-violet-500" },
     { label: "おむつ",   href: "/diaper",    Icon: Baby,       color: "text-amber-500" },
-    { label: "成長",     href: "/growth",    Icon: TrendingUp, color: "text-emerald-500" },
+    { label: "成長",     href: "/growth",    Icon: Ruler,      color: "text-emerald-500" },
 ]
 
 export default function DashboardLayout({

--- a/frontend/components/dashboard/GrowthWidget.tsx
+++ b/frontend/components/dashboard/GrowthWidget.tsx
@@ -4,7 +4,7 @@ import { createWidgetMemoComparison } from "@/lib/memoUtils"
 import { WidgetCard } from "./WidgetCard"
 import { WidgetLoading } from "./WidgetLoading"
 import { BaseWidgetProps } from "@/types/widget"
-import { TrendingUp } from "lucide-react"
+import { Ruler } from "lucide-react"
 
 export const GrowthWidget = memo(function GrowthWidget({ babyId, records, isLoading, isError }: BaseWidgetProps) {
     const growthRecords = records?.filter(r => r.type === 'growth') ?? []
@@ -19,7 +19,12 @@ export const GrowthWidget = memo(function GrowthWidget({ babyId, records, isLoad
 
     return (
         <WidgetCard
-            title={<span className="text-emerald-500 dark:text-emerald-400 flex items-center gap-1"><TrendingUp className="w-4 h-4" /> 成長</span>}
+            title={
+                <span className="text-emerald-500 dark:text-emerald-400 flex items-center gap-1.5">
+                    <Ruler className="w-4 h-4" />
+                    成長
+                </span>
+            }
             href={`/growth?baby_id=${babyId}`}
             isError={isError}
             actionHoverColor="hover:text-emerald-500 dark:hover:text-emerald-400"

--- a/frontend/constants/ui.ts
+++ b/frontend/constants/ui.ts
@@ -3,7 +3,7 @@
  */
 
 import { RECORD_TYPES } from '@/types/enums';
-import { Milk, Moon, Baby, TrendingUp, FileText, Zap, type LucideIcon } from 'lucide-react';
+import { Milk, Moon, Baby, Ruler, FileText, Zap, type LucideIcon } from 'lucide-react';
 
 export const TOAST_DURATION_MS = 3000;
 export const MOBILE_BREAKPOINT_PX = 768;
@@ -21,7 +21,7 @@ export const RECORD_TYPE_LUCIDE_ICONS: Record<keyof typeof RECORD_TYPE_LABELS, L
   [RECORD_TYPES.FEEDING]: Milk,
   [RECORD_TYPES.SLEEP]: Moon,
   [RECORD_TYPES.DIAPER]: Baby,
-  [RECORD_TYPES.GROWTH]: TrendingUp,
+  [RECORD_TYPES.GROWTH]: Ruler,
   [RECORD_TYPES.NOTE]: FileText,
   [RECORD_TYPES.CONTRACTION]: Zap,
 } as const;


### PR DESCRIPTION
## 概要
「成長」に関するアイコンを `TrendingUp` (📈) から `Ruler` (定規) に変更し、アプリ全体での一貫性を向上させるとともに、絵文字が残っているように見える問題を完全に解消しました。

## 変更内容
- `frontend/constants/ui.ts`: `GROWTH` のアイコンを `Ruler` に変更
- `frontend/components/dashboard/GrowthWidget.tsx`: タイトルアイコンを `Ruler` に変更
- `frontend/app/(dashboard)/layout.tsx`: ナビゲーションアイコンを `Ruler` に変更
- `frontend/app/(dashboard)/growth/page.tsx`: ページヘッダーアイコンを `Ruler` に変更

## 確認事項
- [x] `sh scripts/verify_all.sh` がパスすること
- [x] 全ての「成長」ラベルの横に定規アイコンが表示されること
