### PR TITLE
⚡ Bolt: 主要な記録テーブルのuser_idにインデックスを追加

### DIFF
--- a/alembic/versions/01a66095cc44_add_user_id_indexes_to_records.py
+++ b/alembic/versions/01a66095cc44_add_user_id_indexes_to_records.py
@@ -1,0 +1,36 @@
+"""add_user_id_indexes_to_records
+
+Revision ID: 01a66095cc44
+Revises: 5c7e95cda081
+Create Date: 2026-02-27 05:30:14.082708+09:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '01a66095cc44'
+down_revision: Union[str, Sequence[str], None] = '5c7e95cda081'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index(op.f('ix_feedings_user_id'), 'feedings', ['user_id'], unique=False)
+    op.create_index(op.f('ix_sleeps_user_id'), 'sleeps', ['user_id'], unique=False)
+    op.create_index(op.f('ix_diapers_user_id'), 'diapers', ['user_id'], unique=False)
+    op.create_index(op.f('ix_growths_user_id'), 'growths', ['user_id'], unique=False)
+    op.create_index(op.f('ix_notes_user_id'), 'notes', ['user_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_notes_user_id'), table_name='notes')
+    op.drop_index(op.f('ix_growths_user_id'), table_name='growths')
+    op.drop_index(op.f('ix_diapers_user_id'), table_name='diapers')
+    op.drop_index(op.f('ix_sleeps_user_id'), table_name='sleeps')
+    op.drop_index(op.f('ix_feedings_user_id'), table_name='feedings')

--- a/app/models/diaper.py
+++ b/app/models/diaper.py
@@ -13,7 +13,7 @@ class Diaper(Base):
     __tablename__ = "diapers"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
     change_time = Column(DateTime, nullable=False, index=True)
     diaper_type = Column(Enum(DiaperType, name="diapertype"), nullable=False)
     notes = Column(String, nullable=True)

--- a/app/models/feeding.py
+++ b/app/models/feeding.py
@@ -30,7 +30,7 @@ class Feeding(Base):
     __tablename__ = "feedings"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
     feeding_time = Column(DateTime, nullable=False, index=True)
     feeding_type = Column(Enum(FeedingType, name="feedingtype"), nullable=False)
     amount_ml = Column(Float, nullable=True)

--- a/app/models/growth.py
+++ b/app/models/growth.py
@@ -6,7 +6,7 @@ class Growth(Base):
     __tablename__ = "growths"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
     date = Column(Date, nullable=False, index=True)
     weight = Column(Integer, nullable=True)  # in grams
     height = Column(Float, nullable=True)  # in cm

--- a/app/models/note.py
+++ b/app/models/note.py
@@ -11,7 +11,7 @@ class Note(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
     baby_id = Column(Integer, ForeignKey("babies.id", ondelete="CASCADE"), nullable=False)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
     content = Column(Text, nullable=False)
     note_time = Column(DateTime, nullable=False, server_default=func.now(), index=True)
     created_at = Column(DateTime, nullable=False, server_default=func.now())

--- a/app/models/sleep.py
+++ b/app/models/sleep.py
@@ -6,7 +6,7 @@ class Sleep(Base):
     __tablename__ = "sleeps"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
     start_time = Column(DateTime, nullable=False, index=True)
     end_time = Column(DateTime, nullable=True)
     notes = Column(String, nullable=True)


### PR DESCRIPTION
主要な記録テーブル（feedings, sleeps, diapers, growths, notes）の `user_id` カラムにインデックスを追加し、クエリパフォーマンスを向上させました。

---
*PR created automatically by Jules for task [6229853147587911662](https://jules.google.com/task/6229853147587911662) started by @eburairu*