### PR TITLE
fix: 授乳記録作成時に AI フィードバックが実行されない問題を修正

### DIFF
--- a/frontend/app/(dashboard)/feeding/page.tsx
+++ b/frontend/app/(dashboard)/feeding/page.tsx
@@ -9,7 +9,7 @@ import { FeedingForm } from "@/components/feeding/feeding-form"
 import { FeedingHistory } from "@/components/feeding/feeding-history"
 import { TipsCard } from "@/components/ui/tips-card"
 import { feedingTips } from "@/lib/tips-data"
-import { FeedingCreate } from "@/types/feeding"
+import { Feeding, FeedingCreate } from "@/types/feeding"
 import { RECORD_TYPES } from "@/types/enums"
 import { RecordPageLayout } from "@/components/ui/record-page-layout"
 
@@ -38,11 +38,12 @@ export default function FeedingPage() {
         refresh: refreshFeedings,
     } = useFeeding(numericBabyId ?? null)
 
-    const handleAddFeeding = async (data: FeedingCreate): Promise<void> => {
+    const handleAddFeeding = async (data: FeedingCreate): Promise<Feeding | undefined> => {
         const newRecord = await addFeeding(data)
         if (newRecord && numericBabyId) {
             triggerFeedback(RECORD_TYPES.FEEDING, newRecord.id)
         }
+        return newRecord
     }
 
     return (

--- a/frontend/components/feeding/feeding-form.tsx
+++ b/frontend/components/feeding/feeding-form.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { FEEDING_COMPLETIONS } from "@/constants/feeding"
 import { useState, useEffect, useCallback } from "react"
 import { useFeedingTimer } from "@/hooks/useFeedingTimer"
 import { useForm } from "react-hook-form"
@@ -8,10 +7,9 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { feedingSchema, FeedingFormValues } from "@/schemas/feeding"
 import { format } from "date-fns"
 import { Save, Heart, Milk } from "lucide-react"
-import { toast } from "sonner"
 
 import { cn } from "@/lib/utils"
-import { UI_BUTTONS, UI_FORMS } from "@/constants/ui-colors"
+import { UI_BUTTONS } from "@/constants/ui-colors"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import {
@@ -35,7 +33,7 @@ import { FeedingCompletionSelector } from "./FeedingCompletionSelector"
 
 interface FeedingFormProps {
     babyId: number
-    onAdd?: (data: FeedingCreate) => Promise<void>
+    onAdd?: (data: FeedingCreate) => Promise<Feeding | undefined>
     onUpdate?: (id: number, data: FeedingUpdate) => Promise<Feeding | undefined>
     initialData?: Feeding
     onSuccess?: () => void
@@ -123,41 +121,36 @@ export function FeedingForm({ babyId, onAdd, onUpdate, initialData, onSuccess, l
     })
 
     const onSubmit = useCallback(async (values: FeedingFormValues) => {
-        // If custom handlers are provided, we use them instead of submitRecord default
-        // However, we still want to reuse the payload building logic
-
-        // Note: We are using useBaseRecordForm mainly for state management here if we use onAdd/onUpdate
-        // But submitRecord automatically calls the API.
-        // To avoid double submission or conflict, we only use submitRecord if onAdd/onUpdate are NOT provided?
-        // Actually, for this refactor, we are simplifying by accepting that we might need to duplicate some logic
-        // OR we just use submitRecord for the "Create" case if onAdd is not provided (which is rare).
-        //
-        // Let's respect the existing props.
         try {
-           // We'll manually manage the submission process using the injected handlers if present
-           // This keeps the "useBaseRecordForm" primarily for the shared "success" logic if we could hook into it,
-           // but since we can't easily, we'll just fall back to manual handling for the custom props cases
-           // and use submitRecord ONLY if we want default behavior (which is just POST).
-
-           // BUT, to clean up this file, let's just use the manual logic we had, but simplified.
-           // Wait, I already introduced useBaseRecordForm above.
-           // I will use `submitRecord` for the standard creation case, and manual for Update.
-
             if (isEditing && initialData && onUpdate) {
-                const data = buildFeedingPayload({
-                    babyId,
+                // Update case
+                await submitRecord(
                     values,
-                    activeTab,
-                    feedingCompletion,
-                    bottleContentType
-                })
-                await onUpdate(initialData.id, data)
-                toast.success("更新しました")
-                if (onSuccess) onSuccess()
+                    (vals) => buildFeedingPayload({
+                        babyId,
+                        values: vals,
+                        activeTab,
+                        feedingCompletion,
+                        bottleContentType
+                    }),
+                    (payload) => onUpdate(initialData.id, payload)
+                )
+            } else if (onAdd) {
+                // Create case with custom onAdd (needed for triggerFeedback etc)
+                await submitRecord(
+                    values,
+                    (vals) => buildFeedingPayload({
+                        babyId,
+                        values: vals,
+                        activeTab,
+                        feedingCompletion,
+                        bottleContentType
+                    }),
+                    onAdd
+                )
             } else {
-                // Create case
-                // We use submitRecord.
-                await submitRecord(values, (vals, base) => {
+                // Default create case (standard POST)
+                await submitRecord(values, (vals) => {
                     return buildFeedingPayload({
                         babyId,
                         values: vals,
@@ -166,13 +159,12 @@ export function FeedingForm({ babyId, onAdd, onUpdate, initialData, onSuccess, l
                         bottleContentType
                     })
                 })
-           }
-
+            }
         } catch (error) {
             console.error(error)
-            toast.error("保存に失敗しました")
+            // Error handling is mostly done by the hook, but we catch to avoid unhandled rejections
         }
-    }, [activeTab, babyId, bottleContentType, feedingCompletion, form, onUpdate, isEditing, initialData, submitRecord, onSuccess])
+    }, [activeTab, babyId, bottleContentType, feedingCompletion, isEditing, initialData, onAdd, onUpdate, submitRecord])
 
     const handleFormSubmit = form.handleSubmit(onSubmit)
 

--- a/frontend/hooks/useBaseRecordForm.ts
+++ b/frontend/hooks/useBaseRecordForm.ts
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { toast } from "sonner"
 import { api } from "@/lib/api"
 
-interface UseBaseRecordFormOptions<T> {
+interface UseBaseRecordFormOptions<_T> {
     endpoint: string
     babyId: string | number
     onSuccess?: (data?: unknown) => void
@@ -20,9 +20,10 @@ export function useBaseRecordForm<T>({
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [error, setError] = useState<string | null>(null)
 
-    const submitRecord = async (
+    const submitRecord = async <TPayload = unknown, TResult = unknown>(
         values: T,
-        payloadFormatter?: (values: T, basePayload: Record<string, unknown>) => unknown
+        payloadFormatter?: (values: T, basePayload: Record<string, unknown>) => TPayload,
+        customSubmitter?: (payload: TPayload) => Promise<TResult>
     ) => {
         setIsSubmitting(true)
         setError(null)
@@ -32,9 +33,16 @@ export function useBaseRecordForm<T>({
                 baby_id: Number(babyId),
             }
 
-            const payload = payloadFormatter ? payloadFormatter(values, basePayload) : basePayload
+            const payload = payloadFormatter 
+                ? payloadFormatter(values, basePayload) 
+                : (basePayload as unknown as TPayload)
 
-            const data = await api.post(endpoint, payload)
+            let data: TResult;
+            if (customSubmitter) {
+                data = await customSubmitter(payload)
+            } else {
+                data = await api.post(endpoint, payload) as unknown as TResult
+            }
 
             if (successMessage) {
                 toast.success(successMessage)


### PR DESCRIPTION
## 概要
FeedingForm が refactor された際、`onAdd` プロップが呼び出されなくなっており、その結果 `triggerFeedback` が実行されず AI フィードバック機能が動作しなくなっていた問題を修正しました。

## 変更内容
- `useBaseRecordForm` に `customSubmitter` オプションを追加し、`api.post` 以外のカスタム処理（プロップ経由の関数など）を呼び出せるようにしました。
- `FeedingForm` の `onSubmit` を修正し、`onAdd` や `onUpdate` プロップが提供されている場合はそれらを使用するようにしました。
- これにより、`page.tsx` で定義されている `handleAddFeeding`（およびそこでの `triggerFeedback` 呼び出し）が正しく実行されるようになります。
- 併せて、更新（Update）時にも `isSubmitting` 状態やトースト表示が正しく動作するように改善しました。

## 動作確認
- `sh scripts/verify_all.sh` がパスすることを確認。
- 授乳記録の作成および更新が正常に行えることをコードレベルで確認。
