### PR TITLE
🧹 Tidy: 共通定数の整理とFatなuseDataフックの分割

### DIFF
--- a/frontend/components/diaper/DiaperHistory.tsx
+++ b/frontend/components/diaper/DiaperHistory.tsx
@@ -11,44 +11,27 @@ import { HistoryCard } from "@/components/records/HistoryCard"
 import { RecordListItem } from "@/components/records/RecordListItem"
 import { RecordActionButtons } from "@/components/records/RecordActionButtons"
 import { useRecordComments } from "@/hooks/useRecordComments"
-
-
+import { DIAPER_STYLES, DIAPER_UNKNOWN_STYLE } from "@/constants/diaper"
 
 const getStyles = (type: DiaperType) => {
+    const style = DIAPER_STYLES[type] || DIAPER_UNKNOWN_STYLE;
+
+    let icon;
     switch (type) {
         case DiaperType.WET:
-            return {
-                bg: "bg-blue-50 dark:bg-blue-950/30",
-                border: "border-blue-100 dark:border-blue-900/50",
-                text: "text-blue-700 dark:text-blue-400",
-                icon: <Droplets className="w-6 h-6" />,
-                label: "おしっこ"
-            }
+            icon = <Droplets className="w-6 h-6" />;
+            break;
         case DiaperType.DIRTY:
-            return {
-                bg: "bg-amber-50 dark:bg-amber-950/30",
-                border: "border-amber-100 dark:border-amber-900/50",
-                text: "text-amber-700 dark:text-amber-400",
-                icon: <Biohazard className="w-6 h-6" />,
-                label: "うんち"
-            }
+            icon = <Biohazard className="w-6 h-6" />;
+            break;
         case DiaperType.BOTH:
-            return {
-                bg: "bg-purple-50 dark:bg-purple-950/30",
-                border: "border-purple-100 dark:border-purple-900/50",
-                text: "text-purple-700 dark:text-purple-400",
-                icon: <span className="flex gap-0.5"><Droplets className="w-6 h-6" /><Biohazard className="w-6 h-6" /></span>,
-                label: "両方"
-            }
+            icon = <span className="flex gap-0.5"><Droplets className="w-6 h-6" /><Biohazard className="w-6 h-6" /></span>;
+            break;
         default:
-            return {
-                bg: "bg-gray-50 dark:bg-zinc-800/50",
-                border: "border-gray-100 dark:border-zinc-700",
-                text: "text-gray-700 dark:text-zinc-400",
-                icon: "?",
-                label: "不明"
-            }
+            icon = "?";
     }
+
+    return { ...style, icon };
 }
 
 interface Props {

--- a/frontend/components/feeding/feeding-history.tsx
+++ b/frontend/components/feeding/feeding-history.tsx
@@ -12,6 +12,7 @@ import { RecordListItem } from "@/components/records/RecordListItem"
 import { RecordActionButtons } from "@/components/records/RecordActionButtons"
 import { FeedingEditDialog } from "./FeedingEditDialog"
 import { useRecordComments } from "@/hooks/useRecordComments"
+import { BOTTLE_CONTENT_LABEL, COMPLETION_STYLE } from "@/constants/feeding"
 
 interface FeedingHistoryProps {
     feedings: Feeding[];
@@ -22,17 +23,6 @@ interface FeedingHistoryProps {
     initialCommentRecordId?: number | null;
     babyId?: number;
 }
-
-const BOTTLE_CONTENT_LABEL: Record<string, string> = {
-    FORMULA: "粉ミルク",
-    EXPRESSED_MILK: "搾母乳",
-    MIXED: "混合",
-};
-
-const COMPLETION_STYLE: Record<string, { label: string; className: string }> = {
-    FULL: { label: "しっかり飲んだ", className: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" },
-    PARTIAL: { label: "途中でやめた", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400" },
-};
 
 function BreastDuration({ feeding }: { feeding: Feeding }) {
     const { left_breast_minutes, right_breast_minutes, duration_minutes } = feeding;

--- a/frontend/constants/diaper.ts
+++ b/frontend/constants/diaper.ts
@@ -1,2 +1,32 @@
 export const POOP_COLORS = ["黄色", "緑", "茶色", "黒", "白", "その他"] as const;
 export const POOP_AMOUNTS = ["少量", "普通", "多量", "その他"] as const;
+
+import { DiaperType } from "@/types/diaper";
+
+export const DIAPER_STYLES: Record<DiaperType, { bg: string; border: string; text: string; label: string }> = {
+    [DiaperType.WET]: {
+        bg: "bg-blue-50 dark:bg-blue-950/30",
+        border: "border-blue-100 dark:border-blue-900/50",
+        text: "text-blue-700 dark:text-blue-400",
+        label: "おしっこ"
+    },
+    [DiaperType.DIRTY]: {
+        bg: "bg-amber-50 dark:bg-amber-950/30",
+        border: "border-amber-100 dark:border-amber-900/50",
+        text: "text-amber-700 dark:text-amber-400",
+        label: "うんち"
+    },
+    [DiaperType.BOTH]: {
+        bg: "bg-purple-50 dark:bg-purple-950/30",
+        border: "border-purple-100 dark:border-purple-900/50",
+        text: "text-purple-700 dark:text-purple-400",
+        label: "両方"
+    }
+};
+
+export const DIAPER_UNKNOWN_STYLE = {
+    bg: "bg-gray-50 dark:bg-zinc-800/50",
+    border: "border-gray-100 dark:border-zinc-700",
+    text: "text-gray-700 dark:text-zinc-400",
+    label: "不明"
+};

--- a/frontend/constants/feeding.ts
+++ b/frontend/constants/feeding.ts
@@ -6,7 +6,17 @@ export const BOTTLE_CONTENT_TYPES: { value: BottleContentType; label: string }[]
     { value: "MIXED", label: "混合" },
 ];
 
+export const BOTTLE_CONTENT_LABEL: Record<string, string> = BOTTLE_CONTENT_TYPES.reduce((acc, item) => ({
+    ...acc,
+    [item.value]: item.label
+}), {});
+
 export const FEEDING_COMPLETIONS: { value: FeedingCompletion; label: string }[] = [
     { value: "FULL", label: "しっかり飲んだ" },
     { value: "PARTIAL", label: "途中でやめた" },
 ];
+
+export const COMPLETION_STYLE: Record<string, { label: string; className: string }> = {
+    FULL: { label: "しっかり飲んだ", className: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" },
+    PARTIAL: { label: "途中でやめた", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400" },
+};

--- a/frontend/hooks/useBabies.ts
+++ b/frontend/hooks/useBabies.ts
@@ -1,0 +1,19 @@
+import useSWR from 'swr';
+import { fetcher } from '@/lib/api';
+import type { Baby } from '@/types/baby';
+
+export function useBabies(options?: { fallbackData?: Baby[] }) {
+    const { data, error, isLoading, mutate } = useSWR<Baby[]>('/babies/', fetcher, {
+        ...options,
+        shouldRetryOnError: false,
+        revalidateOnFocus: true,
+        revalidateOnMount: true,
+        keepPreviousData: true,
+    });
+    return {
+        babies: data,
+        isLoading,
+        isError: error,
+        mutate,
+    };
+}

--- a/frontend/hooks/useData.ts
+++ b/frontend/hooks/useData.ts
@@ -1,63 +1,14 @@
-import useSWR from 'swr';
-import { fetcher } from '@/lib/api';
-import type { Baby } from '@/types/baby';
-import { Family, FamilyMember } from "@/types/family";
-import { BabyRecord } from "@/types/record";
-
 // Re-export hooks from their new locations for backward compatibility
+
+// Extracted in this refactor
+export { useBabies } from '@/hooks/useBabies';
+export { useRecords } from '@/hooks/useRecords';
+export { useFamilySettings, useFamilyMembers } from '@/hooks/useFamily';
+
+// Previously extracted
 export { useContractions } from '@/hooks/useContraction';
 export { useSleeps } from '@/hooks/useSleep';
 export { useDiapers } from '@/hooks/useDiaper';
 export { useGrowths } from '@/hooks/useGrowth';
 export { useMilestoneTimeline } from '@/hooks/useMilestone';
 export { useVaccinations } from '@/hooks/useVaccination';
-
-export function useFamilySettings() {
-    const { data, error, isLoading, mutate } = useSWR<Family>('/family/', fetcher);
-    return {
-        family: data,
-        isLoading,
-        isError: error,
-        mutate,
-    };
-}
-
-export function useFamilyMembers() {
-    const { data, error, isLoading, mutate } = useSWR<FamilyMember[]>('/family/members', fetcher);
-    return {
-        members: data,
-        isLoading,
-        isError: error,
-        mutate,
-    };
-}
-
-export function useBabies(options?: { fallbackData?: Baby[] }) {
-    const { data, error, isLoading, mutate } = useSWR<Baby[]>('/babies/', fetcher, {
-        ...options,
-        shouldRetryOnError: false,
-        revalidateOnFocus: true,
-        revalidateOnMount: true,
-        keepPreviousData: true,
-    });
-    return {
-        babies: data,
-        isLoading,
-        isError: error,
-        mutate,
-    };
-}
-
-export function useRecords(babyId: string | null) {
-    const { data, error, isLoading, mutate } = useSWR<BabyRecord[]>(
-        babyId ? `/babies/${babyId}/records` : null, 
-        fetcher,
-        { keepPreviousData: true }
-    );
-    return {
-        records: data,
-        isLoading,
-        isError: error,
-        mutate,
-    };
-}

--- a/frontend/hooks/useFamily.ts
+++ b/frontend/hooks/useFamily.ts
@@ -1,0 +1,23 @@
+import useSWR from 'swr';
+import { fetcher } from '@/lib/api';
+import { Family, FamilyMember } from "@/types/family";
+
+export function useFamilySettings() {
+    const { data, error, isLoading, mutate } = useSWR<Family>('/family/', fetcher);
+    return {
+        family: data,
+        isLoading,
+        isError: error,
+        mutate,
+    };
+}
+
+export function useFamilyMembers() {
+    const { data, error, isLoading, mutate } = useSWR<FamilyMember[]>('/family/members', fetcher);
+    return {
+        members: data,
+        isLoading,
+        isError: error,
+        mutate,
+    };
+}

--- a/frontend/hooks/useRecords.ts
+++ b/frontend/hooks/useRecords.ts
@@ -1,0 +1,17 @@
+import useSWR from 'swr';
+import { fetcher } from '@/lib/api';
+import { BabyRecord } from "@/types/record";
+
+export function useRecords(babyId: string | null) {
+    const { data, error, isLoading, mutate } = useSWR<BabyRecord[]>(
+        babyId ? `/babies/${babyId}/records` : null,
+        fetcher,
+        { keepPreviousData: true }
+    );
+    return {
+        records: data,
+        isLoading,
+        isError: error,
+        mutate,
+    };
+}


### PR DESCRIPTION
Tidyエージェントによるリファクタリングを実施しました。

### 変更内容

1.  **授乳定数の共通化 (`frontend/constants/feeding.ts`)**:
    *   `BOTTLE_CONTENT_LABEL` や `COMPLETION_STYLE` などの定数を `feeding-history.tsx` から移動・統合しました。
2.  **オムツ定数の共通化 (`frontend/constants/diaper.ts`)**:
    *   オムツのスタイル定義 (`DIAPER_STYLES`) を `DiaperHistory.tsx` から抽出しました。
3.  **データフックの分割 (`frontend/hooks/`)**:
    *   `useData.ts` に混在していたロジックを以下のファイルに分割しました：
        *   `useBabies.ts`: 赤ちゃん一覧の取得
        *   `useRecords.ts`: 記録一覧の取得
        *   `useFamily.ts`: 家族設定・メンバーの取得
    *   `useData.ts` はこれらのフックへのリエクスポートとして機能するように変更しました。

### 検証

*   `pnpm lint`: 警告のみでエラーなし
*   `pnpm build`: 正常終了
*   `pnpm test`: 全テストパス (111 tests)

既存の機能やUIの振る舞いに変更はありません。

---
*PR created automatically by Jules for task [16657929700402305917](https://jules.google.com/task/16657929700402305917) started by @eburairu*