### PR TITLE
chore: Alembic のヘッドリビジョンをマージ

### DIFF
--- a/alembic/versions/0a21d5589dc8_merge_heads.py
+++ b/alembic/versions/0a21d5589dc8_merge_heads.py
@@ -1,0 +1,28 @@
+"""merge heads
+
+Revision ID: 0a21d5589dc8
+Revises: 01a66095cc44, c3d95298c271
+Create Date: 2026-02-27 12:55:30.996950+09:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0a21d5589dc8'
+down_revision: Union[str, Sequence[str], None] = ('01a66095cc44', 'c3d95298c271')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## 概要
Alembic で複数のヘッドリビジョンが発生していたため、これらをマージするマイグレーションを作成しました。

## 変更内容
- `alembic/versions/0a21d5589dc8_merge_heads.py` を作成し、ヘッド `01a66095cc44` と `c3d95298c271` をマージ
- `verify_all.sh` による全テスト・ビルドの正常動作を確認
