### PR TITLE
feat: クイックアクションのミルク記録に前回の量をデフォルト値として設定

### DIFF
--- a/frontend/components/dashboard/QuickActionBar.tsx
+++ b/frontend/components/dashboard/QuickActionBar.tsx
@@ -31,6 +31,18 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
         return records?.find(r => r.type === 'sleep' && !r.details?.end_time)
     }, [records])
 
+    // 前回のミルク量を取得（デフォルト値として使用）
+    const lastMilkAmount = useMemo(() => {
+        const milkRecord = records?.find(r => {
+            if (r.type !== 'feeding') return false
+            const ft = r.details?.feeding_type
+            if (ft !== 'BOTTLE' && ft !== 'MIXED') return false
+            const amount = Number(r.details?.amount_ml)
+            return amount > 0
+        })
+        return milkRecord ? Number(milkRecord.details?.amount_ml) : null
+    }, [records])
+
     if (!canWrite) return null
 
     const handleQuickRecord = async (type: "feeding_bottle" | "feeding_breast" | "sleep" | "diaper_wet" | "diaper_dirty") => {
@@ -41,6 +53,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                 baby_id: Number(babyId),
                 feeding_type: "BOTTLE",
                 feeding_time: new Date().toISOString(),
+                ...(lastMilkAmount ? { amount_ml: lastMilkAmount } : {}),
             }),
             "feeding_breast": async () => api.post<{ id: number }>("/feedings/", {
                 baby_id: Number(babyId),


### PR DESCRIPTION
## 概要

ダッシュボードのクイックアクション（ハニカムUI）からミルクを記録する際に、前回のミルク量を `amount_ml` のデフォルト値として自動設定するようにしました。

## 変更内容

### `QuickActionBar.tsx`
- `records` から直近のミルク記録（BOTTLE/MIXED で `amount_ml > 0`）を `useMemo` で検索し `lastMilkAmount` として算出
- ミルク記録の POST リクエストに `amount_ml: lastMilkAmount` を含める（前回記録がない場合は省略）

## 背景

従来、クイックアクションからミルクを記録すると `amount_ml` が送信されず、毎回手動で量を入力する必要がありました。授乳記録ページ（`/feeding`）の `FeedingForm` では既に前回量をデフォルトにする仕組みがありましたが、クイックアクションでは未対応でした。

## テスト

- TypeScript 型チェック（`tsc --noEmit`）: ✅ パス
