### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix stack trace leakage on 500 errors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,30 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from app.middleware.security import SecurityHeadersMiddleware
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 import os
+import logging
 from dotenv import load_dotenv
 
 load_dotenv()
 
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 app = FastAPI(title="Botoro API")
+
+# Global Exception Handler
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    logger.error(f"Unhandled exception: {exc}", exc_info=True)
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"},
+    )
 
 # Trigger reload
 

--- a/tests/test_global_exception.py
+++ b/tests/test_global_exception.py
@@ -1,0 +1,34 @@
+from app.dependencies import get_db
+from fastapi.testclient import TestClient
+from app.main import app
+
+def test_unhandled_exception():
+    """
+    Simulate an unhandled exception to verify the global exception handler.
+    """
+    # Define a dependency override that raises an exception
+    def override_get_db_raise():
+        raise Exception("Simulated unexpected error")
+
+    # Apply the override
+    app.dependency_overrides[get_db] = override_get_db_raise
+
+    try:
+        # Initialize TestClient with raise_server_exceptions=False
+        with TestClient(app, raise_server_exceptions=False) as client:
+            # Call an endpoint that uses the get_db dependency
+            response = client.post("/api/auth/login", json={"username": "test", "password": "password"})
+
+            # Check that the status code is 500
+            assert response.status_code == 500
+
+            # Check that the response body is secure (no stack trace or specific error message)
+            data = response.json()
+            assert data == {"detail": "Internal Server Error"}
+
+            # Ensure the sensitive error message is NOT in the response
+            assert "Simulated unexpected error" not in response.text
+
+    finally:
+        # Clean up the override
+        del app.dependency_overrides[get_db]


### PR DESCRIPTION
🚨 深刻度: MEDIUM
💡 脆弱性: 予期せぬサーバーエラー（500）が発生した際、スタックトレースや詳細なエラーメッセージがレスポンスに含まれる可能性がありました。これにより、内部のシステム構成やファイルパスが攻撃者に漏洩するリスクがあります。
🎯 影響: 悪意のある攻撃者がエラーレスポンスを分析し、システム内部の構造を把握することで、さらなる攻撃（例：パストラバーサルやSQLインジェクション）の手がかりを得る可能性があります。
🔧 修正: `app/main.py` に `Exception` に対するグローバルな例外ハンドラを追加しました。このハンドラは、未処理の例外をサーバー側でログ（スタックトレース付き）として記録しつつ、クライアントには汎用的な `{"detail": "Internal Server Error"}` というJSONレスポンスのみを返すようにしました。
✅ 検証: 新規作成したテスト `tests/test_global_exception.py` を実行し、意図的に例外を発生させた際にステータスコード 500 と安全なエラーメッセージが返されることを確認しました。また、既存のバックエンドテストスイートも通過することを確認しました。

---
*PR created automatically by Jules for task [13739896199425235261](https://jules.google.com/task/13739896199425235261) started by @eburairu*