### PR TITLE
✍️ Scribe: 設定画面ヘッダー実装の仕様書同期

### DIFF
--- a/.specify/specs/ui/ui_design_system.md
+++ b/.specify/specs/ui/ui_design_system.md
@@ -702,6 +702,6 @@ export function SettingsHeader({
 
 ### 設定画面
 
-- [ ] `SettingsHeader` コンポーネント新規作成
-- [ ] Profile, Notification, Family, Babies, Permissions 各ページで `SettingsHeader` を適用
-- [ ] 各ページの個別実装ヘッダーを削除
+- [x] `SettingsHeader` コンポーネント新規作成
+- [x] Profile, Notification, Family, Babies, Permissions 各ページで `SettingsHeader` を適用
+- [x] 各ページの個別実装ヘッダーを削除


### PR DESCRIPTION
💡 **何を**: `.specify/specs/ui/ui_design_system.md` の「設定画面」セクションのチェックリストを更新しました。
🔍 **発見**: コードベース（`frontend/components/settings/SettingsHeader.tsx` および各設定ページ）では `SettingsHeader` コンポーネントの実装と適用が完了していましたが、仕様書のチェックリストが未完了 `[ ]` のままでした。
🎯 **影響**: 仕様書と実装の乖離を解消し、デザインシステムの適用状況を正確に反映させました。これにより、開発者は設定画面のヘッダー移行が完了済みであることを仕様書から正しく把握できます。

---
*PR created automatically by Jules for task [15204469202562650614](https://jules.google.com/task/15204469202562650614) started by @eburairu*