### PR TITLE
fix: ウィジェットタップ時の挙動を詳細ページ遷移に差し戻し

### DIFF
--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -6,13 +6,9 @@ import { createWidgetMemoComparison } from "@/lib/memoUtils"
 import { HexagonWidgetCard } from "./HexagonWidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
 import { calculateDiaperStats, NormalizedDiaper, normalizeDiaperFromRecord } from "@/lib/diaperUtils"
-import { useQuickRecord } from "@/hooks/useQuickRecord"
-import { api } from "@/lib/api"
-import { RECORD_TYPES } from "@/types/enums"
+import Link from "next/link"
 
-export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isError, isLoading, size, mutate }: BaseWidgetProps) {
-    const { executeRecord } = useQuickRecord(babyId, { onSuccess: mutate })
-
+export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isError, isLoading, size }: BaseWidgetProps) {
     const { wetCount, dirtyCount, lastElapsed } = useMemo(() => {
         const diaperRecords = records
             ?.map(normalizeDiaperFromRecord)
@@ -20,25 +16,8 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
         return calculateDiaperStats(diaperRecords)
     }, [records])
 
-    const handleQuickWet = async (e: React.MouseEvent) => {
-        // タイル全体のクリックで「おしっこ」を記録
-        e.preventDefault()
-        e.stopPropagation()
-        
-        const action = async () => api.post<{ id: number }>("/diapers/", {
-            baby_id: Number(babyId),
-            diaper_type: "WET",
-            change_time: new Date().toISOString(),
-        })
-
-        await executeRecord(action, { 
-            feedbackType: RECORD_TYPES.DIAPER, 
-            label: "おしっこ" 
-        })
-    }
-
     return (
-        <div onClick={handleQuickWet} className="cursor-pointer">
+        <Link href={`/diaper?baby_id=${babyId}`} className="block">
             <HexagonWidgetCard
                 title="おむつ"
                 icon={<Baby className="w-5 h-5 text-amber-500" />}
@@ -55,6 +34,6 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
                     </div>
                 </div>
             </HexagonWidgetCard>
-        </div>
+        </Link>
     )
 }, createWidgetMemoComparison('diaper'))

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -6,45 +6,18 @@ import { HexagonWidgetCard } from "./HexagonWidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
 import { normalizeFeedingFromRecord, calculateFeedingStats, NormalizedFeeding } from "@/lib/feedingUtils"
 import { Milk } from "lucide-react"
-import { useQuickRecord } from "@/hooks/useQuickRecord"
-import { api } from "@/lib/api"
-import { RECORD_TYPES } from "@/types/enums"
+import Link from "next/link"
 
-export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isError, isLoading, size, mutate }: BaseWidgetProps) {
-    const { executeRecord } = useQuickRecord(babyId, { onSuccess: mutate })
-
-    const { todayCount, lastElapsed, lastFeedingType, lastAmount } = useMemo(() => {
+export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isError, isLoading, size }: BaseWidgetProps) {
+    const { todayCount, lastElapsed } = useMemo(() => {
         const feedingRecords = records
             ?.map(normalizeFeedingFromRecord)
             .filter((f): f is NormalizedFeeding => f !== null) ?? []
-        const stats = calculateFeedingStats(feedingRecords)
-        const last = feedingRecords[0]
-        return {
-            ...stats,
-            lastFeedingType: last?.type || "BOTTLE",
-            lastAmount: last?.amount
-        }
+        return calculateFeedingStats(feedingRecords)
     }, [records])
 
-    const handleQuickFeeding = async (e: React.MouseEvent) => {
-        e.preventDefault()
-        e.stopPropagation()
-
-        const action = async () => api.post<{ id: number }>("/feedings/", {
-            baby_id: Number(babyId),
-            feeding_type: lastFeedingType,
-            feeding_time: new Date().toISOString(),
-            ...(lastFeedingType !== "BREAST" && lastAmount ? { amount_ml: lastAmount } : {}),
-        })
-
-        await executeRecord(action, { 
-            feedbackType: RECORD_TYPES.FEEDING, 
-            label: lastFeedingType === "BOTTLE" ? "ミルク" : lastFeedingType === "BREAST" ? "母乳" : "授乳"
-        })
-    }
-
     return (
-        <div onClick={handleQuickFeeding} className="cursor-pointer">
+        <Link href={`/feeding?baby_id=${babyId}`} className="block">
             <HexagonWidgetCard
                 title="授乳"
                 icon={<Milk className="w-5 h-5 text-rose-500" />}
@@ -58,6 +31,6 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
                     <span className="text-[10px] text-gray-500 dark:text-zinc-500 mt-0.5">今日 {todayCount}回</span>
                 </div>
             </HexagonWidgetCard>
-        </div>
+        </Link>
     )
 }, createWidgetMemoComparison('feeding'))


### PR DESCRIPTION
## 概要
ダッシュボードのハニカムタイルをタップした際の挙動を、クイック記録から詳細ページへの遷移に差し戻しました。

## 変更内容
- **挙動の差し戻し**: `FeedingWidget` および `DiaperWidget` のタイルをクリックした際、それぞれの詳細ページ（`/feeding`, `/diaper`）へ遷移するように修正しました。
- **一貫性の確保**: クイック記録は画面下部の `QuickActionBar` から行う運用に統一し、メインウィジェットは情報の入り口として機能させます。
- **クリーンアップ**: `HoneycombGrid` 内の未使用変数を削除しました。

## 検証結果
- `pnpm build` および `pnpm lint` を実行し、正常に完了することを確認済みです。
