### PR TITLE
fix: 授乳記録の編集時にゲップの有無が保存されないバグを修正

### DIFF
--- a/frontend/components/feeding/feeding-form.tsx
+++ b/frontend/components/feeding/feeding-form.tsx
@@ -134,7 +134,8 @@ export function FeedingForm({ babyId, onAdd, onUpdate, initialData, onSuccess, l
                         values: vals,
                         activeTab,
                         feedingCompletion,
-                        bottleContentType
+                        bottleContentType,
+                        burped
                     }),
                     (payload) => onUpdate(initialData.id, payload)
                 )


### PR DESCRIPTION
## 概要
授乳記録の編集（Update）時に、ゲップの有無（burped）の状態がペイロードに含まれていなかったため、ユーザーの入力が無視されるバグを修正しました。

## 変更内容
- `frontend/components/feeding/feeding-form.tsx` の `onSubmit` 関数内、編集時のコードパスにおいて `buildFeedingPayload` を呼び出す際に `burped` パラメータを追加しました。

## 検証結果
- `sh scripts/verify_all.sh` を実行し、バックエンドテスト、ビルド、Lint が全てパスすることを確認しました。
