### PR TITLE
fix: ダッシュボードウィジェットのダークモード対応を修正

### DIFF
--- a/frontend/components/dashboard/HexagonWidgetCard.tsx
+++ b/frontend/components/dashboard/HexagonWidgetCard.tsx
@@ -38,22 +38,21 @@ export const HexagonWidgetCard = ({
         <div className={cn("relative transition-all duration-300 hover:-translate-y-1", className)}>
             <Hexagon 
                 size={size} 
-                className="bg-white dark:bg-zinc-900 shadow-sm border-0 transition-colors"
+                className="text-white dark:text-zinc-900 shadow-sm border-0 transition-colors"
                 cornerRadius={12}
-                color="white"
                 borderColor="transparent"
                 borderWidth={0}
             >
                 <div className="flex flex-col items-center justify-center text-center p-3 h-full w-full overflow-hidden">
                     {isLoading ? (
                         <div className="flex flex-col items-center gap-2">
-                            <Loader2 className="h-6 w-6 animate-spin text-indigo-500" />
-                            <span className="text-[10px] text-gray-400">読み込み中...</span>
+                            <Loader2 className="h-6 w-6 animate-spin text-indigo-500 dark:text-indigo-400" />
+                            <span className="text-[10px] text-gray-400 dark:text-zinc-500">読み込み中...</span>
                         </div>
                     ) : isError ? (
                         <div className="flex flex-col items-center gap-1">
-                            <ShieldOff className="h-5 w-5 text-rose-400 mb-1" />
-                            <span className="text-[10px] text-rose-500 leading-tight">
+                            <ShieldOff className="h-5 w-5 text-rose-400 dark:text-rose-500 mb-1" />
+                            <span className="text-[10px] text-rose-500 dark:text-rose-400 leading-tight">
                                 {isForbidden ? "閲覧制限中" : "エラーが発生しました"}
                             </span>
                         </div>


### PR DESCRIPTION
## 概要
ダッシュボードのハニカムウィジェット（HexagonWidgetCard）がダークモード時に白く表示される問題を修正しました。

## 変更点
- `HexagonWidgetCard.tsx` において、背景色を `bg-white dark:bg-zinc-900` から `text-white dark:text-zinc-900` に変更し、子コンポーネントの `Hexagon` が `currentColor` を通じて正しい色を受け取れるようにしました。
- `Hexagon` コンポーネントにハードコードされていた `color="white"` プロップを削除しました。
- ウィジェット内の「読み込み中...」および「エラーが発生しました」の状態について、ダークモード用のテキスト色・アイコン色（`dark:text-indigo-400`, `dark:text-rose-400` 等）を追加しました。

## 影響範囲
- ダッシュボード上の全てのウィジェット（授乳、睡眠、おむつ、成長、メモ、日誌）

## 検証結果
- `sh scripts/verify_all.sh` によるバックエンドテスト、型チェック、Lint、ビルドが全て正常に完了することを確認済み。
