### PR TITLE
fix: ウィジェットサイズを160に統一

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -18,7 +18,6 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { DashboardSkeleton } from "@/components/dashboard/DashboardSkeleton"
 import { PullToRefresh } from "@/components/ui/pull-to-refresh"
 import { HoneycombGrid } from "@/components/ui/honeycomb-grid"
-import { useWindowSize } from "@/hooks/useWindowSize"
 import dynamic from "next/dynamic"
 
 const RecentActivityFeed = dynamic(() => import("@/components/dashboard/RecentActivityFeed").then(mod => mod.RecentActivityFeed), {
@@ -29,7 +28,6 @@ const RecentActivityFeed = dynamic(() => import("@/components/dashboard/RecentAc
 export default function DashboardPage() {
     const { babies, isLoading, isError: babiesError, mutate: mutateBabies, selectedBabyId } = useSelectedBaby()
     const { canWrite, isAdmin } = usePermissions()
-    const { width } = useWindowSize()
 
     const { records, isLoading: recordsLoading, isError: recordsError, mutate: mutateRecords } = useRecords(selectedBabyId)
 
@@ -61,8 +59,7 @@ export default function DashboardPage() {
     const born = selectedBaby ? isBorn(selectedBaby.birthday) : true
     const babiesWithStrId = babies.map(b => ({ ...b, id: String(b.id) }))
 
-    // レスポンシブサイズの計算
-    const honeycombSize = (width && width < 640) ? 150 : 170
+    const honeycombSize = 160
 
     return (
         <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 transition-colors pb-24">


### PR DESCRIPTION
## 変更内容

ダッシュボードのウィジェットサイズをレスポンシブ計算（150/170）から固定値160に統一。

- `honeycombSize` の計算ロジックを削除し、`160` に固定
- 不要になった `useWindowSize` の import と `width` 変数を削除
- `HexagonWidgetCard` のデフォルト値（160）と一致し、全レイヤーで統一

## テスト

- ビルド成功確認済み