### PR TITLE
feat: HoneycombGrid に null による空セル（スペーサー）指定を追加

### DIFF
--- a/frontend/components/ui/honeycomb-grid.tsx
+++ b/frontend/components/ui/honeycomb-grid.tsx
@@ -8,7 +8,7 @@ interface HoneycombGridProps {
   size: number        // 1つの六角形の基準サイズ (高さ = cellRadius * 2)
   gap?: number        // 六角形同士の隙間 (cellSpacing)
   className?: string
-  rows?: number[][]   // 各行に何個のアイテムを配置するか [[0,1,2], [3,4], [5,6,7]] のようにインデックスで指定
+  rows?: (number | null)[][]   // 各行のアイテム配置。null は空セル（スペーサー）
 }
 
 /**
@@ -65,7 +65,22 @@ export function HoneycombGrid({
               marginTop: rowIndex === 0 ? 0 : -(hexHeight / 4) + verticalSpacing,
             }}
           >
-            {rowItems.map((childIndex) => {
+            {rowItems.map((childIndex, itemIndex) => {
+              // null は空セル（スペーサー）として幅を確保する
+              if (childIndex === null) {
+                return (
+                  <div
+                    key={`spacer-${rowIndex}-${itemIndex}`}
+                    style={{
+                      width: hexWidth,
+                      height: hexHeight,
+                      marginLeft: gap / 2,
+                      marginRight: gap / 2,
+                    }}
+                  />
+                );
+              }
+
               const child = childrenArray[childIndex];
               if (!child) return null;
 


### PR DESCRIPTION
## 変更内容

`HoneycombGrid` の `rows` プロパティに `null` を指定することで、空セル（スペーサー）を配置できるようにした。

## 使い方

```tsx
<HoneycombGrid
  rows={[[0, 1], [2, null, 3], [4, 5]]}
>
  <FeedingWidget />   {/* 0 */}
  <SleepWidget />     {/* 1 */}
  <DiaperWidget />    {/* 2 */}
  {/* null → 空セル */}
  <NoteWidget />      {/* 3 */}
  <GrowthWidget />    {/* 4 */}
  <DiaryWidget />     {/* 5 */}
</HoneycombGrid>
```

中段を「おむつ・空・メモ」のように配置調整できる。

## 動作

- `null` のセルは六角形と同じサイズの透明 `div` を描画（幅・高さを確保）
- 既存の `number` インデックス指定との完全な後方互換性を維持
- TypeScript 型: `rows?: (number | null)[][]`