### PR TITLE
feat: ダッシュボードのウィジェット配置を変更（上:授乳・おむつ、中:睡眠・空・成長、下:メモ・日誌）

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -82,7 +82,7 @@ export default function DashboardPage() {
                     <HoneycombGrid
                         size={honeycombSize}
                         gap={16}
-                        rows={[[0, 1], [2], [3, 4], [5]]}
+                        rows={[[0, 2], [1, null, 3], [4, 5]]}
                     >
                         <FeedingWidget
                             babyId={effectiveBabyId}


### PR DESCRIPTION
## 変更内容

ダッシュボードのウィジェット配置を変更。

| 段 | 配置 |
|---|---|
| 上段 | 授乳・おむつ |
| 中段 | 睡眠・空・成長 |
| 下段 | メモ・日誌 |

`rows={[[0, 2], [1, null, 3], [4, 5]]}` に変更。