### PR TITLE
feat: ダッシュボードウィジェットのローディングを哺乳瓶アニメーションに変更

### DIFF
--- a/.specify/specs/ui/ui_design_system.md
+++ b/.specify/specs/ui/ui_design_system.md
@@ -310,8 +310,8 @@ interface WidgetQuickButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>
 1.  **カラーバリアント**: `color` プロップ (`rose`, `amber`, `indigo`) により、背景色とテキスト色が自動的に決定される（`HexagonButton` の `variant` に渡される）。
 2.  **アクティブ状態**: `isActive` プロップにより、選択状態（濃い背景色 + 白文字 + グロー効果）のスタイルが適用される。
 3.  **ローディング時の挙動**:
-    - `loading={true}` の場合、ボタン内のコンテンツ（アイコンなど）が自動的にスピナー (`Loader2`) に置き換わる。
-    - ボタンのサイズは `size` プロップによって固定されているため、スピナー表示時もレイアウトシフトは発生しない。
+    - `loading={true}` の場合、ボタン内のコンテンツ（アイコンなど）が自動的に哺乳瓶のアニメーション (`BabyBottleLoading`) に置き換わる。
+    - ボタンのサイズは `size` プロップによって固定されているため、アニメーション表示時もレイアウトシフトは発生しない。
 
 ```tsx
 // 内部実装 (HexagonButton ラッパー)
@@ -368,7 +368,7 @@ export function WidgetQuickButton({
 1. **ボタンの無効化（Disabled）**: APIリクエスト中や状態遷移中は、連打による重複登録を防ぐため、必ず `disabled` 属性を付与する。
 2. **視覚的フィードバック**:
     - **テキスト置換**: 「保存」を「保存中...」のように変更する。
-    - **スピナー表示**: 文字列の代わりに、または文字列の隣に `Loader2`（Lucide React）などのスピナーを `animate-spin` で表示する。
+    - **スピナー表示**: 文字列の代わりに、または文字列の隣に `Loader2`（Lucide React）などのスピナーを `animate-spin` で表示する。ダッシュボードのウィジェットやクイックアクションボタンなどの「育児」に関連する主要なローディング表示には、`BabyBottleLoading`（哺乳瓶のアニメーション）を優先的に使用する。
     - **透明度**: `disabled` 時のスタイルとして `opacity-50` 等を適用し、クリック不可であることを示す（shadcn/ui のデフォルト挙動を推奨）。
 
 ---

--- a/frontend/components/dashboard/HexagonWidgetCard.tsx
+++ b/frontend/components/dashboard/HexagonWidgetCard.tsx
@@ -3,7 +3,8 @@
 import React from "react"
 import { Hexagon } from "@/components/ui/hexagon"
 import { cn } from "@/lib/utils"
-import { ShieldOff, Loader2 } from "lucide-react"
+import { ShieldOff } from "lucide-react"
+import { BabyBottleLoading } from "@/components/ui/baby-bottle-loading"
 
 interface ErrorWithStatus {
     status?: number;
@@ -45,7 +46,7 @@ export const HexagonWidgetCard = ({
                 <div className="flex flex-col items-center justify-center text-center p-3 h-full w-full overflow-hidden">
                     {isLoading ? (
                         <div className="flex flex-col items-center gap-2">
-                            <Loader2 className="h-6 w-6 animate-spin text-indigo-500 dark:text-indigo-400" />
+                            <BabyBottleLoading className="w-8 h-8 text-indigo-500 dark:text-indigo-400" />
                             <span className="text-[10px] text-gray-400 dark:text-zinc-500">読み込み中...</span>
                         </div>
                     ) : isError ? (

--- a/frontend/components/ui/hexagon-button.tsx
+++ b/frontend/components/ui/hexagon-button.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Hexagon, HEX_CONSTANTS } from "./hexagon"
 import { cn } from "@/lib/utils"
-import { Loader2 } from "lucide-react"
+import { BabyBottleLoading } from "./baby-bottle-loading"
 import { HEXAGON_BUTTON_THEMES } from "@/constants/ui-colors"
 
 /**
@@ -79,7 +79,7 @@ export function HexagonButton({
             </div>
             {loading && (
               <div className="absolute inset-0 flex items-center justify-center">
-                <Loader2 className="h-5 w-5 animate-spin" />
+                <BabyBottleLoading className="h-6 w-6" />
               </div>
             )}
           </div>


### PR DESCRIPTION
## 概要
ダッシュボードのウィジェット（授乳、睡眠、おむつ、成長、メモ、日誌）およびクイックアクションボタンのローディング表示を、既存の「最近の記録」と同様の哺乳瓶アニメーション（`BabyBottleLoading`）に変更しました。

## 変更内容
- `HexagonWidgetCard.tsx`: `Loader2` (spin) を `BabyBottleLoading` に変更。サイズを `w-8 h-8` に、カラーを `text-indigo-500 dark:text-indigo-400` に設定。
- `hexagon-button.tsx`: `Loader2` (spin) を `BabyBottleLoading` に変更。サイズを `h-6 w-6` に設定。
- `.specify/specs/ui/ui_design_system.md`: ダッシュボードの主要なローディング表示に哺乳瓶アニメーションを使用する旨を仕様として追記。

## 確認事項
- [x] `sh scripts/verify_all.sh` が正常終了することを確認
- [x] 既存の `RecentActivityFeed.tsx` のローディング表示と視覚的に整合していることを確認
