### PR TITLE
fix: ダッシュボードウィジェットの再描画判定にサイズを追加し、スケルトンのレイアウトを統一

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -23,7 +23,7 @@ import { DASHBOARD_UI } from "@/constants/dashboard"
 import dynamic from "next/dynamic"
 
 const RecentActivityFeed = dynamic(() => import("@/components/dashboard/RecentActivityFeed").then(mod => mod.RecentActivityFeed), {
-    loading: () => <Skeleton className="h-32 w-full rounded-2xl" />,
+    loading: () => <Skeleton className="h-64 w-full rounded-2xl" />,
     ssr: false
 })
 
@@ -57,9 +57,15 @@ export default function DashboardPage() {
         return <OnboardingForm isAdmin={!!isAdmin} onSuccess={mutateBabies} />
     }
 
-    const effectiveBabyId = selectedBabyId || String(babies[0].id)
-    const selectedBaby = babies.find(b => String(b.id) === effectiveBabyId)
-    const born = selectedBaby ? isBorn(selectedBaby.birthday) : true
+    const effectiveBabyId = selectedBabyId || (babies.length > 0 ? String(babies[0].id) : null)
+    const selectedBaby = babies.find(b => String(b.id) === effectiveBabyId) || babies[0]
+    const actualBabyId = selectedBaby ? String(selectedBaby.id) : null
+
+    if (!selectedBaby || !actualBabyId) {
+        return <OnboardingForm isAdmin={!!isAdmin} onSuccess={mutateBabies} />
+    }
+
+    const born = isBorn(selectedBaby.birthday)
     const honeycombSize = (width && width < 640) 
         ? DASHBOARD_UI.WIDGET_SIZE.MOBILE 
         : DASHBOARD_UI.WIDGET_SIZE.DESKTOP
@@ -70,7 +76,7 @@ export default function DashboardPage() {
                 <main className="px-4 py-6 max-w-2xl mx-auto space-y-6">
                     {!born && canWrite && selectedBaby && (
                         <BirthRegistrationDialog
-                            babyId={effectiveBabyId}
+                            babyId={actualBabyId}
                             babyName={selectedBaby.name}
                             onSuccess={mutateBabies}
                         />
@@ -82,7 +88,7 @@ export default function DashboardPage() {
                         rows={DASHBOARD_UI.WIDGET_ROWS}
                     >
                         <FeedingWidget
-                            babyId={effectiveBabyId}
+                            babyId={actualBabyId}
                             records={records}
                             isLoading={recordsLoading}
                             isError={recordsError}
@@ -90,7 +96,7 @@ export default function DashboardPage() {
                             size={honeycombSize}
                         />
                         <SleepWidget
-                            babyId={effectiveBabyId}
+                            babyId={actualBabyId}
                             records={records}
                             isLoading={recordsLoading}
                             isError={recordsError}
@@ -98,7 +104,7 @@ export default function DashboardPage() {
                             size={honeycombSize}
                         />
                         <DiaperWidget
-                            babyId={effectiveBabyId}
+                            babyId={actualBabyId}
                             records={records}
                             isLoading={recordsLoading}
                             isError={recordsError}
@@ -106,33 +112,31 @@ export default function DashboardPage() {
                             size={honeycombSize}
                         />
                         <GrowthWidget
-                            babyId={effectiveBabyId}
+                            babyId={actualBabyId}
                             records={records}
                             isLoading={recordsLoading}
                             isError={recordsError}
                             size={honeycombSize}
                         />
                         <NoteWidget
-                            babyId={effectiveBabyId}
+                            babyId={actualBabyId}
                             records={records}
                             isLoading={recordsLoading}
                             isError={recordsError}
                             size={honeycombSize}
                         />
                         <DiaryWidget
-                            babyId={effectiveBabyId}
+                            babyId={actualBabyId}
                             size={honeycombSize}
                         />
-                        {selectedBaby && (
-                            <BabyWidget
-                                baby={selectedBaby}
-                                size={honeycombSize}
-                            />
-                        )}
+                        <BabyWidget
+                            baby={selectedBaby}
+                            size={honeycombSize}
+                        />
                     </HoneycombGrid>
 
                     <RecentActivityFeed
-                        babyId={effectiveBabyId}
+                        babyId={actualBabyId}
                         records={records}
                         isLoading={recordsLoading}
                         mutate={handleMutateRecords}
@@ -142,7 +146,7 @@ export default function DashboardPage() {
 
             {born && (
                 <QuickActionBar
-                    babyId={effectiveBabyId}
+                    babyId={actualBabyId}
                     mutateRecords={handleMutateRecords}
                     records={records}
                 />

--- a/frontend/components/dashboard/DashboardSkeleton.tsx
+++ b/frontend/components/dashboard/DashboardSkeleton.tsx
@@ -11,24 +11,29 @@ export function DashboardSkeleton() {
         : DASHBOARD_UI.WIDGET_SIZE.DESKTOP
 
     return (
-        <main className="px-4 py-6 max-w-2xl mx-auto space-y-6">
-            {/* ハニカムウィジェットグリッドスケルトン */}
-            <HoneycombGrid
-                size={honeycombSize}
-                gap={DASHBOARD_UI.WIDGET_GAP}
-                rows={DASHBOARD_UI.WIDGET_ROWS}
-            >
-                {[...Array(7)].map((_, i) => (
-                    <HexagonWidgetCard
-                        key={i}
-                        isSkeleton
-                        size={honeycombSize}
-                    />
-                ))}
-            </HoneycombGrid>
-            
-            {/* アクティビティフィード */}
-            <Skeleton className="h-64 w-full rounded-2xl" />
-        </main>
+        <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 transition-colors pb-24">
+            <main className="px-4 py-6 max-w-2xl mx-auto space-y-6">
+                {/* ハニカムウィジェットグリッドスケルトン */}
+                <HoneycombGrid
+                    size={honeycombSize}
+                    gap={DASHBOARD_UI.WIDGET_GAP}
+                    rows={DASHBOARD_UI.WIDGET_ROWS}
+                >
+                    {[...Array(7)].map((_, i) => (
+                        <HexagonWidgetCard
+                            key={i}
+                            isSkeleton
+                            size={honeycombSize}
+                        />
+                    ))}
+                </HoneycombGrid>
+                
+                {/* アクティビティフィードのスケルトン */}
+                <div className="space-y-4">
+                    <Skeleton className="h-8 w-32" />
+                    <Skeleton className="h-64 w-full rounded-2xl" />
+                </div>
+            </main>
+        </div>
     )
 }

--- a/frontend/lib/memoUtils.ts
+++ b/frontend/lib/memoUtils.ts
@@ -38,7 +38,7 @@ export function areRecordsEqual(prevRecords: BabyRecord[] | undefined, nextRecor
 
 /**
  * Creates a comparison function for React.memo optimized for Dashboard Widgets.
- * Checks common props (isLoading, isError, babyId, mutate) and uses areRecordsEqual for records.
+ * Checks common props (isLoading, isError, babyId, mutate, size) and uses areRecordsEqual for records.
  */
 export function createWidgetMemoComparison(recordType: string) {
     return (prev: BaseWidgetProps, next: BaseWidgetProps) => {
@@ -46,6 +46,7 @@ export function createWidgetMemoComparison(recordType: string) {
         if (prev.isError !== next.isError) return false
         if (prev.babyId !== next.babyId) return false
         if (prev.mutate !== next.mutate) return false
+        if (prev.size !== next.size) return false
         return areRecordsEqual(prev.records, next.records, recordType)
     }
 }


### PR DESCRIPTION
## 概要
ダッシュボードウィジェットがローディング中やモバイル表示で大きさが不揃いになる問題を修正しました。

## 変更内容
- **memoUtils.ts**: `createWidgetMemoComparison` に `size` プロパティの比較を追加
  - 画面サイズ変更（160px ↔ 140px）が正しく検知され、ウィジェットが再描画されるようにしました。
- **DashboardSkeleton.tsx**: スケルトンの外側コンテナを `DashboardPage` と同じ構造に修正
  - 背景色やパディングを統一し、読み込み完了時のレイアウトシフトを抑制しました。
- **Dashboard/page.tsx**: 赤ちゃん選択ロジックを強化
  - 選択中の赤ちゃん ID が無効な場合でもフォールバックするようにし、ハニカムグリッドの配置安定性を向上させました。
  - アクティビティフィードのスケルトン高さを `h-64` に統一しました。

## 確認事項
- [x] `sh scripts/verify_all.sh` がパスすることを確認
- [x] ウィジェットのサイズが画面幅に応じて正しく切り替わることを確認
- [x] スケルトン表示から実データ表示への遷移がスムーズであることを確認

Closes #
