### PR TITLE
refactor: 全体で統一して使用するアイコンの定義（AppIcons）を追加

### DIFF
--- a/frontend/app/(dashboard)/contraction/page.tsx
+++ b/frontend/app/(dashboard)/contraction/page.tsx
@@ -1,17 +1,17 @@
 "use client"
+import { AppIcons } from "@/constants/icons"
 
 import { useContractions } from "@/hooks/useData"
 import { useRecordPage } from "@/hooks/useRecordPage"
 import {
-    ContractionTimer,
     ContractionStats,
+    ContractionTimer,
     ContractionHistory,
     ContractionWaveGraph
 } from "@/components/contraction"
 import type { ContractionRecord } from "@/types/contraction"
 import { TipsCard } from "@/components/ui/tips-card"
 import { contractionTips } from "@/lib/tips-data"
-import { Timer } from "lucide-react"
 import { RecordPageLayout } from "@/components/ui/record-page-layout"
 
 /**
@@ -41,7 +41,7 @@ export default function ContractionPage() {
         return (
             <RecordPageLayout
                 title="陣痛タイマー"
-                icon={Timer}
+                icon={AppIcons.contraction}
                 iconColorClass="text-red-500 dark:text-red-400"
                 isLoading={babiesLoading}
                 isDataLoading={contractionsLoading}

--- a/frontend/app/(dashboard)/diaper/page.tsx
+++ b/frontend/app/(dashboard)/diaper/page.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { AppIcons } from "@/constants/icons"
 
 import { useDiapers } from "@/hooks/useData"
 import { useRecordPage } from "@/hooks/useRecordPage"
@@ -7,7 +8,6 @@ import { DiaperForm } from "@/components/diaper/DiaperForm"
 import { DiaperHistory } from "@/components/diaper/DiaperHistory"
 import { TipsCard } from "@/components/ui/tips-card"
 import { diaperTips } from "@/lib/tips-data"
-import { Smile } from "lucide-react"
 import { RecordPageLayout } from "@/components/ui/record-page-layout"
 
 /**
@@ -31,7 +31,7 @@ export default function DiaperPage() {
     return (
         <RecordPageLayout
             title="おむつ記録"
-            icon={Smile}
+            icon={AppIcons.diaper}
             iconColorClass="text-amber-500 dark:text-amber-400"
             isLoading={babiesLoading}
             isDataLoading={diapersLoading}

--- a/frontend/app/(dashboard)/diary/page.tsx
+++ b/frontend/app/(dashboard)/diary/page.tsx
@@ -1,7 +1,8 @@
 "use client"
+import { AppIcons } from "@/constants/icons"
 
 import { useState } from "react"
-import { BookOpen, Loader2, CalendarDays } from "lucide-react"
+import { Loader2, CalendarDays } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -121,7 +122,7 @@ export default function DiaryPage() {
     return (
         <RecordPageLayout
             title="育児日誌"
-            icon={BookOpen}
+            icon={AppIcons.diary}
             iconColorClass="text-amber-500 dark:text-amber-400"
             isLoading={babiesLoading}
             isDataLoading={summariesLoading}
@@ -172,7 +173,7 @@ export default function DiaryPage() {
             {/* 日誌一覧 */}
             {!summaries || summaries.length === 0 ? (
                 <div className="text-center text-gray-400 dark:text-zinc-500 py-12">
-                    <BookOpen className="h-10 w-10 mx-auto mb-3 opacity-40" />
+                    <AppIcons.diary className="h-10 w-10 mx-auto mb-3 opacity-40" />
                     <p className="text-sm">まだ育児日誌がありません。</p>
                     <p className="text-xs mt-1">育児記録がある日の日付を選んで「生成」を押してください。</p>
                 </div>

--- a/frontend/app/(dashboard)/feeding/page.tsx
+++ b/frontend/app/(dashboard)/feeding/page.tsx
@@ -1,6 +1,6 @@
 "use client"
+import { AppIcons } from "@/constants/icons"
 
-import { Baby as BabyIcon } from "lucide-react"
 
 import { useFeeding } from "@/hooks/useFeeding"
 import { useRecordPage } from "@/hooks/useRecordPage"
@@ -49,7 +49,7 @@ export default function FeedingPage() {
     return (
         <RecordPageLayout
             title="授乳記録"
-            icon={BabyIcon}
+            icon={AppIcons.feeding}
             iconColorClass="text-rose-500 dark:text-rose-400"
             isLoading={babiesLoading}
             isDataLoading={feedingsLoading}

--- a/frontend/app/(dashboard)/growth/page.tsx
+++ b/frontend/app/(dashboard)/growth/page.tsx
@@ -1,10 +1,11 @@
 "use client"
+import { AppIcons } from "@/constants/icons"
 
 import { useState } from "react"
 import { useGrowths } from "@/hooks/useData"
 import { useRecordPage } from "@/hooks/useRecordPage"
 import { Button } from "@/components/ui/button"
-import { Plus, Ruler } from "lucide-react"
+import { Plus } from "lucide-react"
 import { GrowthChart } from "@/components/growth/GrowthChart"
 import { GrowthHistoryList } from "@/components/growth/GrowthHistoryList"
 import { GrowthRecordForm } from "@/components/growth/GrowthRecordForm"
@@ -51,7 +52,7 @@ export default function GrowthPage() {
     return (
         <RecordPageLayout
             title="成長記録"
-            icon={Ruler}
+            icon={AppIcons.growth}
             iconColorClass="text-emerald-500 dark:text-emerald-400"
             isLoading={babiesLoading}
             isDataLoading={growthsLoading}

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -11,7 +11,8 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Check, ChevronDown, ChevronLeft, Settings, Menu, Home, Milk, Moon, Baby, Ruler, StickyNote, BookOpen, Timer, Syringe, Trophy } from "lucide-react"
+import { Check, ChevronDown, ChevronLeft, Settings, Menu, Home, Baby } from "lucide-react"
+import { AppIcons } from "@/constants/icons"
 import { useSelectedBaby } from "@/hooks/useSelectedBaby"
 import { cn, getDisplayName } from "@/lib/utils"
 import { isBorn } from "@/lib/babyUtils"
@@ -39,15 +40,15 @@ const ALL_NAV_ITEMS: {
     postnatal: boolean
 }[] = [
     { label: "ホーム",       href: "/dashboard",   Icon: Home,       color: "text-pink-500",    prenatal: true,  postnatal: true  },
-    { label: "授乳",         href: "/feeding",     Icon: Milk,       color: "text-pink-500",    prenatal: false, postnatal: true  },
-    { label: "睡眠",         href: "/sleep",       Icon: Moon,       color: "text-violet-500",  prenatal: false, postnatal: true  },
-    { label: "おむつ",       href: "/diaper",      Icon: Baby,       color: "text-amber-500",   prenatal: false, postnatal: true  },
-    { label: "成長",         href: "/growth",      Icon: Ruler,      color: "text-emerald-500", prenatal: false, postnatal: true  },
-    { label: "予防接種",     href: "/vaccinations",Icon: Syringe,    color: "text-sky-500",     prenatal: false, postnatal: true  },
-    { label: "発育発達マイルストーン",href: "/milestones",  Icon: Trophy,     color: "text-yellow-500",  prenatal: false, postnatal: true  },
-    { label: "メモ",         href: "/note",        Icon: StickyNote, color: "text-orange-400",  prenatal: false, postnatal: true  },
-    { label: "日誌",         href: "/diary",       Icon: BookOpen,   color: "text-indigo-400",  prenatal: false, postnatal: true  },
-    { label: "陣痛タイマー", href: "/contraction", Icon: Timer,      color: "text-red-500",     prenatal: true,  postnatal: false },
+    { label: "授乳",         href: "/feeding",     Icon: AppIcons.feeding,       color: "text-pink-500",    prenatal: false, postnatal: true  },
+    { label: "睡眠",         href: "/sleep",       Icon: AppIcons.sleep,       color: "text-violet-500",  prenatal: false, postnatal: true  },
+    { label: "おむつ",       href: "/diaper",      Icon: AppIcons.diaper,       color: "text-amber-500",   prenatal: false, postnatal: true  },
+    { label: "成長",         href: "/growth",      Icon: AppIcons.growth,      color: "text-emerald-500", prenatal: false, postnatal: true  },
+    { label: "予防接種",     href: "/vaccinations",Icon: AppIcons.vaccination,    color: "text-sky-500",     prenatal: false, postnatal: true  },
+    { label: "発育発達マイルストーン",href: "/milestones",  Icon: AppIcons.milestone,     color: "text-yellow-500",  prenatal: false, postnatal: true  },
+    { label: "メモ",         href: "/note",        Icon: AppIcons.note, color: "text-orange-400",  prenatal: false, postnatal: true  },
+    { label: "日誌",         href: "/diary",       Icon: AppIcons.diary,   color: "text-indigo-400",  prenatal: false, postnatal: true  },
+    { label: "陣痛タイマー", href: "/contraction", Icon: AppIcons.contraction,      color: "text-red-500",     prenatal: true,  postnatal: false },
 ]
 
 const BOTTOM_NAV_ITEMS: {
@@ -57,10 +58,10 @@ const BOTTOM_NAV_ITEMS: {
     color: string
 }[] = [
     { label: "ホーム",   href: "/dashboard", Icon: Home,       color: "text-pink-500" },
-    { label: "授乳",     href: "/feeding",   Icon: Milk,       color: "text-pink-500" },
-    { label: "睡眠",     href: "/sleep",     Icon: Moon,       color: "text-violet-500" },
-    { label: "おむつ",   href: "/diaper",    Icon: Baby,       color: "text-amber-500" },
-    { label: "成長",     href: "/growth",    Icon: Ruler,      color: "text-emerald-500" },
+    { label: "授乳",     href: "/feeding",   Icon: AppIcons.feeding,       color: "text-pink-500" },
+    { label: "睡眠",     href: "/sleep",     Icon: AppIcons.sleep,       color: "text-violet-500" },
+    { label: "おむつ",   href: "/diaper",    Icon: AppIcons.diaper,       color: "text-amber-500" },
+    { label: "成長",     href: "/growth",    Icon: AppIcons.growth,      color: "text-emerald-500" },
 ]
 
 export default function DashboardLayout({

--- a/frontend/app/(dashboard)/milestones/page.tsx
+++ b/frontend/app/(dashboard)/milestones/page.tsx
@@ -1,9 +1,10 @@
 "use client"
+import { AppIcons } from "@/constants/icons"
 
 import { useMilestoneTimeline } from "@/hooks/useData"
 import { useRecordPage } from "@/hooks/useRecordPage"
 import { Button } from "@/components/ui/button"
-import { Plus, Trophy, Image as ImageIcon, Calendar, ChevronRight } from "lucide-react"
+import { Plus, Image as ImageIcon, Calendar, ChevronRight } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { RecordPageLayout } from "@/components/ui/record-page-layout"
 import { format } from "date-fns"
@@ -36,7 +37,7 @@ export default function MilestonesPage() {
     return (
         <RecordPageLayout
             title="発育発達マイルストーン"
-            icon={Trophy}
+            icon={AppIcons.milestone}
             iconColorClass="text-amber-500 dark:text-amber-400"
             isLoading={babiesLoading}
             isDataLoading={milestonesLoading}

--- a/frontend/app/(dashboard)/note/page.tsx
+++ b/frontend/app/(dashboard)/note/page.tsx
@@ -1,6 +1,6 @@
 "use client"
+import { AppIcons } from "@/constants/icons"
 
-import { StickyNote } from "lucide-react"
 
 import { useNotes } from "@/hooks/useNotes"
 import { useRecordPage } from "@/hooks/useRecordPage"
@@ -38,7 +38,7 @@ export default function NotePage() {
     return (
         <RecordPageLayout
             title="メモ一覧"
-            icon={StickyNote}
+            icon={AppIcons.note}
             iconColorClass="text-amber-500 dark:text-amber-400"
             isLoading={babiesLoading}
             isDataLoading={notesLoading}

--- a/frontend/app/(dashboard)/sleep/page.tsx
+++ b/frontend/app/(dashboard)/sleep/page.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { AppIcons } from "@/constants/icons"
 
 import { useSleeps } from "@/hooks/useData"
 import { useRecordPage } from "@/hooks/useRecordPage"
@@ -8,7 +9,6 @@ import { SleepHistory } from "@/components/sleep/sleep-history"
 import { SleepCreateDialog } from "@/components/sleep/SleepCreateDialog"
 import { TipsCard } from "@/components/ui/tips-card"
 import { sleepTips } from "@/lib/tips-data"
-import { Moon as MoonIcon } from "lucide-react"
 import { RecordPageLayout } from "@/components/ui/record-page-layout"
 
 /**
@@ -31,7 +31,7 @@ export default function SleepPage() {
     return (
         <RecordPageLayout
             title="睡眠記録"
-            icon={MoonIcon}
+            icon={AppIcons.sleep}
             iconColorClass="text-indigo-500 dark:text-indigo-400"
             isLoading={babiesLoading}
             isDataLoading={sleepsLoading}

--- a/frontend/app/(dashboard)/vaccinations/page.tsx
+++ b/frontend/app/(dashboard)/vaccinations/page.tsx
@@ -1,10 +1,11 @@
 "use client"
+import { AppIcons } from "@/constants/icons"
 
 import { useState } from "react"
 import { useVaccinations } from "@/hooks/useData"
 import { useRecordPage } from "@/hooks/useRecordPage"
 import { Button } from "@/components/ui/button"
-import { Plus, Syringe, RefreshCcw, CheckCircle2, Clock, AlertCircle } from "lucide-react"
+import { Plus, RefreshCcw, CheckCircle2, Clock, AlertCircle } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { RecordPageLayout } from "@/components/ui/record-page-layout"
 import { format } from "date-fns"
@@ -71,7 +72,7 @@ export default function VaccinationsPage() {
     return (
         <RecordPageLayout
             title="予防接種"
-            icon={Syringe}
+            icon={AppIcons.vaccination}
             iconColorClass="text-blue-500 dark:text-blue-400"
             isLoading={babiesLoading}
             isDataLoading={vaxLoading}

--- a/frontend/components/dashboard/QuickActionBar.tsx
+++ b/frontend/components/dashboard/QuickActionBar.tsx
@@ -6,7 +6,8 @@ import { useRouter } from "next/navigation"
 import { api } from "@/lib/api"
 import { useQuickRecord } from "@/hooks/useQuickRecord"
 import { BabyRecord } from "@/types/record"
-import { Moon, Bed, StickyNote, Milk, Baby, Biohazard, HandHeart, Ruler, BookOpen } from "lucide-react"
+import { AppIcons } from "@/constants/icons"
+import { StickyNote } from "lucide-react" // keep StickyNote for dialog title
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { NoteForm } from "@/components/note/NoteForm"
 import { HexagonButton } from "@/components/ui/hexagon-button"
@@ -116,7 +117,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     {/* 上段: ミルク */}
                     <HexagonButton
                         variant="rose"
-                        icon={<Milk className="h-5 w-5" />}
+                        icon={<AppIcons.feedingBottle className="h-5 w-5" />}
                         size={BUTTON_SIZE}
                         onClick={() => handleQuickRecord("feeding_bottle")}
                         loading={loadingAction === "feeding_bottle"}
@@ -126,7 +127,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     {/* 上段: 睡眠（中央・メイン） */}
                     <HexagonButton
                         variant="indigo"
-                        icon={activeSleep ? <Bed className="h-6 w-6" /> : <Moon className="h-6 w-6" />}
+                        icon={activeSleep ? <AppIcons.sleepActive className="h-6 w-6" /> : <AppIcons.sleep className="h-6 w-6" />}
                         size={BUTTON_SIZE}
                         active={!!activeSleep}
                         onClick={() => handleQuickRecord("sleep")}
@@ -137,7 +138,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     {/* 上段: 母乳 */}
                     <HexagonButton
                         variant="rose"
-                        icon={<HandHeart className="h-5 w-5" />}
+                        icon={<AppIcons.feedingBreast className="h-5 w-5" />}
                         size={BUTTON_SIZE}
                         onClick={() => handleQuickRecord("feeding_breast")}
                         loading={loadingAction === "feeding_breast"}
@@ -147,7 +148,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     {/* 中段: おしっこ */}
                     <HexagonButton
                         variant="amber"
-                        icon={<Baby className="h-5 w-5" />}
+                        icon={<AppIcons.diaperWet className="h-5 w-5" />}
                         size={BUTTON_SIZE}
                         onClick={() => handleQuickRecord("diaper_wet")}
                         loading={loadingAction === "diaper_wet"}
@@ -157,7 +158,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     {/* 中段: うんち */}
                     <HexagonButton
                         variant="amber"
-                        icon={<Biohazard className="h-5 w-5" />}
+                        icon={<AppIcons.diaperDirty className="h-5 w-5" />}
                         size={BUTTON_SIZE}
                         onClick={() => handleQuickRecord("diaper_dirty")}
                         loading={loadingAction === "diaper_dirty"}
@@ -167,7 +168,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     {/* 下段: メモ */}
                     <HexagonButton
                         variant="amber"
-                        icon={<StickyNote className="h-5 w-5" />}
+                        icon={<AppIcons.note className="h-5 w-5" />}
                         size={BUTTON_SIZE}
                         onClick={() => setNoteDialogOpen(true)}
                         disabled={isLoading}
@@ -176,7 +177,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     {/* 下段: 成長 */}
                     <HexagonButton
                         variant="emerald"
-                        icon={<Ruler className="h-5 w-5" />}
+                        icon={<AppIcons.growth className="h-5 w-5" />}
                         size={BUTTON_SIZE}
                         onClick={() => router.push(`/growth`)}
                         disabled={isLoading}
@@ -185,7 +186,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     {/* 下段: 日誌 */}
                     <HexagonButton
                         variant="zinc"
-                        icon={<BookOpen className="h-5 w-5" />}
+                        icon={<AppIcons.diary className="h-5 w-5" />}
                         size={BUTTON_SIZE}
                         onClick={() => router.push(`/diary`)}
                         disabled={isLoading}

--- a/frontend/components/diaper/DiaperIcon.tsx
+++ b/frontend/components/diaper/DiaperIcon.tsx
@@ -1,4 +1,4 @@
-import { Droplets, Biohazard } from "lucide-react"
+import { AppIcons } from "@/constants/icons"
 import { DiaperType } from "@/types/diaper"
 
 interface DiaperIconProps {
@@ -8,11 +8,11 @@ interface DiaperIconProps {
 export function DiaperIcon({ type }: DiaperIconProps) {
     switch (type) {
         case DiaperType.WET:
-            return <Droplets className="w-6 h-6" />;
+            return <AppIcons.diaperWet className="w-6 h-6" />;
         case DiaperType.DIRTY:
-            return <Biohazard className="w-6 h-6" />;
+            return <AppIcons.diaperDirty className="w-6 h-6" />;
         case DiaperType.BOTH:
-            return <span className="flex gap-0.5"><Droplets className="w-6 h-6" /><Biohazard className="w-6 h-6" /></span>;
+            return <span className="flex gap-0.5"><AppIcons.diaperWet className="w-6 h-6" /><AppIcons.diaperDirty className="w-6 h-6" /></span>;
         default:
             return <span>?</span>;
     }

--- a/frontend/components/feeding/FeedingIcon.tsx
+++ b/frontend/components/feeding/FeedingIcon.tsx
@@ -1,4 +1,4 @@
-import { Milk, Baby } from "lucide-react"
+import { AppIcons } from "@/constants/icons"
 import { FeedingType } from "@/types/feeding"
 
 interface FeedingIconProps {
@@ -15,7 +15,7 @@ export function FeedingIcon({ type, className }: FeedingIconProps) {
 
     return (
         <div className={`${baseClasses} ${colorClasses} ${className || ''}`}>
-            {isBreast ? <Baby className="w-5 h-5" /> : <Milk className="w-5 h-5" />}
+            {isBreast ? <AppIcons.feedingBreast className="w-5 h-5" /> : <AppIcons.feedingBottle className="w-5 h-5" />}
         </div>
     );
 }

--- a/frontend/components/records/RecordIcon.tsx
+++ b/frontend/components/records/RecordIcon.tsx
@@ -1,4 +1,4 @@
-import { Milk, Moon, Baby, StickyNote, Ruler } from "lucide-react";
+import { AppIcons } from "@/constants/icons";
 import { cn } from "@/lib/utils";
 
 export type RecordType = 'feeding' | 'sleep' | 'diaper' | 'note' | 'growth';
@@ -16,16 +16,8 @@ const styles: Record<RecordType, string> = {
   growth: "bg-green-100 dark:bg-green-950/40 text-green-500 dark:text-green-400",
 };
 
-const icons = {
-  feeding: Milk,
-  sleep: Moon,
-  diaper: Baby,
-  note: StickyNote,
-  growth: Ruler,
-};
-
 export function RecordIcon({ type, className }: RecordIconProps) {
-  const Icon = icons[type];
+  const Icon = AppIcons[type];
   const style = styles[type];
 
   if (!Icon) return null;

--- a/frontend/constants/icons.ts
+++ b/frontend/constants/icons.ts
@@ -1,0 +1,60 @@
+import {
+  Milk,
+  Moon,
+  Baby,
+  Ruler,
+  StickyNote,
+  Zap,
+  Timer,
+  BookOpen,
+  Syringe,
+  Trophy,
+  Smile,
+  Droplets,
+  Biohazard,
+  HandHeart,
+  Bed,
+  type LucideIcon
+} from "lucide-react";
+import { RECORD_TYPES } from "@/types/enums";
+
+/**
+ * アプリケーション全体で統一して使用するアイコンの定義
+ * 
+ * 異なる箇所で異なるアイコンが使われるのを防ぐため、
+ * 機能やレコード種類に対応するアイコンはすべてここで定義し、インポートして使用する。
+ */
+export const AppIcons = {
+  // レコード・機能ごとのメインアイコン
+  feeding: Milk,           // 授乳
+  sleep: Moon,             // 睡眠
+  diaper: Smile,           // おむつ (実際の赤ちゃんと区別するためSmileを採用)
+  growth: Ruler,           // 成長
+  note: StickyNote,        // メモ
+  contraction: Timer,      // 陣痛
+  diary: BookOpen,         // 日誌
+  vaccination: Syringe,    // 予防接種
+  milestone: Trophy,       // マイルストーン
+  
+  // 状態やサブアクションのアイコン
+  baby: Baby,              // 赤ちゃん（プロフィール等）
+  sleepActive: Bed,        // 睡眠中
+  feedingBreast: HandHeart,// 母乳
+  feedingBottle: Milk,     // ミルク
+  diaperWet: Droplets,     // おしっこ
+  diaperDirty: Biohazard,  // うんち
+} as const;
+
+export type AppIconType = keyof typeof AppIcons;
+
+/**
+ * レコードタイプとアイコンの直接マッピング
+ */
+export const RECORD_TYPE_ICONS: Record<string, LucideIcon> = {
+  [RECORD_TYPES.FEEDING]: AppIcons.feeding,
+  [RECORD_TYPES.SLEEP]: AppIcons.sleep,
+  [RECORD_TYPES.DIAPER]: AppIcons.diaper,
+  [RECORD_TYPES.GROWTH]: AppIcons.growth,
+  [RECORD_TYPES.NOTE]: AppIcons.note,
+  [RECORD_TYPES.CONTRACTION]: AppIcons.contraction,
+};

--- a/frontend/constants/ui.ts
+++ b/frontend/constants/ui.ts
@@ -3,7 +3,8 @@
  */
 
 import { RECORD_TYPES } from '@/types/enums';
-import { Milk, Moon, Baby, Ruler, FileText, Zap, type LucideIcon } from 'lucide-react';
+import { type LucideIcon } from 'lucide-react';
+import { RECORD_TYPE_ICONS } from './icons';
 
 export const TOAST_DURATION_MS = 3000;
 export const MOBILE_BREAKPOINT_PX = 768;
@@ -17,11 +18,4 @@ export const RECORD_TYPE_LABELS = {
   [RECORD_TYPES.CONTRACTION]: '陣痛',
 } as const;
 
-export const RECORD_TYPE_LUCIDE_ICONS: Record<keyof typeof RECORD_TYPE_LABELS, LucideIcon> = {
-  [RECORD_TYPES.FEEDING]: Milk,
-  [RECORD_TYPES.SLEEP]: Moon,
-  [RECORD_TYPES.DIAPER]: Baby,
-  [RECORD_TYPES.GROWTH]: Ruler,
-  [RECORD_TYPES.NOTE]: FileText,
-  [RECORD_TYPES.CONTRACTION]: Zap,
-} as const;
+export const RECORD_TYPE_LUCIDE_ICONS: Record<keyof typeof RECORD_TYPE_LABELS, LucideIcon> = RECORD_TYPE_ICONS;


### PR DESCRIPTION
## 概要
アプリ全体で統一して使用できるアイコン定義（`AppIcons`）を新規作成し、各所でそれを参照するようにリファクタリングを行いました。

## 変更内容
- `frontend/constants/icons.ts` を新規作成し、各機能や詳細アクションで使用するアイコンを `AppIcons` として定義
- `frontend/constants/ui.ts` の `RECORD_TYPE_LUCIDE_ICONS` を `RECORD_TYPE_ICONS` へのマッピングに修正
- `frontend/components/records/RecordIcon.tsx`、フロントエンドのレイアウト、各種ダッシュボードページ、QuickActionBar、DiaperIcon、FeedingIcon などのアイコンを `AppIcons` を使用するように変更
- 不要になった個別の `lucide-react` からのアイコンインポートを削除
