### PR TITLE
⚡ Bolt: 管理画面の家族一覧取得におけるN+1クエリの解消

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-03-05 - [SQLAlchemy N+1 Loop Prevention]
 **Learning:** Querying related entities (like `FamilyUser` roles) inside a loop across multiple records (`RecordComment`) is a hidden N+1 bottleneck. SQLAlchemy's `first()` inside a loop does not batch queries by default.
 **Action:** Extract all required IDs from the list into a set, and perform a single `.in_()` query to fetch related records in batch. Combine this with `joinedload` for eager loading of direct relationships (like `.user`) to keep database queries constant regardless of list size.
+
+## 2026-03-05 - [SQLAlchemy N+1 Loop Prevention in Family Retrieval]
+**Learning:** Querying related entity aggregations (like member count per family) inside a loop (`db.query(func.count(FamilyUser.user_id)).filter(FamilyUser.family_id == f.id).scalar()`) creates a significant N+1 bottleneck when paginating families in the admin dashboard.
+**Action:** Extract family IDs into a list (`[f.id for f in families]`) and execute a single grouped query (`.in_(family_ids)` combined with `.group_by(FamilyUser.family_id)`) to map counts into a dictionary before the loop. This reduces queries from O(N) to O(1).

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -85,13 +85,27 @@ def get_admin_families(
         escaped_search = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         query = query.filter(Family.name.ilike(f"%{escaped_search}%", escape="\\"))
     families = query.offset(skip).limit(limit).all()
+
+    # ⚡ Bolt: N+1クエリを防ぐため、全家族のメンバー数を1回のクエリで一括取得する
+    family_ids = [f.id for f in families]
+    member_counts = {}
+    if family_ids:
+        counts = db.query(
+            FamilyUser.family_id,
+            func.count(FamilyUser.user_id)
+        ).filter(
+            FamilyUser.family_id.in_(family_ids)
+        ).group_by(
+            FamilyUser.family_id
+        ).all()
+        member_counts = {family_id: count for family_id, count in counts}
+
     result = []
     for f in families:
-        member_count = db.query(func.count(FamilyUser.user_id)).filter(FamilyUser.family_id == f.id).scalar()
         result.append(FamilyAdminResponse(
             id=f.id,
             name=f.name,
-            member_count=member_count,
+            member_count=member_counts.get(f.id, 0),
             created_at=f.created_at
         ))
     return result


### PR DESCRIPTION
💡 何を: `app/routers/admin.py` の `get_admin_families` におけるループ処理内での家族メンバー数取得クエリを、`IN` と `GROUP BY` を用いた一括取得（1クエリ）に変更しました。
🎯 なぜ: 一覧取得時に各家族に対して `func.count(FamilyUser.user_id)` を実行していたため、最大で `limit=100` 回の追加クエリが発行されるN+1問題が発生していました。
📊 影響: 家族一覧を取得する際、発行されるクエリ数が O(N)（1 + Nクエリ）から O(1)（正確には2クエリ固定）に減少し、表示速度が大幅に向上し、データベース負荷が軽減されます。
🔬 測定: 改善後のコードでバックエンドテスト (`npm run test:backend`) が全てパスすることを確認済みです。

---
*PR created automatically by Jules for task [10135518342560883696](https://jules.google.com/task/10135518342560883696) started by @eburairu*