### PR TITLE
fix: ダッシュボードの経過時間表示が更新されない不具合を修正

### DIFF
--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -17,12 +17,10 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
         return () => clearInterval(id)
     }, [])
 
-    // tick は再レンダリングを促すために state として持つが、計算自体には含める必要がない
-    // (再レンダリング時に calcProgress が新しい時刻で再計算されるため)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const _tick = tick;
-
     const { wetCount, dirtyCount, lastElapsed, lastDiaperTime } = useMemo(() => {
+        // tick に依存させることで1分ごとの更新を保証する
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        tick;
         const diaperRecords = records
             ?.map(normalizeDiaperFromRecord)
             .filter((d): d is NormalizedDiaper => d !== null) ?? []
@@ -31,7 +29,7 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
             ...stats,
             lastDiaperTime: diaperRecords[0]?.timestamp ?? null
         }
-    }, [records])
+    }, [records, tick])
 
     const progress = thresholdMinutes != null
         ? calcProgress(lastDiaperTime, thresholdMinutes)

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -17,17 +17,15 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
         return () => clearInterval(id)
     }, [])
 
-    // tick は再レンダリングを促すために state として持つが、計算自体には含める必要がない
-    // (再レンダリング時に calcProgress が新しい時刻で再計算されるため)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const _tick = tick;
-
     const { todayCount, lastElapsed, lastFeedingTime } = useMemo(() => {
+        // tick に依存させることで1分ごとの更新を保証する
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        tick;
         const feedingRecords = records
             ?.map(normalizeFeedingFromRecord)
             .filter((f): f is NormalizedFeeding => f !== null) ?? []
         return calculateFeedingStats(feedingRecords)
-    }, [records])
+    }, [records, tick])
 
     // tick は再レンダリングを促すために state として持つが、計算自体には含める必要がない
     // (再レンダリング時に calcProgress が新しい時刻で再計算されるため)

--- a/frontend/components/dashboard/SleepWidget.tsx
+++ b/frontend/components/dashboard/SleepWidget.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, memo } from "react"
+import { useMemo, memo, useState, useEffect } from "react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
 import { HexagonWidgetCard } from "./HexagonWidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
@@ -9,9 +9,19 @@ import { Moon } from "lucide-react"
 import Link from "next/link"
 
 export const SleepWidget = memo(function SleepWidget({ babyId, records, isError, isLoading, size }: BaseWidgetProps) {
+    const [tick, setTick] = useState(0)
+
+    useEffect(() => {
+        const id = setInterval(() => setTick(t => t + 1), 60000)
+        return () => clearInterval(id)
+    }, [])
+
     const { isSleeping, todayTotal, elapsed, lastElapsed } = useMemo(() => {
+        // tick に依存させることで1分ごとの更新を保証する
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        tick;
         return calculateSleepStats(records)
-    }, [records])
+    }, [records, tick])
 
     return (
         <Link href={`/sleep?baby_id=${babyId}`} className="block">


### PR DESCRIPTION
## 概要
ダッシュボードの「授乳」「睡眠」「おむつ」の各ウィジェットにおいて、表示されている「経過時間」（例：「1時間10分前」）が、時間が経過しても自動的に更新されない、およびプルリフレッシュをしても即座に最新の時間に更新されないという不具合を修正しました。

## 変更内容
- **自動更新ロジックの追加**: 各ウィジェットに `tick` ステートを追加し、`setInterval` を使用して1分ごとに再レンダリングを促すようにしました。
- **経過時間の再計算**: `useMemo` の依存配列に `tick` を含め、1分経過ごとに表示テキストが自動的に最新の経過時間に再計算されるようにしました。
- **リフレッシュ時の即時反映**: プルリフレッシュによって `records` が再取得されると、`useMemo` の依存関係により経過時間が即座に最新の時刻で再計算されます。
- **Lint エラーの修正**: `useMemo` 内で `tick` をダミー参照することで、依存関係の警告（exhaustive-deps）を解消しました。

## 影響範囲
- ダッシュボード（`DashboardPage`）の各ウィジェット表示のみ。

## 確認事項
- [x] 1分経過後に表示が「x分前」から「x+1分前」に更新されること。
- [x] プルリフレッシュ時に、現在の時刻に基づいた最新の経過時間が表示されること。
- [x] フロントエンドの Lint とビルドがパスしていること。

Co-Authored-By: Gemini <gemini@google.com>
