### PR TITLE
✍️ Scribe: [マイルストーン記録API仕様の実装との同期]

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -77,3 +77,7 @@
 ## 2026-02-18 - [おむつAPIと仕様書の乖離解消]
 **学び:** `get_diapers` エンドポイントがページネーション対応 (`skip`, `limit` パラメータの追加) や部分更新のスキーマ (`DiaperUpdate`) をサポートしていたにも関わらず、`diaper_tracker.md` などの仕様書が古いままでした。APIエンドポイントの引数やPydanticスキーマが追加された場合、それを参照する仕様書側へも迅速に反映させる必要があります。
 **アクション:** API側のモデル (`app/schemas/diaper.py` 等) やルーター (`app/routers/diaper.py` 等) に変更が入った際には、対応する `.specify/specs/` 下の仕様書 (今回であれば `diaper_tracker.md`) も同期して更新・確認するプロセスを徹底します。
+
+## 2024-05-18 - [マイルストーン記録API仕様と実装の乖離の発見]
+**学び:** マイルストーン機能（`app/routers/milestones.py`）において、仕様書（`milestone_tracker.md`）では更新メソッドが `PUT` と記載され、さらに `timeline` のグループ化取得エンドポイントや、具体的なリクエスト・レスポンスのスキーマ定義が完全に欠落していました。特に `POST` 時に `baby_id` をリクエストボディではなくクエリパラメータから受け取る実装（スキーマ定義では `baby_id` が存在しない）は特有の挙動であり、これが仕様書に記載されていないとフロントエンドの実装や将来の拡張で混乱を招く原因となります。
+**アクション:** `milestone_tracker.md` を更新し、`PUT` を `PATCH` に修正するとともに、不足していた `GET /api/milestones/timeline` エンドポイント、および `MilestoneCreate`, `MilestoneUpdate`, `MilestoneResponse`, `MilestoneTimelineGroup` のスキーマ定義を追記しました。今後、他のトラッカー仕様書も同様に、特有のパラメータ渡し方（クエリ vs ボディ）や便利機能としてのグループ化APIが漏れていないか定期的に照合・補完するようにします。

--- a/.specify/specs/tracking/milestone_tracker.md
+++ b/.specify/specs/tracking/milestone_tracker.md
@@ -31,7 +31,7 @@
     - `first_word`: 初めてのおしゃべり
     - `first_solid_food`: 離乳食開始
     - `bye_bye`: バイバイ
-- **保存**: API に POST/PUT して保存する。
+- **保存**: API に POST/PATCH して保存する。
     - 保存成功後、家族全員にプッシュ通知（"できたね！: {赤ちゃん名}が「{マイルストーン名}」に成功しました！"）。
 
 ### F2: マイルストーン一覧 (Milestone Timeline)
@@ -61,13 +61,50 @@
 ## API
 
 - `GET /api/milestones/?baby_id={id}`
-    - 指定した赤ちゃんの全マイルストーンを取得。
-- `POST /api/milestones/`
-    - 新規作成。
-- `PUT /api/milestones/{id}`
+    - 指定した赤ちゃんの全マイルストーンを降順で取得。
+- `GET /api/milestones/timeline?baby_id={id}`
+    - 指定した赤ちゃんの全マイルストーンを月齢（生後○ヶ月）ごとにグループ化して取得。
+- `POST /api/milestones/?baby_id={id}`
+    - 新規作成。リクエストボディに `baby_id` を含めず、クエリパラメータから取得する。
+- `PATCH /api/milestones/{id}`
     - 編集更新。
 - `DELETE /api/milestones/{id}`
     - 削除。
+
+### リクエスト/レスポンス スキーマ
+
+```typescript
+// POST リクエスト (クエリパラメータ: ?baby_id={id})
+interface MilestoneCreate {
+  milestone_type: string
+  title: string
+  achieved_date: string // YYYY-MM-DD形式
+  image_urls?: string[]
+  notes?: string
+}
+
+// PATCH リクエスト
+interface MilestoneUpdate {
+  milestone_type?: string
+  title?: string
+  achieved_date?: string
+  image_urls?: string[]
+  notes?: string
+}
+
+// レスポンス
+interface MilestoneResponse extends MilestoneCreate {
+  id: number
+  baby_id: number
+  user_id: number | null
+}
+
+// タイムラインレスポンス
+interface MilestoneTimelineGroup {
+  month_age: number
+  milestones: MilestoneResponse[]
+}
+```
 
 ## 技術設計
 


### PR DESCRIPTION
## 概要
✍️ Scribe: マイルストーン機能のAPI仕様書（`milestone_tracker.md`）とバックエンド実装（`app/routers/milestones.py`）の間に存在していた乖離を解消しました。

## 💡 何を
- `.specify/specs/tracking/milestone_tracker.md` の更新
  - 更新メソッドを `PUT` から `PATCH` へ修正。
  - 欠落していた `GET /api/milestones/timeline?baby_id={id}` エンドポイントの記述を追加。
  - `MilestoneCreate`, `MilestoneUpdate`, `MilestoneResponse`, `MilestoneTimelineGroup` のスキーマ定義を追記。
- `.jules/scribe.md` への学習内容の記録。

## 🔍 発見
- 実装では `PATCH` が使われているにも関わらず、仕様書では `PUT` と記載されていました。
- 月齢ごとのグループ化を行う `timeline` エンドポイントが仕様書から完全に抜け落ちていました。
- `POST` エンドポイントにおいて、`baby_id` をリクエストボディではなくクエリパラメータから受け取るという特有の実装（スキーマ定義に `baby_id` が含まれない）が明記されていませんでした。

## 🎯 影響
- 今後フロントエンドの連携や機能拡張を行う際、開発者が「存在しない仕様」や「間違った仕様」に基づいて実装してしまうリスクを防ぐことができます。
- 特に `timeline` のような重要な機能が仕様として可視化されることで、開発者体験が向上します。

---
*PR created automatically by Jules for task [9685841057964999205](https://jules.google.com/task/9685841057964999205) started by @eburairu*