### PR TITLE
🧹 Tidy: [ダッシュボードウィジェットの時間更新と画像最適化のリファクタリング]

### DIFF
--- a/.jules/tidy.md
+++ b/.jules/tidy.md
@@ -76,3 +76,7 @@
 ### アクション:
 - 今後も React Hook Form を使用する際、特定のフィールド値のみを監視してUIを切り替える場合は `useWatch` を標準として利用する。
 - 新しいトラッカーや履歴画面を追加する際は、必ず `components/records/` 配下の共通コンポーネントと、`hooks/useRecordDelete`, `useRecordComments` などの共通フックを使用する。
+
+2024-03-01 - [ダッシュボードウィジェットの時間更新ロジックの共通化と画像最適化]
+学び: 複数のダッシュボードウィジェット（FeedingWidget, DiaperWidget, SleepWidget）で、時間経過をリアルタイムにUIへ反映させるためだけに `useState` と `setInterval` + `useEffect` のセットが各ファイルで重複して実装されていました。これはコードの冗長性を生み、保守性を下げるアンチパターンです。また、LandingHeroコンポーネントで標準の `<img>` タグが使用されており、Next.jsのESLint警告（no-img-element）が出現していました。
+アクション: 時間更新のためのロジックをラップした `useTick` フックを新規作成し、各ウィジェットでこのフックを呼び出す形にリファクタリングしました。これにより、不要なライフサイクル管理コードを排除し、DRY原則を適用できました。今後は、同様の「単なるポーリングや時間更新」目的のState+Effectの組み合わせを見つけたら、`useTick` や `useInterval` のような共通フックへの移行を検討します。また、`<img>` タグを `next/image` に置き換えました。

--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, memo, useState, useEffect } from "react"
+import { useMemo, memo } from "react"
 import { Baby, Droplets, Biohazard } from "lucide-react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
 import { HexagonWidgetCard } from "./HexagonWidgetCard"
@@ -8,14 +8,10 @@ import { BaseWidgetProps } from "@/types/widget"
 import { calculateDiaperStats, NormalizedDiaper, normalizeDiaperFromRecord } from "@/lib/diaperUtils"
 import { calcProgress, isOverThreshold } from "@/lib/indicatorUtils"
 import Link from "next/link"
+import { useTick } from "@/hooks/useTick"
 
 export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isError, isLoading, size, thresholdMinutes }: BaseWidgetProps) {
-    const [tick, setTick] = useState(0)
-
-    useEffect(() => {
-        const id = setInterval(() => setTick(t => t + 1), 60000)
-        return () => clearInterval(id)
-    }, [])
+    const tick = useTick()
 
     const { wetCount, dirtyCount, lastElapsed, lastDiaperTime } = useMemo(() => {
         // tick に依存させることで1分ごとの更新を保証する

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, memo, useState, useEffect } from "react"
+import { useMemo, memo } from "react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
 import { HexagonWidgetCard } from "./HexagonWidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
@@ -8,14 +8,10 @@ import { normalizeFeedingFromRecord, calculateFeedingStats, NormalizedFeeding } 
 import { calcProgress, isOverThreshold } from "@/lib/indicatorUtils"
 import { Milk } from "lucide-react"
 import Link from "next/link"
+import { useTick } from "@/hooks/useTick"
 
 export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isError, isLoading, size, thresholdMinutes }: BaseWidgetProps) {
-    const [tick, setTick] = useState(0)
-
-    useEffect(() => {
-        const id = setInterval(() => setTick(t => t + 1), 60000)
-        return () => clearInterval(id)
-    }, [])
+    const tick = useTick()
 
     const { todayCount, lastElapsed, lastFeedingTime } = useMemo(() => {
         // tick に依存させることで1分ごとの更新を保証する

--- a/frontend/components/dashboard/SleepWidget.tsx
+++ b/frontend/components/dashboard/SleepWidget.tsx
@@ -1,20 +1,16 @@
 "use client"
 
-import { useMemo, memo, useState, useEffect } from "react"
+import { useMemo, memo } from "react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
 import { HexagonWidgetCard } from "./HexagonWidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
 import { calculateSleepStats } from "@/lib/sleepUtils"
 import { Moon } from "lucide-react"
 import Link from "next/link"
+import { useTick } from "@/hooks/useTick"
 
 export const SleepWidget = memo(function SleepWidget({ babyId, records, isError, isLoading, size }: BaseWidgetProps) {
-    const [tick, setTick] = useState(0)
-
-    useEffect(() => {
-        const id = setInterval(() => setTick(t => t + 1), 60000)
-        return () => clearInterval(id)
-    }, [])
+    const tick = useTick()
 
     const { isSleeping, todayTotal, elapsed, lastElapsed } = useMemo(() => {
         // tick に依存させることで1分ごとの更新を保証する

--- a/frontend/components/landing/LandingHero.tsx
+++ b/frontend/components/landing/LandingHero.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion"
 import Link from "next/link"
+import Image from "next/image"
 import { ArrowRight, Monitor, Smartphone, Star, User } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useState } from "react"
@@ -137,10 +138,12 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                                     baby-app.example.com/dashboard
                                 </div>
                             </div>
-                            <img
+                            <Image
                                 src="/screenshots/dashboard.png"
                                 alt="ダッシュボードのスクリーンショット（デスクトップ）"
-                                className="w-full opacity-90 dark:opacity-100"
+                                width={1200}
+                                height={800}
+                                className="w-full h-auto opacity-90 dark:opacity-100"
                             />
                         </motion.div>
                     )}
@@ -158,10 +161,12 @@ export function LandingHero({ isLoggedIn = false }: LandingHeroProps) {
                             <div className="relative rounded-[2.5rem] overflow-hidden shadow-2xl border-[6px] border-slate-800 dark:border-zinc-800 bg-slate-800 dark:bg-zinc-900">
                                 {/* パンチホール */}
                                 <div className="absolute top-3 left-1/2 -translate-x-1/2 w-16 h-5 bg-slate-800 dark:bg-zinc-900 rounded-full z-10" />
-                                <img
+                                <Image
                                     src="/screenshots/dashboard-mobile.png"
                                     alt="ダッシュボードのスクリーンショット（モバイル）"
-                                    className="w-full opacity-90 dark:opacity-100"
+                                    width={400}
+                                    height={800}
+                                    className="w-full h-auto opacity-90 dark:opacity-100"
                                 />
                             </div>
                         </motion.div>

--- a/frontend/hooks/useTick.ts
+++ b/frontend/hooks/useTick.ts
@@ -1,0 +1,19 @@
+import { useState } from "react"
+import { useInterval } from "./useInterval"
+
+/**
+ * 指定した間隔（ミリ秒）ごとに再レンダリングをトリガーするためのフック。
+ * `delay` を指定しない場合は、デフォルトで1分（60000ms）ごとに再レンダリングされます。
+ *
+ * @param delay 更新間隔（ミリ秒）。null の場合はタイマーを停止。
+ * @returns 増加し続ける数値（tick）
+ */
+export function useTick(delay: number | null = 60000): number {
+    const [tick, setTick] = useState(0)
+
+    useInterval(() => {
+        setTick((t) => t + 1)
+    }, delay)
+
+    return tick
+}


### PR DESCRIPTION
💡 何を:
1. 時間経過をリアルタイムにUIへ反映させるための `useState` と `setInterval` + `useEffect` のセットを `useTick` フックに共通化しました。
2. FeedingWidget、DiaperWidget、SleepWidget で `useTick` を使用するよう変更しました。
3. LandingHero コンポーネントの標準 `<img>` タグを、Next.jsの `<Image>` コンポーネントに置き換えました。

🎯 なぜ:
各ウィジェットで全く同じポーリング実装が散在していたため、共通のフック `useTick` を作成することで、冗長なライフサイクル管理コードを排除しDRY原則を適用しました（コードの可読性と保守性が向上します）。
また、標準の `<img>` タグの使用によるESLintの警告（`@next/next/no-img-element`）を解消し、アセット読み込みのベストプラクティスに準拠させました。

🛡️ 安全性:
- `pnpm test` が全てパスすることを確認しました。
- `pnpm lint` で警告やエラーが出ないことを確認しました。
- `pnpm build` が正常に完了することを確認しました。
- `Playwright` を使用してUIの見た目に影響がないことを目視確認しました。

---
*PR created automatically by Jules for task [13464099757475245451](https://jules.google.com/task/13464099757475245451) started by @eburairu*