### PR TITLE
feat: 各記録のアイコンとカラーを統一・最適化

### DIFF
--- a/frontend/components/dashboard/ActivityItem.tsx
+++ b/frontend/components/dashboard/ActivityItem.tsx
@@ -3,7 +3,9 @@ import React from "react"
 import { BabyRecord } from "@/types/record"
 import { formatElapsed } from "@/lib/ageUtils"
 import { MessageCircle, User, StickyNote } from "lucide-react"
-import { RECORD_TYPE_LABELS, RECORD_TYPE_LUCIDE_ICONS } from "@/constants/ui"
+import { RECORD_TYPE_LABELS, RECORD_TYPE_LUCIDE_ICONS, RECORD_TYPE_COLORS } from "@/constants/ui"
+import { AppIcons } from "@/constants/icons"
+import { cn } from "@/lib/utils"
 
 interface ActivityItemProps {
     record: BabyRecord
@@ -13,7 +15,19 @@ interface ActivityItemProps {
 export const ActivityItem = React.memo(function ActivityItem({ record, onClick }: ActivityItemProps) {
     const recordType = record.type as keyof typeof RECORD_TYPE_LABELS
     const label = RECORD_TYPE_LABELS[recordType] || record.type
-    const LucideIcon = RECORD_TYPE_LUCIDE_ICONS[recordType]
+    const colorClass = RECORD_TYPE_COLORS[recordType as keyof typeof RECORD_TYPE_COLORS] || 'text-muted-foreground'
+    
+    let LucideIcon = RECORD_TYPE_LUCIDE_ICONS[recordType]
+    
+    // 授乳の場合は詳細タイプに応じてアイコンを切り替え
+    if (recordType === 'feeding') {
+        const feedingType = record.details?.feeding_type
+        if (feedingType === 'BREAST') {
+            LucideIcon = AppIcons.feedingBreast
+        } else if (feedingType === 'BOTTLE') {
+            LucideIcon = AppIcons.feedingBottle
+        }
+    }
 
     return (
         <li>
@@ -24,8 +38,8 @@ export const ActivityItem = React.memo(function ActivityItem({ record, onClick }
                 onClick={() => onClick(record)}
             >
                 {LucideIcon
-                    ? <LucideIcon className="h-5 w-5 text-muted-foreground shrink-0" aria-hidden="true" />
-                    : <StickyNote className="h-5 w-5 text-muted-foreground shrink-0" aria-hidden="true" />
+                    ? <LucideIcon className={cn("h-5 w-5 shrink-0", colorClass)} aria-hidden="true" />
+                    : <StickyNote className={cn("h-5 w-5 shrink-0", colorClass)} aria-hidden="true" />
                 }
                 <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-gray-800 dark:text-zinc-200">

--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMemo, memo } from "react"
-import { Baby, Droplets, Biohazard } from "lucide-react"
+import { Droplets, Biohazard } from "lucide-react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
 import { HexagonWidgetCard } from "./HexagonWidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
@@ -9,6 +9,7 @@ import { calculateDiaperStats, NormalizedDiaper, normalizeDiaperFromRecord } fro
 import { calcProgress, isOverThreshold } from "@/lib/indicatorUtils"
 import Link from "next/link"
 import { useTick } from "@/hooks/useTick"
+import { AppIcons } from "@/constants/icons"
 
 export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isError, isLoading, size, thresholdMinutes }: BaseWidgetProps) {
     const tick = useTick()
@@ -36,7 +37,7 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
         <Link href={`/diaper?baby_id=${babyId}`} className="block">
             <HexagonWidgetCard
                 title="おむつ"
-                icon={<Baby className="w-5 h-5 text-amber-500" />}
+                icon={<AppIcons.diaper className="w-5 h-5 text-amber-500" />}
                 isError={isError}
                 isLoading={isLoading}
                 size={size}

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -6,7 +6,7 @@ import { HexagonWidgetCard } from "./HexagonWidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
 import { normalizeFeedingFromRecord, calculateFeedingStats, NormalizedFeeding } from "@/lib/feedingUtils"
 import { calcProgress, isOverThreshold } from "@/lib/indicatorUtils"
-import { Milk } from "lucide-react"
+import { AppIcons } from "@/constants/icons"
 import Link from "next/link"
 import { useTick } from "@/hooks/useTick"
 
@@ -34,7 +34,7 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
         <Link href={`/feeding?baby_id=${babyId}`} className="block">
             <HexagonWidgetCard
                 title="授乳"
-                icon={<Milk className="w-5 h-5 text-rose-500" />}
+                icon={<AppIcons.feeding className="w-5 h-5 text-rose-500" />}
                 isError={isError}
                 isLoading={isLoading}
                 size={size}

--- a/frontend/components/dashboard/QuickActionBar.tsx
+++ b/frontend/components/dashboard/QuickActionBar.tsx
@@ -167,7 +167,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     />
                     {/* 下段: メモ */}
                     <HexagonButton
-                        variant="amber"
+                        variant="blue"
                         icon={<AppIcons.note className="h-5 w-5" />}
                         size={BUTTON_SIZE}
                         onClick={() => setNoteDialogOpen(true)}
@@ -185,7 +185,7 @@ export function QuickActionBar({ babyId, mutateRecords, records }: Props) {
                     />
                     {/* 下段: 日誌 */}
                     <HexagonButton
-                        variant="zinc"
+                        variant="purple"
                         icon={<AppIcons.diary className="h-5 w-5" />}
                         size={BUTTON_SIZE}
                         onClick={() => router.push(`/diary`)}

--- a/frontend/constants/ui-colors.ts
+++ b/frontend/constants/ui-colors.ts
@@ -247,4 +247,32 @@ export const HEXAGON_BUTTON_THEMES = {
       glow: "bg-zinc-500/20",
     },
   },
+  purple: {
+    active: {
+      bg: "text-purple-500",
+      icon: "text-white",
+      border: "var(--color-purple-500)",
+      glow: "bg-purple-500/20",
+    },
+    inactive: {
+      bg: "text-purple-100 dark:text-purple-950/40",
+      icon: "text-purple-600 dark:text-purple-400",
+      border: "rgba(0,0,0,0.05)",
+      glow: "bg-purple-500/20",
+    },
+  },
+  blue: {
+    active: {
+      bg: "text-blue-500",
+      icon: "text-white",
+      border: "var(--color-blue-500)",
+      glow: "bg-blue-500/20",
+    },
+    inactive: {
+      bg: "text-blue-100 dark:text-blue-950/40",
+      icon: "text-blue-600 dark:text-blue-400",
+      border: "rgba(0,0,0,0.05)",
+      glow: "bg-blue-500/20",
+    },
+  },
 } as const;

--- a/frontend/constants/ui.ts
+++ b/frontend/constants/ui.ts
@@ -18,4 +18,13 @@ export const RECORD_TYPE_LABELS = {
   [RECORD_TYPES.CONTRACTION]: '陣痛',
 } as const;
 
+export const RECORD_TYPE_COLORS = {
+  [RECORD_TYPES.FEEDING]: 'text-rose-500 dark:text-rose-400',
+  [RECORD_TYPES.SLEEP]: 'text-indigo-500 dark:text-indigo-400',
+  [RECORD_TYPES.DIAPER]: 'text-amber-500 dark:text-amber-400',
+  [RECORD_TYPES.GROWTH]: 'text-emerald-500 dark:text-emerald-400',
+  [RECORD_TYPES.NOTE]: 'text-blue-500 dark:text-blue-400',
+  [RECORD_TYPES.CONTRACTION]: 'text-orange-500 dark:text-orange-400',
+} as const;
+
 export const RECORD_TYPE_LUCIDE_ICONS: Record<keyof typeof RECORD_TYPE_LABELS, LucideIcon> = RECORD_TYPE_ICONS;


### PR DESCRIPTION
## 概要
各記録（授乳、おむつ、睡眠など）で使用されるアイコンとカラーを統一し、一貫性のあるデザインに修正しました。

## 変更内容
- **おむつウィジェット**: アイコンを Baby から Smile に変更。
- **クイックアクション**: 
    - 「日誌」を zinc から purple に変更。
    - 「メモ」を amber から blue に変更。
- **履歴フィード**: 
    - 各アイコンに記録タイプ固有のカラー（rose, indigo, amber 等）を適用。
    - 授乳記録の場合、詳細タイプに応じて母乳とミルクのアイコンを使い分けるように修正。
- **定数定義**:
    - `frontend/constants/ui-colors.ts`: purple と blue のボタンテーマを追加。
    - `frontend/constants/ui.ts`: 各記録タイプに対応するカラーマッピング `RECORD_TYPE_COLORS` を追加。

## 確認事項
- [x] `sh scripts/verify_all.sh` がパスすること
- [x] アイコンの変更が正しいこと
- [x] カラーの適用が意図通りであること
