### PR TITLE
feat: 統計アイコンと赤ちゃんアバターを六角形に変更

### DIFF
--- a/.specify/specs/ui/ui_design_system.md
+++ b/.specify/specs/ui/ui_design_system.md
@@ -81,7 +81,7 @@ Botoro 全ページに適用する統一 UI/UX ガイドライン。
 | ボタン（大） | `rounded-xl`（`h-12` 以上） |
 | ボタン（小・インライン） | shadcn デフォルト（`rounded-md`） |
 | ウィジェット内クイックボタン | `rounded-lg h-8` |
-| アイコンラッパー | `rounded-full` |
+| アイコンラッパー | `Hexagon` (六角形) |
 
 ### 1.4 Z-Index 階層
 
@@ -193,9 +193,9 @@ Botoro 全ページに適用する統一 UI/UX ガイドライン。
     <div className="grid grid-cols-2 gap-4">
       {/* 個々の統計ミニカード */}
       <div className="bg-{category}-50 rounded-xl p-4 flex items-center gap-3">
-        <div className="bg-white rounded-full p-2 shadow-sm">
+        <Hexagon size={32} cornerRadius={4} className="text-white dark:text-zinc-800 shadow-sm transition-colors shrink-0 mt-0.5">
           <Icon className="h-4 w-4 text-{category}-500" />
-        </div>
+        </Hexagon>
         <div>
           <p className="text-xs text-gray-500">ラベル</p>
           <p className="text-lg font-bold text-gray-800">値</p>

--- a/frontend/components/dashboard/BabyInfoPopup.tsx
+++ b/frontend/components/dashboard/BabyInfoPopup.tsx
@@ -60,7 +60,7 @@ export function BabyInfoPopup({ baby, open, onOpenChange }: BabyInfoPopupProps) 
       >
         <SheetHeader className="items-center pb-4">
           <div className="flex justify-center mb-2">
-            <Hexagon size={56} color="var(--primary)">
+            <Hexagon size={56} color="var(--primary)" cornerRadius={8}>
               <span className="text-white font-bold text-xl">
                 {baby.name.charAt(0) || "?"}
               </span>

--- a/frontend/components/dashboard/BabyWidget.tsx
+++ b/frontend/components/dashboard/BabyWidget.tsx
@@ -39,7 +39,7 @@ export function BabyWidget({ baby, size }: BabyWidgetProps) {
         <HexagonWidgetCard
           title={baby.name}
           icon={
-            <Hexagon size={28} color="rgb(99 102 241)">
+            <Hexagon size={28} color="rgb(99 102 241)" cornerRadius={4}>
               <span className="text-white font-bold text-xs">{initial}</span>
             </Hexagon>
           }

--- a/frontend/components/feeding/FeedingIcon.tsx
+++ b/frontend/components/feeding/FeedingIcon.tsx
@@ -1,5 +1,7 @@
 import { AppIcons } from "@/constants/icons"
 import { FeedingType } from "@/types/feeding"
+import { Hexagon } from "@/components/ui/hexagon"
+import { cn } from "@/lib/utils"
 
 interface FeedingIconProps {
     type: FeedingType
@@ -8,14 +10,24 @@ interface FeedingIconProps {
 
 export function FeedingIcon({ type, className }: FeedingIconProps) {
     const isBreast = type === 'BREAST';
-    const baseClasses = "p-2 rounded-full shrink-0";
-    const colorClasses = isBreast
-        ? "bg-pink-100 text-pink-600 dark:bg-pink-900/30 dark:text-pink-400"
-        : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400";
+    const bgClass = isBreast
+        ? "text-pink-100 dark:text-pink-900/30"
+        : "text-blue-100 dark:text-blue-900/30";
+    const iconClass = isBreast
+        ? "text-pink-600 dark:text-pink-400"
+        : "text-blue-600 dark:text-blue-400";
 
     return (
-        <div className={`${baseClasses} ${colorClasses} ${className || ''}`}>
-            {isBreast ? <AppIcons.feedingBreast className="w-5 h-5" /> : <AppIcons.feedingBottle className="w-5 h-5" />}
-        </div>
+        <Hexagon
+            size={36}
+            cornerRadius={6}
+            className={cn("shrink-0", bgClass, className)}
+        >
+            {isBreast ? (
+                <AppIcons.feedingBreast className={cn("w-4 h-4", iconClass)} />
+            ) : (
+                <AppIcons.feedingBottle className={cn("w-4 h-4", iconClass)} />
+            )}
+        </Hexagon>
     );
 }

--- a/frontend/components/records/RecordIcon.tsx
+++ b/frontend/components/records/RecordIcon.tsx
@@ -1,5 +1,6 @@
 import { AppIcons } from "@/constants/icons";
 import { cn } from "@/lib/utils";
+import { Hexagon } from "@/components/ui/hexagon";
 
 export type RecordType = 'feeding' | 'sleep' | 'diaper' | 'note' | 'growth';
 
@@ -8,12 +9,12 @@ interface RecordIconProps {
   className?: string;
 }
 
-const styles: Record<RecordType, string> = {
-  feeding: "bg-orange-100 dark:bg-orange-950/40 text-orange-500 dark:text-orange-400",
-  sleep: "bg-indigo-100 dark:bg-indigo-950/40 text-indigo-500 dark:text-indigo-400",
-  diaper: "bg-amber-100 dark:bg-amber-950/40 text-amber-500 dark:text-amber-400",
-  note: "bg-amber-100 dark:bg-amber-950/40 text-amber-500 dark:text-amber-400",
-  growth: "bg-green-100 dark:bg-green-950/40 text-green-500 dark:text-green-400",
+const styles: Record<RecordType, { bg: string, icon: string }> = {
+  feeding: { bg: "text-orange-100 dark:text-orange-950/40", icon: "text-orange-500 dark:text-orange-400" },
+  sleep: { bg: "text-indigo-100 dark:text-indigo-950/40", icon: "text-indigo-500 dark:text-indigo-400" },
+  diaper: { bg: "text-amber-100 dark:text-amber-950/40", icon: "text-amber-500 dark:text-amber-400" },
+  note: { bg: "text-amber-100 dark:text-amber-950/40", icon: "text-amber-500 dark:text-amber-400" },
+  growth: { bg: "text-green-100 dark:text-green-950/40", icon: "text-green-500 dark:text-green-400" },
 };
 
 export function RecordIcon({ type, className }: RecordIconProps) {
@@ -23,8 +24,12 @@ export function RecordIcon({ type, className }: RecordIconProps) {
   if (!Icon) return null;
 
   return (
-    <div className={cn("p-2 rounded-full", style, className)}>
-      <Icon className="w-5 h-5" />
-    </div>
+    <Hexagon
+      size={36}
+      cornerRadius={6}
+      className={cn("shrink-0", style.bg, className)}
+    >
+      <Icon className={cn("w-4 h-4", style.icon)} />
+    </Hexagon>
   );
 }

--- a/frontend/components/ui/stats-block.tsx
+++ b/frontend/components/ui/stats-block.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils"
 import { LucideIcon } from "lucide-react"
 import { STATS_BLOCK_CONFIG } from "@/constants/ui-colors"
+import { Hexagon } from "@/components/ui/hexagon"
 
 export type StatsBlockColor = keyof typeof STATS_BLOCK_CONFIG
 
@@ -31,9 +32,13 @@ export function StatsBlock({
         className
       )}
     >
-      <div className="bg-white dark:bg-zinc-800 rounded-full p-2 shadow-sm transition-colors shrink-0 mt-0.5">
+      <Hexagon
+        size={32}
+        cornerRadius={4}
+        className="text-white dark:text-zinc-800 shadow-sm shrink-0 mt-0.5"
+      >
         <Icon className={cn("h-4 w-4", styles.icon)} />
-      </div>
+      </Hexagon>
       <div className="min-w-0 flex-1">
         <p className="text-xs text-gray-500 dark:text-zinc-400">{label}</p>
         <p className="text-lg font-bold text-gray-800 dark:text-zinc-100 truncate">


### PR DESCRIPTION
## 概要
おむつ、授乳、睡眠記録の統計サマリーおよび履歴のアイコン背景を丸から六角形（Hexagon）に変更しました。
また、ダッシュボードの赤ちゃんアバターについても六角形がより際立つように角丸を調整しました。

## 変更内容
- `RecordIcon.tsx`, `FeedingIcon.tsx`: 履歴アイコンの背景を六角形に変更
- `stats-block.tsx`: 統計サマリーのアイコン背景を六角形に変更
- `BabyWidget.tsx`, `BabyInfoPopup.tsx`: 赤ちゃんアバターの六角形の角丸を調整（より鋭角に）
- `ui_design_system.md`: アイコンラッパーの形状規定を六角形に更新

## 確認事項
- [x] `pnpm build` が正常に完了すること
- [x] `spec-checker` による仕様整合性の確認
