### PR TITLE
feat: ダッシュボード警告点滅時の波紋アニメーション追加

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -166,3 +166,18 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes ripple {
+  0% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(1.3);
+    opacity: 0;
+  }
+}
+
+@utility animate-ripple {
+  animation: ripple 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+}

--- a/frontend/components/ui/HexagonProgressArc.tsx
+++ b/frontend/components/ui/HexagonProgressArc.tsx
@@ -92,8 +92,18 @@ export function HexagonProgressArc({
         pointerEvents: 'none',
         zIndex: 5
       }}
-      className={`${pulseClass} ${className ?? ''}`.trim()}
+      className={`${className ?? ''}`.trim()}
     >
+      {isOverThreshold && (
+        <path
+          d={pathD}
+          fill="none"
+          stroke={color}
+          strokeWidth={5}
+          className="animate-ripple origin-center"
+          style={{ transformBox: 'fill-box' }}
+        />
+      )}
       <path
         d={pathD}
         fill="none"
@@ -103,6 +113,7 @@ export function HexagonProgressArc({
         strokeDasharray={`${clampedProgress} 1`}
         strokeDashoffset={0}
         strokeLinecap="round"
+        className={pulseClass}
       />
     </svg>
   )


### PR DESCRIPTION
## 概要
ダッシュボードの警告点滅時（閾値超過時）に、六角形のストロークが外側に波紋のように広がるアニメーション (`animate-ripple`) を追加しました。

## 変更内容
- `globals.css` に `@keyframes ripple` および `@utility animate-ripple` を追加
- `HexagonProgressArc.tsx` の閾値超過時に表示されるSVGパスの背景として、波紋アニメーションを再生するパスを追加

## 検証結果
- Lint、テスト、ビルドの通過を確認済み
