### PR TITLE
fix: 波紋アニメーションのクリッピングと点滅間隔の同期を修正

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -179,5 +179,5 @@
 }
 
 @utility animate-ripple {
-  animation: ripple 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+  animation: ripple 2s cubic-bezier(0, 0, 0.2, 1) infinite;
 }

--- a/frontend/components/ui/HexagonProgressArc.tsx
+++ b/frontend/components/ui/HexagonProgressArc.tsx
@@ -90,7 +90,8 @@ export function HexagonProgressArc({
         left: '50%', 
         transform: 'translateX(-50%)', 
         pointerEvents: 'none',
-        zIndex: 5
+        zIndex: 5,
+        overflow: 'visible'
       }}
       className={`${className ?? ''}`.trim()}
     >


### PR DESCRIPTION
## 概要
前回追加した警告点滅時の波紋アニメーション (`animate-ripple`) において、以下の2点を修正しました。

1. **クリッピングの修正**: 四角のエリア（SVGの viewBox）で波紋が途切れて消えてしまう問題を修正するため、`<svg>` 要素に `overflow: 'visible'` を追加し、拡大されたパスが表示領域外でも描画されるようにしました。
2. **点滅間隔の同期**: Tailwindの `animate-pulse`（2秒周期）と波紋が同時に発生するように、`globals.css` の `animate-ripple` の `animation-duration` を `1.5s` から `2s` に変更しました。

## 変更内容
- `HexagonProgressArc.tsx`: SVGタグに `overflow: 'visible'` を追加
- `globals.css`: `@utility animate-ripple` の時間を `2s` に変更

## 検証結果
- Lint、テスト、ビルドの通過を確認済み
- UIの崩れがないことをローカルで確認済み
