### PR TITLE
fix: 設定画面とダークモードボタンの六角形アイコンの歪みを修正

### DIFF
--- a/frontend/components/settings/SettingItem.tsx
+++ b/frontend/components/settings/SettingItem.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight, LucideIcon } from "lucide-react"
 import Link from "next/link"
 import React from "react"
+import { Hexagon } from "@/components/ui/hexagon"
 
 interface SettingItemProps {
     href?: string
@@ -25,19 +26,22 @@ export function SettingItem({
     isDestructive = false,
     rightElement,
 }: SettingItemProps) {
+    const hexagonColorClass = bgClass.replace(/bg-/g, 'text-');
+    
     const content = (
         <div className={`bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 flex items-center gap-4 transition-colors ${
             onClick || href ? "cursor-pointer hover:bg-gray-50 dark:hover:bg-zinc-800" : ""
         } ${
             isDestructive ? "hover:bg-red-50 dark:hover:bg-red-950/20 group" : ""
         }`}>
-            <div className={`relative flex items-center justify-center w-10 h-10 ${
+            <div className={`relative flex items-center justify-center ${
                 isDestructive ? "group-hover:text-red-100 dark:group-hover:text-red-900/30 transition-colors" : ""
             }`}>
-                <div className={`absolute inset-0 ${bgClass}`} style={{ clipPath: "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)" }}></div>
-                <Icon className={`relative z-10 h-5 w-5 ${colorClass} ${
-                    isDestructive ? "group-hover:text-red-600 dark:group-hover:text-red-400" : ""
-                }`} />
+                <Hexagon size={40} className={hexagonColorClass}>
+                    <Icon className={`relative z-10 h-5 w-5 ${colorClass} ${
+                        isDestructive ? "group-hover:text-red-600 dark:group-hover:text-red-400" : ""
+                    }`} />
+                </Hexagon>
             </div>
             <div className="flex-1">
                 <p className={`font-semibold text-gray-900 dark:text-zinc-100 text-sm ${

--- a/frontend/components/theme-toggle.tsx
+++ b/frontend/components/theme-toggle.tsx
@@ -20,7 +20,7 @@ export function ThemeToggle() {
         <HexagonButton
           variant="zinc"
           size={40}
-          className="dark:bg-zinc-900 dark:border-zinc-800 cursor-pointer"
+          className="cursor-pointer"
           icon={
             <>
               <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />


### PR DESCRIPTION
## 概要
設定画面の各アイテムのアイコン背景と、ヘッダーのダークモード切り替えボタンの背景が、正六角形になっていなかった問題を修正しました。

## 修正内容
- `SettingItem.tsx`: 独自の `clipPath` 実装を削除し、共通の `<Hexagon>` コンポーネントを使用するように変更しました。
- `theme-toggle.tsx`: `<HexagonButton>` の外側の `className` に背景色と枠線のスタイルが指定されていたため、それを削除し内部の六角形のみが正しく描画されるように修正しました。