### PR TITLE
🎨 Palette: CommentSectionの空状態のUXを改善

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,7 @@
 ## 2024-03-01 - [カスタムラジオボタン群でのキーボードフォーカスの視認性向上]
 **学び:** `<button>`要素を使って独自のラジオボタングループ（例：`FeedingCompletionSelector`, `BottleFeedingFields`, `DiaperTypeButton`など）を実装する場合、デフォルトのフォーカススタイル（`outline`）がリセットされることが多い。そのため、キーボードで操作（Tab移動）した際に現在どこにフォーカスが当たっているのかが視覚的に分からなくなる問題がある。
 **アクション:** カスタムUIのインタラクティブな要素には、必ずTailwindの `focus-visible:` ユーティリティ（例：`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`）を追加して、キーボードナビゲーション時のアクセシビリティを確保する。
+
+## 2024-05-18 - [CommentSectionのEmpty State改善]
+**学び:** 空の状態（Empty State）は、単なるテキストよりもアイコンや枠線などの視覚的な手がかりを加えることで、ユーザーの次のアクション（今回は「応援メッセージを送る」）を自然に促すことができる。
+**アクション:** 今後、他のリストやセクションの空状態を実装・改善する際にも、同じようにアイコンと淡い背景色を用いたコンポーネントパターンの適用を検討する。

--- a/frontend/components/records/CommentSection.tsx
+++ b/frontend/components/records/CommentSection.tsx
@@ -72,9 +72,10 @@ export function CommentSection({ recordType, recordId, currentUserId, onCommentC
         )) : null}
 
         {comments?.length === 0 && !isLoading && !error ? (
-          <p className="text-xs text-gray-400 dark:text-gray-500 text-center py-2">
-            メッセージを送って育児を応援しましょう！
-          </p>
+          <div className="flex flex-col items-center justify-center py-6 text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-zinc-900/50 rounded-lg border border-dashed border-gray-200 dark:border-zinc-800">
+            <MessageCircle className="w-8 h-8 mb-2 opacity-50" />
+            <p className="text-xs">メッセージを送って育児を応援しましょう！</p>
+          </div>
         ) : null}
       </div>
 


### PR DESCRIPTION
💡 何を:
フロントエンドの `CommentSection` コンポーネントにおける「空状態 (Empty State)」のUX改善を実施しました。単なるテキスト表示だった部分を、淡い背景色と点線ボーダー、および半透明のアイコンを用いたカード形式のレイアウトにアップグレードしました。

🎯 なぜ:
何もコメントがない状態は、ユーザーにとって「どうしていいかわからない」状態になりがちです。視覚的にわかりやすい枠とアイコンを配置することで、「ここにメッセージを書き込める」というサインになり、自然なコミュニケーションを促すことができます。

📸 Before/After:
検証用スクリプトを使用してスクリーンショットを取得し、アイコンや枠線の表示、およびマージン・パディングが正しく適用されていることを確認しました。

♿ アクセシビリティ:
既存の色（`text-gray-400` と `bg-gray-50`）や余白のルールを維持しつつ、アイコンを適切に装飾（`opacity-50`等）として使用しているため、スクリーンリーダー等の利用体験を損ないません。

検証コマンド (`pnpm lint`, `pnpm test`, `pnpm build`) もすべて正常にパスしています。

---
*PR created automatically by Jules for task [12709080005844300643](https://jules.google.com/task/12709080005844300643) started by @eburairu*