### PR TITLE
⚡ Bolt: GrowthWidget における不要な再計算の抑止

### DIFF
--- a/frontend/components/dashboard/GrowthWidget.tsx
+++ b/frontend/components/dashboard/GrowthWidget.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { memo } from "react"
+import { memo, useMemo } from "react"
 import { createWidgetMemoComparison } from "@/lib/memoUtils"
 import { HexagonWidgetCard } from "./HexagonWidgetCard"
 import { BaseWidgetProps } from "@/types/widget"
@@ -8,15 +8,19 @@ import { AppIcons } from "@/constants/icons"
 import Link from "next/link"
 
 export const GrowthWidget = memo(function GrowthWidget({ babyId, records, isLoading, isError, size }: BaseWidgetProps) {
-    const growthRecords = records?.filter(r => r.type === 'growth') ?? []
-    const latest = growthRecords[0] ?? null
-
-    const dateStr = latest?.timestamp 
-        ? `${new Date(latest.timestamp).getMonth() + 1}/${new Date(latest.timestamp).getDate()}`
-        : null
-
-    const weight = latest?.details.weight_kg as number | undefined
-    const height = latest?.details.height_cm as number | undefined
+    // パフォーマンス最適化: レコードのフィルタリングとパース処理をメモ化し、再レンダリング時の不要な計算を抑止
+    const { latest, dateStr, weight, height } = useMemo(() => {
+        const growthRecords = records?.filter(r => r.type === 'growth') ?? []
+        const latestRecord = growthRecords[0] ?? null
+        return {
+            latest: latestRecord,
+            dateStr: latestRecord?.timestamp
+                ? `${new Date(latestRecord.timestamp).getMonth() + 1}/${new Date(latestRecord.timestamp).getDate()}`
+                : null,
+            weight: latestRecord?.details.weight_kg as number | undefined,
+            height: latestRecord?.details.height_cm as number | undefined
+        }
+    }, [records])
 
     return (
         <Link href={`/growth?baby_id=${babyId}`} className="block">


### PR DESCRIPTION
💡 **何を**: `GrowthWidget` コンポーネント内で毎回のレンダリング時に実行されていた配列のフィルタリング処理 (`records?.filter`) および日付等のパース処理 (`new Date(...)`) を、`useMemo` でラップするように最適化しました。
🎯 **なぜ**: ダッシュボードには複数のウィジェットが並んでおり、他のウィジェットや親のステート変更（例: 時間の経過による再描画）のたびに、ウィジェット自身のプロパティ（`records`）が変わっていなくても重いパース処理が走ってしまうため。
📊 **影響**: `GrowthWidget` における不要な計算処理を抑制し、プロファイリング時のCPU負荷とメインスレッドの占有時間を削減しました（マイクロ最適化）。
🔬 **測定**: コンポーネントのProps（`records`）が変わらない状態での再レンダリング時に、`useMemo` 内のブロックがスキップされることを確認。また `pnpm test` にて既存のテストがすべて通過することを検証済み。

---
*PR created automatically by Jules for task [15981552978525610438](https://jules.google.com/task/15981552978525610438) started by @eburairu*