### PR TITLE
fix: 授乳タイマー更新時の IntegrityError の修正

### DIFF
--- a/app/routers/timer.py
+++ b/app/routers/timer.py
@@ -85,10 +85,20 @@ def put_feeding_timer(
     if state is None:
         state = FeedingTimerState(baby_id=baby_id)
         db.add(state)
-    state.active_side = body.active_side
-    state.left_elapsed_seconds = body.left_elapsed_seconds
-    state.right_elapsed_seconds = body.right_elapsed_seconds
-    state.segment_start_time = body.segment_start_time
+
+    # 送信された（Noneでない）フィールドのみを更新
+    if body.active_side is not None or "active_side" in body.model_fields_set:
+        state.active_side = body.active_side
+    
+    if body.left_elapsed_seconds is not None:
+        state.left_elapsed_seconds = body.left_elapsed_seconds
+    
+    if body.right_elapsed_seconds is not None:
+        state.right_elapsed_seconds = body.right_elapsed_seconds
+    
+    if body.segment_start_time is not None or "segment_start_time" in body.model_fields_set:
+        state.segment_start_time = body.segment_start_time
+        
     db.commit()
     db.refresh(state)
     return state


### PR DESCRIPTION
## 概要
授乳タイマーの状態更新（PUT /api/babies/{id}/timer/feeding）において、累積時間フィールド（left_elapsed_seconds, right_elapsed_seconds）を省略して送信した場合に発生する IntegrityError を修正しました。

## 変更内容
- `app/routers/timer.py` の `put_feeding_timer` を修正し、None でないフィールドのみを DB モデルに反映するようにしました。

## 検証
- 累積時間を省略したリクエストでもエラーが発生せず、他のフィールド（active_side 等）のみが正しく更新されることを確認。
