### PR TITLE
fix: 授乳タイマー開始時の同期情報の不完全さを修正

### DIFF
--- a/app/routers/timer.py
+++ b/app/routers/timer.py
@@ -89,6 +89,9 @@ def put_feeding_timer(
     # 送信された（Noneでない）フィールドのみを更新
     if body.active_side is not None or "active_side" in body.model_fields_set:
         state.active_side = body.active_side
+        # 停止時は segment_start_time をクリアする
+        if body.active_side is None:
+            state.segment_start_time = None
     
     if body.left_elapsed_seconds is not None:
         state.left_elapsed_seconds = body.left_elapsed_seconds
@@ -98,6 +101,10 @@ def put_feeding_timer(
     
     if body.segment_start_time is not None or "segment_start_time" in body.model_fields_set:
         state.segment_start_time = body.segment_start_time
+    elif state.active_side is not None and state.segment_start_time is None:
+        # サイドが設定されているのに開始時刻がない場合は現在時刻をセットする
+        from datetime import datetime
+        state.segment_start_time = datetime.utcnow()
         
     db.commit()
     db.refresh(state)

--- a/frontend/hooks/useFeedingTimer.ts
+++ b/frontend/hooks/useFeedingTimer.ts
@@ -45,9 +45,15 @@ export function useFeedingTimer({
     const syncWithServer = useCallback(async (side: ActiveBreastSide) => {
         if (!babyId) return
         
+        // 最新のストアの状態を取得（start/stop 後の最新の状態を同期する）
+        const { segmentStartTime, leftElapsedSeconds, rightElapsedSeconds } = useFeedingTimerStore.getState()
+        
         try {
             await api.put(`/babies/${babyId}/timer/feeding`, {
-                active_side: side
+                active_side: side,
+                segment_start_time: segmentStartTime ? segmentStartTime.toISOString() : null,
+                left_elapsed_seconds: leftElapsedSeconds,
+                right_elapsed_seconds: rightElapsedSeconds
             })
         } catch (error) {
             console.error("Failed to sync feeding timer to server:", error)


### PR DESCRIPTION
## 概要
授乳タイマーの同期において、開始（toggle）時にサーバーへ開始時刻を送信していなかったため、その後のポーリングで `segmentStartTime: null` が返り、タイマーが止まってしまう問題を修正しました。

## 修正内容
- **フロントエンド**: `useFeedingTimer.ts` の `syncWithServer` を修正し、ストアの最新状態（開始時刻、累積秒数）を全てサーバーへ送信するようにしました。
- **バックエンド**: `app/routers/timer.py` の `put_feeding_timer` を強化し、サイドが指定されているが開始時刻が欠落している場合に、サーバー時刻で自動補完するロジックを追加しました。

## 検証
- タイマー開始直後の `PUT` リクエストに `segment_start_time` が含まれることを確認。
- バックエンドテスト `tests/test_timer_feeding.py` がパス。
