### PR TITLE
fix: 授乳タイマーが NaN:NaN と表示される問題の修正

### DIFF
--- a/frontend/__tests__/hooks/useFeedingTimerSync.test.ts
+++ b/frontend/__tests__/hooks/useFeedingTimerSync.test.ts
@@ -31,10 +31,10 @@ describe('useFeedingTimerSync', () => {
     const segmentStartTime = new Date(now.getTime() - 10000)
 
     const mockData = {
-      activeSide: 'LEFT',
-      leftElapsedSeconds: 10,
-      rightElapsedSeconds: 20,
-      segmentStartTime: segmentStartTime.toISOString(),
+      active_side: 'LEFT',
+      left_elapsed_seconds: 10,
+      right_elapsed_seconds: 20,
+      segment_start_time: segmentStartTime.toISOString(),
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/hooks/useFeedingTimerSync.ts
+++ b/frontend/hooks/useFeedingTimerSync.ts
@@ -6,10 +6,10 @@ import { fetcher } from '@/lib/api'
 import { useFeedingTimerStore } from '@/stores/feedingTimerStore'
 
 interface TimerResponse {
-  activeSide: 'LEFT' | 'RIGHT' | null
-  leftElapsedSeconds: number
-  rightElapsedSeconds: number
-  segmentStartTime: string | null
+  active_side: 'LEFT' | 'RIGHT' | null
+  left_elapsed_seconds: number
+  right_elapsed_seconds: number
+  segment_start_time: string | null
 }
 
 /**
@@ -29,11 +29,13 @@ export function useFeedingTimerSync(babyId: number | null) {
 
   useEffect(() => {
     if (data) {
+      // API レスポンスの snake_case をストアの期待する引数にマッピング
+      // また、値が undefined や null の場合に 0 をデフォルト値として渡すことで NaN を防止
       sync(
-        data.activeSide,
-        data.leftElapsedSeconds,
-        data.rightElapsedSeconds,
-        data.segmentStartTime
+        data.active_side,
+        data.left_elapsed_seconds ?? 0,
+        data.right_elapsed_seconds ?? 0,
+        data.segment_start_time
       )
     }
   }, [data, sync])


### PR DESCRIPTION
## 概要
授乳タイマーの同期において、タイマーが `NaN:NaN` と表示されてしまう問題を修正しました。

## 修正内容
- **原因**: API レスポンスのフィールド名（`left_elapsed_seconds` 等の snake_case）と、同期フック (`useFeedingTimerSync.ts`) で参照していた変数名（`leftElapsedSeconds` 等の camelCase）が一致していなかったため、数値計算時に `undefined` が混入し `NaN` が発生していました。
- **対応**: 同期フックにおいて正しいフィールド名を参照するように修正し、さらに値が欠落している場合に `0` をデフォルト値として使用するようにガードを追加しました。

## 検証
- ユニットテスト (`useFeedingTimerSync.test.ts`) がパスすることを確認。
- 実環境においてタイマーが正しい形式（MM:SS）で表示され、同期されることを確認。
