### PR TITLE
style: pull-to-refresh のインジケーターを正六角形に修正

### DIFF
--- a/frontend/components/ui/pull-to-refresh.tsx
+++ b/frontend/components/ui/pull-to-refresh.tsx
@@ -94,15 +94,23 @@ export function PullToRefresh({
                 style={{ opacity, scale, height: pullThreshold }}
                 className="absolute top-0 left-0 right-0 flex items-center justify-center pointer-events-none z-0"
             >
-                <div className="bg-white dark:bg-zinc-800 rounded-xl p-0.5 shadow-lg border border-slate-200 dark:border-zinc-700 overflow-hidden">
-                    <motion.div style={{ rotate: isRefreshing ? undefined : rotate }}>
-                        <Hexagon size={48} color="transparent" className="flex items-center justify-center relative">
-                            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-                                <BabyBottleLoading className="w-6 h-6 text-primary" />
-                            </div>
-                        </Hexagon>
-                    </motion.div>
-                </div>
+                <motion.div 
+                    style={{ rotate: isRefreshing ? undefined : rotate }}
+                    className="drop-shadow-sm"
+                >
+                    <Hexagon 
+                        size={48} 
+                        color="white" 
+                        className="flex items-center justify-center relative dark:text-zinc-800"
+                        borderColor="rgba(226, 232, 240, 0.8)"
+                        borderWidth={1}
+                        cornerRadius={6}
+                    >
+                        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+                            <BabyBottleLoading className="w-6 h-6 text-primary" />
+                        </div>
+                    </Hexagon>
+                </motion.div>
             </motion.div>
 
             {/* Content Area */}


### PR DESCRIPTION
## 概要
pull-to-refresh のインジケーター（背景）が角丸四角形になっていたため、`Hexagon` コンポーネントを使用して正六角形に修正しました。

## 変更内容
- `frontend/components/ui/pull-to-refresh.tsx` において、インジケーターを包んでいた `rounded-xl` の `div` を `Hexagon` コンポーネントに置き換え
- 背景色を `white` (ダークモードは `zinc-800`)、境界線を `slate-200` 相当に設定
- `drop-shadow-sm` を適用して視認性を確保

## 検証結果
- `sh scripts/verify_all.sh` による全チェックをパス
- フロントエンドのビルド (`pnpm build`) が正常に完了することを確認