### PR TITLE
✍️ Scribe: スケジュール機能のAPIスキーマ定義を仕様書に追加

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -171,3 +171,15 @@
 ## 2023-10-27 - [TypeScriptインターフェースとPydanticモデルの継承構造の同期]
 **学び:** マイルストーン記録機能の仕様書において、TypeScriptのインターフェースがバックエンドのPydanticモデルの継承構造（`Base` クラスの利用など）を正しく反映していないことによる定義の冗長化や不一致が発生しやすい。例えば、`image_urls` がPythonコードでは `[]` がデフォルトでありながら、仕様書では `?` (Optional) として記載されていたり、`Create` や `Response` が個別にフィールドを再定義していたりする。
 **アクション:** 今後の仕様書の更新時には、単にエンドポイントとスキーマ名を記載するだけでなく、バックエンドのPydanticの継承構造（例：`MilestoneBase` -> `MilestoneCreate` 等）を正確にTypeScriptのインターフェース設計（`interface MilestoneBase`, `extends MilestoneBase`）に反映させることで、冗長なフィールド定義を防ぎ、実装との一貫性を維持する。
+
+## 2026-03-05 - [スケジュールAPI仕様と実装の乖離の発見]
+
+**学び:**
+
+- スケジュール機能（`app/routers/schedule.py`）において、バックエンドではリクエスト・レスポンス用のPydanticモデル（`ScheduleCreate`, `ScheduleResponse`）が定義され使用されているにもかかわらず、仕様書（`schedule_tracker.md`）には「リクエスト/レスポンススキーマ」のセクション自体が存在せず、TypeScriptのインターフェース定義が完全に欠落していました。
+- 他のトラッカー（Growth, Milestone, Vaccinationなど）で見られた「スキーマ定義の欠落」というパターンが、スケジュール機能の仕様書にも同様に残存していることが確認されました。
+
+**アクション:**
+
+- `schedule_tracker.md` を更新し、「リクエスト/レスポンススキーマ」セクションを新設。`ScheduleCreate` と `ScheduleResponse` のTypeScriptインターフェースを、既存のPydanticモデルに合わせて正確に定義しました（`extends` を使用した継承パターンの適用を含む）。
+- 今後の仕様書のレビューや新規作成においては、エンドポイントのパスやメソッドだけでなく、対応する完全なデータモデル（Request/Response Schema）が記述されているかを徹底して確認します。

--- a/.specify/specs/tracking/schedule_tracker.md
+++ b/.specify/specs/tracking/schedule_tracker.md
@@ -55,6 +55,26 @@
 - `DELETE /api/schedules/{id}`
     - 指定したスケジュールを削除。
 
+### リクエスト/レスポンススキーマ
+
+```typescript
+// POST リクエスト
+interface ScheduleCreate {
+  baby_id: number
+  title: string
+  description?: string
+  scheduled_time: string // ISO 8601形式
+  is_completed?: boolean // デフォルト: false
+}
+
+// レスポンス
+interface ScheduleResponse extends ScheduleCreate {
+  id: number
+  user_id: number
+  created_at: string // ISO 8601形式
+}
+```
+
 ## 権限管理
 
 - `verify_baby_access` を通じて、対象の赤ちゃんへのアクセス権限があるユーザーのみが操作可能。


### PR DESCRIPTION
* 💡 **何を**: `.specify/specs/tracking/schedule_tracker.md` の「API」セクションに、リクエストとレスポンスのスキーマ（`ScheduleCreate`, `ScheduleResponse`）を追記しました。また、今回の学びを `.jules/scribe.md` に記録しました。
* 🔍 **発見**: バックエンドの `app/schemas/schedule.py` には `ScheduleCreate` と `ScheduleResponse` の Pydantic モデルが定義・使用されているにもかかわらず、スケジュール機能の仕様書にはこれらのデータモデル（TypeScript インターフェース）に関する記述が完全に欠落していました。
* 🎯 **影響**: フロントエンド開発者がスケジュール機能を実装・保守する際に、バックエンドのコードを直接読まずとも、APIの正確な型定義（必須フィールド、オプショナルフィールド、デフォルト値など）を仕様書から把握できるようになり、開発効率の向上と型の不一致によるバグの防止につながります。

---
*PR created automatically by Jules for task [14284957027540419574](https://jules.google.com/task/14284957027540419574) started by @eburairu*