### PR TITLE
🧹 Tidy: date-fnsの依存排除とuseIntervalの適用

### DIFF
--- a/.jules/tidy.md
+++ b/.jules/tidy.md
@@ -111,3 +111,7 @@
 ## 2026-03-02 - [Tidy: リファクタリング - 日付フォーマットの共通化]
 **学び:** コードベース全体で `format(new Date(), ...)` と date-fns の `ja` ロケールが各コンポーネントに直接インポートされ、散在しているパターン（アンチパターン）を発見しました。これにより、同じフォーマット文字列（例: `"MM/dd"`, `"PPP"`）が複数箇所にハードコードされ、保守性と可読性が低下していました。
 **アクション:** `frontend/lib/dateUtils.ts` に `formatMonthDay`, `formatJapaneseDatePPP`, `formatDateWithWeekday` などの意味のある名前を持つラッパー関数を追加し、これらを利用するように各コンポーネントをリファクタリングしました。今後も日付フォーマットは `dateUtils.ts` に集約し、コンポーネント側からは直接 date-fns を呼び出さないよう徹底します。
+
+## 2026-03-02 - [Tidy: リファクタリング - date-fns の依存排除と useEffect + setInterval の共通化]
+**学び:** `GrowthChart` や `feeding-stats` において、`date-fns` の `subMonths`, `subDays`, `formatDistanceToNow` といった関数が直接インポートされていました。これによりコード内でライブラリへの依存が分散し、将来的なバージョンアップや他のライブラリへの乗り換えが困難になります。また `useFeedingTimer` において、`useEffect` 内部で `setInterval` を利用し手動でクリーンアップを行っていましたが、プロジェクト内にはすでに `useInterval` フックが存在しており、これを活用していない冗長な記述でした。
+**アクション:** `dateUtils.ts` に `subtractMonths`, `subtractDays`, `formatTimeAgo` のラッパーを追加し、これらを経由して `date-fns` を利用するように修正しました。また、インターバル処理は必ず `useInterval` などの専用カスタムフックを使用し、ライフサイクル管理を宣言的かつ安全に行うように統一します。

--- a/frontend/components/feeding/feeding-stats.tsx
+++ b/frontend/components/feeding/feeding-stats.tsx
@@ -1,7 +1,6 @@
 import { FeedingStatsResult } from "@/lib/feedingUtils";
 import { Clock, Baby } from "lucide-react";
-import { formatDistanceToNow } from "date-fns";
-import { ja } from "date-fns/locale";
+import { formatTimeAgo } from "@/lib/dateUtils";
 import { StatsBlock } from "@/components/ui/stats-block";
 import { StatsCard } from "@/components/ui/stats-card";
 import { BREAST_SIDE_LABEL, NEXT_SIDE_GUIDE, FEEDING_TYPE_LABELS } from "@/constants/feeding";
@@ -12,10 +11,7 @@ interface FeedingStatsProps {
 
 export function FeedingStats({ summary }: FeedingStatsProps) {
     const timeSinceLast = summary.lastFeedingTime
-        ? formatDistanceToNow(new Date(summary.lastFeedingTime), {
-            addSuffix: true,
-            locale: ja,
-        })
+        ? formatTimeAgo(summary.lastFeedingTime)
         : "記録なし";
 
     const hasLeftRight = summary.todayLeftDuration > 0 || summary.todayRightDuration > 0;

--- a/frontend/components/growth/GrowthChart.tsx
+++ b/frontend/components/growth/GrowthChart.tsx
@@ -16,11 +16,10 @@ import { Button } from "@/components/ui/button"
 import type { Growth } from "@/types/growth"
 import { generateWhoSeries, mergeData } from "@/lib/growthUtils"
 import { useMemo, useState } from "react"
-import { subMonths, subDays } from "date-fns"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 import { useTheme } from "next-themes"
-import { formatMonthDay, formatDate } from "@/lib/dateUtils"
+import { formatMonthDay, formatDate, subtractDays, subtractMonths } from "@/lib/dateUtils"
 
 interface GrowthChartProps {
     records: Growth[]
@@ -53,7 +52,7 @@ export function GrowthChart({ records, babyBirthday, babyGender }: GrowthChartPr
     const defaultRange = useMemo(() => {
         if (records.length === 0) return { left: "dataMin" as const, right: "dataMax" as const };
         const latestDate = new Date(Math.max(...records.map(r => new Date(r.date).getTime())));
-        const sevenDaysAgo = subDays(latestDate, 7).getTime();
+        const sevenDaysAgo = subtractDays(latestDate, 7).getTime();
         const firstRecordDate = new Date(Math.min(...records.map(r => new Date(r.date).getTime()))).getTime();
         return {
             left: Math.max(sevenDaysAgo, firstRecordDate),
@@ -72,12 +71,12 @@ export function GrowthChart({ records, babyBirthday, babyGender }: GrowthChartPr
             setLeft("dataMin");
             setRight("dataMax");
         } else if (range === "7days") {
-            const startDate = subDays(latestDate, 7).getTime();
+            const startDate = subtractDays(latestDate, 7).getTime();
             const firstRecordDate = new Date(Math.min(...records.map(r => new Date(r.date).getTime()))).getTime();
             setLeft(Math.max(startDate, firstRecordDate));
             setRight(latestDate.getTime());
         } else {
-            const startDate = subMonths(latestDate, range).getTime();
+            const startDate = subtractMonths(latestDate, range).getTime();
             const firstRecordDate = new Date(Math.min(...records.map(r => new Date(r.date).getTime()))).getTime();
             setLeft(Math.max(startDate, firstRecordDate));
             setRight(latestDate.getTime());

--- a/frontend/hooks/useFeedingTimer.ts
+++ b/frontend/hooks/useFeedingTimer.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect } from "react"
+import { useCallback } from "react"
 import { useFeedingTimerStore } from "@/stores/feedingTimerStore"
 import { formatTimeMMSS } from "@/lib/ageUtils"
 import { api } from "@/lib/api"
+import { useInterval } from "./useInterval"
 
 export type ActiveBreastSide = "LEFT" | "RIGHT" | null
 
@@ -29,15 +30,12 @@ export function useFeedingTimer({
     } = useFeedingTimerStore()
 
     // 1秒ごとにストアの tick を呼び出し、経過時間を更新する
-    useEffect(() => {
-        if (!activeSide) return
-        
-        const interval = setInterval(() => {
+    useInterval(
+        () => {
             tick()
-        }, 1000)
-        
-        return () => clearInterval(interval)
-    }, [activeSide, tick])
+        },
+        activeSide ? 1000 : null
+    )
 
     /**
      * 現在のタイマー状態をサーバーに保存する。

--- a/frontend/lib/dateUtils.ts
+++ b/frontend/lib/dateUtils.ts
@@ -1,4 +1,4 @@
-import { format, isToday as isTodayFns } from "date-fns";
+import { format, isToday as isTodayFns, formatDistanceToNow as formatDistanceToNowFns, subMonths as subMonthsFns, subDays as subDaysFns } from "date-fns";
 import { ja } from "date-fns/locale";
 
 /**
@@ -103,4 +103,28 @@ export function formatDateWithWeekday(date: Date | string | number): string {
 export function formatTimeWithSeconds(date: Date | string | number): string {
   const d = typeof date === "string" || typeof date === "number" ? new Date(date) : date;
   return format(d, "HH:mm:ss", { locale: ja });
+}
+
+/**
+ * Returns the distance between the given date and now in words.
+ */
+export function formatTimeAgo(date: Date | string | number): string {
+  const d = typeof date === "string" || typeof date === "number" ? new Date(date) : date;
+  return formatDistanceToNowFns(d, { addSuffix: true, locale: ja });
+}
+
+/**
+ * Subtracts the given number of months from the given date.
+ */
+export function subtractMonths(date: Date | string | number, amount: number): Date {
+  const d = typeof date === "string" || typeof date === "number" ? new Date(date) : date;
+  return subMonthsFns(d, amount);
+}
+
+/**
+ * Subtracts the given number of days from the given date.
+ */
+export function subtractDays(date: Date | string | number, amount: number): Date {
+  const d = typeof date === "string" || typeof date === "number" ? new Date(date) : date;
+  return subDaysFns(d, amount);
 }


### PR DESCRIPTION
💡 何を: 実施したリファクタリングや共通化の内容
- `date-fns` から `formatDistanceToNow`, `subMonths`, `subDays` をコンポーネントで直接インポート・利用していた箇所を、共通ユーティリティ `frontend/lib/dateUtils.ts` 内のラッパー関数 (`formatTimeAgo`, `subtractMonths`, `subtractDays`) に集約しました。
- `frontend/hooks/useFeedingTimer.ts` にて、タイマー処理に `useEffect` と `setInterval` を手動で組み合わせていたものを、安全な共通フック `useInterval` に置き換えました。
- `.jules/tidy.md` に今回の学びと今後のアクションを追記しました。

🎯 なぜ: それがどのように可読性や保守性を向上させるか
- `date-fns` のような外部ライブラリへの依存が各ファイルに分散すると、ライブラリのバージョンアップや他のライブラリ（例: `dayjs`）への乗り換えが困難になります。`dateUtils.ts` にロジックを集約することで、コードの一貫性と保守性が向上します。
- タイマー（インターバル）処理は、クリーンアップ処理の記述漏れなどがバグの温床になりやすいため、宣言的に記述できる `useInterval` カスタムフックを使用することで、ライフサイクル管理を安全かつシンプルに行えます。

🛡️ 安全性: 既存の機能に影響を与えないことをどのように確認したか
- `pnpm lint` を実行し、構文エラーや未使用変数の問題がないことを確認しました。
- `pnpm test` を実行し、すべてのユニットテストがパスすることを確認しました。
- `pnpm build` を実行し、プロダクションビルドが正常に完了することを確認しました。
- コードレビューを行い、`useInterval` の存在および参照関係が正しいことを検証しました。

---
*PR created automatically by Jules for task [3218248177738088258](https://jules.google.com/task/3218248177738088258) started by @eburairu*