### PR TITLE
fix: 通知センターのアイコン背景を正六角形（Hexagonコンポーネント）に変更

### DIFF
--- a/frontend/components/notifications/NotificationItem.tsx
+++ b/frontend/components/notifications/NotificationItem.tsx
@@ -5,6 +5,7 @@ import { Baby, MessageCircle, Sparkles, Bell, Clock, Loader2 } from "lucide-reac
 import { cn } from "@/lib/utils"
 import type { AppNotification } from "@/hooks/useNotifications"
 import { markAsRead } from "@/hooks/useNotifications"
+import { Hexagon } from "@/components/ui/hexagon"
 
 const TYPE_ICON: Record<AppNotification["type"], React.ReactNode> = {
     family_record: <Baby className="h-4 w-4 text-rose-500" />,
@@ -73,16 +74,18 @@ export function NotificationItem({ notification, onRead, onClick }: Props) {
                 isProcessing && "opacity-70 cursor-wait"
             )}
         >
-            <div
-                className="mt-0.5 shrink-0 flex h-8 w-8 items-center justify-center bg-white dark:bg-zinc-800"
-                style={{ clipPath: "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)" }}
+            <Hexagon
+                size={32}
+                className="mt-0.5 shrink-0 text-white dark:text-zinc-800"
+                borderWidth={0}
+                borderColor="transparent"
             >
                 {isProcessing ? (
                     <Loader2 className="h-4 w-4 animate-spin text-indigo-500" />
                 ) : (
                     TYPE_ICON[notification.type]
                 )}
-            </div>
+            </Hexagon>
             <div className="flex-1 min-w-0">
                 <p className={cn(
                     "text-sm text-gray-800 dark:text-zinc-100 leading-snug",


### PR DESCRIPTION
## 変更内容

- `NotificationItem` のアイコンコンテナを `rounded-full`（円形）から共通の `Hexagon` コンポーネント（`@/components/ui/hexagon`）に変更
- clip-pathインラインスタイルではなく既存の共通コンポーネントを使用

## 変更ファイル

- `frontend/components/notifications/NotificationItem.tsx`