### PR TITLE
chore: タスク完了時のプッシュ通知ルールをCLAUDE.mdとGEMINI.mdに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,19 @@ git add frontend/openapi.json
 - `.venv`・`node_modules` — シンボリックリンク（ワークツリー由来）
 - `*.pem`・`*.key`・`*.cert` — 秘密鍵・証明書ファイル
 
+## タスク完了時のプッシュ通知
+
+タスクが完了したら必ず以下のコマンドで通知を送る（トークンは `.env` の `MOSHI_TOKEN`）:
+
+```bash
+source .env 2>/dev/null || true
+curl -X POST https://api.getmoshi.app/api/webhook \
+  -H "Content-Type: application/json" \
+  -d "{\"token\": \"$MOSHI_TOKEN\", \"title\": \"Done\", \"message\": \"Brief summary\"}"
+```
+
+`message` にはタスクの簡潔な要約を英語で記載する。
+
 ## 開発ワークフロー
 
 ワークツリー作成・PR作成・クリーンアップのワークフローは各スクリプトを参照:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -94,6 +94,19 @@ sh scripts/check_staged_files.sh
 - `.venv`・`node_modules` — ワークツリー由来のシンボリックリンク
 - `*.pem`・`*.key`・`*.cert` — 秘密鍵・証明書ファイル
 
+### タスク完了時のプッシュ通知
+
+タスクが完了したら必ず以下のコマンドで通知を送る（トークンは `.env` の `MOSHI_TOKEN`）:
+
+```bash
+source .env 2>/dev/null || true
+curl -X POST https://api.getmoshi.app/api/webhook \
+  -H "Content-Type: application/json" \
+  -d "{\"token\": \"$MOSHI_TOKEN\", \"title\": \"Done\", \"message\": \"Brief summary\"}"
+```
+
+`message` にはタスクの簡潔な要約を英語で記載する。
+
 ---
 
 ## Gemini CLI の活用モード


### PR DESCRIPTION
## 変更内容

タスク完了時に Moshi プッシュ通知を送るルールを両 AI エージェント向け設定ファイルに追加。

- `CLAUDE.md` — 「タスク完了時のプッシュ通知」セクションを追加
- `GEMINI.md` — 「タスク完了時のプッシュ通知」を「絶対に守るべきルール」内に追加