### PR TITLE
fix: おむつ統計のうんちアイコンをBiohazardに統一

### DIFF
--- a/frontend/components/diaper/DiaperStats.tsx
+++ b/frontend/components/diaper/DiaperStats.tsx
@@ -1,8 +1,8 @@
 import { Diaper } from "@/types/diaper"
-import { Droplets, Trash2 } from "lucide-react"
 import { StatsBlock } from "@/components/ui/stats-block"
 import { calculateDiaperStats, normalizeDiaperFromEntity } from "@/lib/diaperUtils"
 import { StatsCard } from "@/components/ui/stats-card"
+import { AppIcons } from "@/constants/icons"
 
 interface Props {
     diapers: Diaper[]
@@ -17,7 +17,7 @@ export function DiaperStats({ diapers }: Props) {
         <StatsCard>
             <div className="grid grid-cols-2 gap-4">
                 <StatsBlock
-                    icon={Droplets}
+                    icon={AppIcons.diaperWet}
                     label="おしっこ"
                     value={`${stats.wetCount}回`}
                     color="amber"
@@ -27,7 +27,7 @@ export function DiaperStats({ diapers }: Props) {
                     </p>
                 </StatsBlock>
                 <StatsBlock
-                    icon={Trash2}
+                    icon={AppIcons.diaperDirty}
                     label="うんち"
                     value={`${stats.dirtyCount}回`}
                     color="amber"


### PR DESCRIPTION
## 問題

`DiaperStats`（おむつ記録ページの統計ブロック）でうんちアイコンに `Trash2` を直接インポートして使っており、`AppIcons.diaperDirty`（Biohazard）と不一致だった。

おしっこも `Droplets` を直接使っており、同様に統一されていなかった。

## 修正内容

`DiaperStats.tsx` のアイコン参照を `AppIcons.diaperWet` / `AppIcons.diaperDirty` に変更し、`constants/icons.ts` の定義と一致させた。