### PR TITLE
🎨 Palette: ミルク量調整ボタンにaria-labelを追加

### DIFF
--- a/frontend/components/feeding/BottleFeedingFields.tsx
+++ b/frontend/components/feeding/BottleFeedingFields.tsx
@@ -57,6 +57,7 @@ export function BottleFeedingFields({ form }: BottleFeedingFieldsProps) {
                                         form.setValue("amount_ml", Math.max(0, current - 10), { shouldValidate: true });
                                     }}
                                     className="h-10 w-10 shrink-0"
+                                    aria-label="減らす"
                                 >
                                     <Minus className="h-4 w-4" />
                                 </Button>
@@ -70,6 +71,7 @@ export function BottleFeedingFields({ form }: BottleFeedingFieldsProps) {
                                         form.setValue("amount_ml", Math.min(500, current + 10), { shouldValidate: true });
                                     }}
                                     className="h-10 w-10 shrink-0"
+                                    aria-label="増やす"
                                 >
                                     <Plus className="h-4 w-4" />
                                 </Button>


### PR DESCRIPTION
💡 何を:
`BottleFeedingFields.tsx` のミルク量を増減するアイコンのみのボタン（Minus / Plus）に `aria-label="減らす"` と `aria-label="増やす"` を追加しました。

🎯 なぜ:
スクリーンリーダーを利用するユーザーが、このボタンが何の機能を持つかを音声で認識できるようにするためです。

📸 Before/After:
視覚的な変更はありません。

♿ アクセシビリティ:
アイコンのみのボタン（`size="icon"`）に対して、テキストによる代替説明 (`aria-label`) を提供しました。

---
*PR created automatically by Jules for task [6669267490557550361](https://jules.google.com/task/6669267490557550361) started by @eburairu*