### PR TITLE
fix: ScrollToTopボタンのシャドウを六角形形状に合わせてdrop-shadowに変更

### DIFF
--- a/frontend/components/ui/scroll-to-top-button.tsx
+++ b/frontend/components/ui/scroll-to-top-button.tsx
@@ -29,7 +29,7 @@ export function ScrollToTopButton({ hasBottomBar = false }: { hasBottomBar?: boo
             onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
             variant="primary"
             size={56}
-            className="shadow-lg"
+            className="drop-shadow-lg"
             aria-label="ページトップへ戻る"
             icon={<ArrowUp className="h-5 w-5" />}
           />


### PR DESCRIPTION
## 変更内容

- ScrollToTopButton の HexagonButton に付いていた shadow-lg（box-shadow）を drop-shadow-lg（filter: drop-shadow）に変更

## 原因

shadow-lg は CSS の box-shadow を使用するため、要素のボックス（長方形）にシャドウがかかる。六角形ボタンには合わず、円形・矩形のシャドウになっていた。

## 修正

drop-shadow-lg に変更することで filter: drop-shadow() が適用され、SVGの六角形形状に沿ったシャドウが表示される。