### PR TITLE
ci: develop->mainのPRでCIが二重実行されないよう修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
## 変更内容

release.ymlの`pull_request`トリガーを削除。

## 背景

`develop -> main` のPR時に ci.yml と release.yml が両方トリガーされ、バリデーションジョブ（フロントエンドビルド・バックエンドテスト・スキーマ検証）が二重実行されていた。

release.yml は `push`（マージ後）のみを対象とし、PR時のバリデーションは ci.yml に一本化する。