### PR TITLE
fix: ダッシュボード2段階スケルトンのウィジェットスタイルを統一

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { DashboardSkeleton } from "@/components/dashboard/DashboardSkeleton"
 import { PullToRefresh } from "@/components/ui/pull-to-refresh"
 import { HoneycombGrid } from "@/components/ui/honeycomb-grid"
+import { HexagonWidgetCard } from "@/components/dashboard/HexagonWidgetCard"
 import { DASHBOARD_UI } from "@/constants/dashboard"
 import dynamic from "next/dynamic"
 import { resolveThreshold } from '@/lib/thresholdUtils'
@@ -115,7 +116,11 @@ export default function DashboardPage() {
                                     animate={false}
                                 >
                                     {[...Array(7)].map((_, i) => (
-                                        <div key={i} className="animate-pulse bg-muted/50 w-full h-full [clip-path:polygon(50%_0%,100%_25%,100%_75%,50%_100%,0%_75%,0%_25%)]" />
+                                        <HexagonWidgetCard
+                                            key={i}
+                                            isSkeleton
+                                            size={honeycombSize}
+                                        />
                                     ))}
                                 </HoneycombGrid>
                             </motion.div>


### PR DESCRIPTION
## 変更内容

初回ロード時のスケルトン（DashboardSkeleton）と、baby選択後のレコードロード時のスケルトンで、ウィジェットの見た目が異なっていた問題を修正。

- **修正前**: 2段階目のスケルトンはraw divのclip-pathで六角形を生成しており、影・カラー等のスタイルが欠如
- **修正後**: HexagonWidgetCard isSkeleton={true} を使用し、初回スケルトンと同一の見た目に統一

## 変更ファイル

- frontend/app/(dashboard)/dashboard/page.tsx