### PR TITLE
refactor: 六角形の形状定義を定数化し共通化

### DIFF
--- a/frontend/components/ui/hexagon.tsx
+++ b/frontend/components/ui/hexagon.tsx
@@ -22,6 +22,9 @@ export const HEX_CONSTANTS = {
   POINTY_W_TO_H: Math.sqrt(3) / 2, // 0.866
   // Flat-topped の場合の幅と高さの比率 (height/width)
   FLAT_H_TO_W: Math.sqrt(3) / 2,
+  // clip-path 用のポリゴン文字列
+  POLYGON_POINTY: "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)",
+  POLYGON_FLAT: "polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)",
 };
 
 export const Hexagon = ({
@@ -101,8 +104,8 @@ export const Hexagon = ({
         height: effectiveSize.height,
         // コンテナ自体も六角形に近い形にしてヒットエリアを調整
         clipPath: pointy 
-          ? "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)"
-          : "polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)"
+          ? HEX_CONSTANTS.POLYGON_POINTY
+          : HEX_CONSTANTS.POLYGON_FLAT
       }}
       {...props}
     >


### PR DESCRIPTION
## 概要
clip-path を使用して六角形を表現しているポリゴン文字列を `Hexagon.tsx` 内の `HEX_CONSTANTS` に定数として抽出し、共通化しました。

## 変更内容
- `frontend/components/ui/hexagon.tsx`: `POLYGON_POINTY` および `POLYGON_FLAT` 定数を追加し、コンポーネント内で使用。
- 最新の `develop` にて、ダッシュボード等の手動 `clip-path` 指定は既に `<Hexagon />` コンポーネントへの移行が完了していたため、今回は定数の抽出と適用を中心に行いました。

Co-Authored-By: Gemini <gemini@google.com>
