### PR TITLE
feat: 授乳記録ページに7日間トレンドグラフを追加

### DIFF
--- a/frontend/app/(dashboard)/feeding/page.tsx
+++ b/frontend/app/(dashboard)/feeding/page.tsx
@@ -5,6 +5,7 @@ import { AppIcons } from "@/constants/icons"
 import { useFeeding } from "@/hooks/useFeeding"
 import { useRecordPage } from "@/hooks/useRecordPage"
 import { FeedingStats } from "@/components/feeding/feeding-stats"
+import { FeedingChart } from "@/components/feeding/FeedingChart"
 import { FeedingForm } from "@/components/feeding/feeding-form"
 import { FeedingHistory } from "@/components/feeding/feeding-history"
 import { TipsCard } from "@/components/ui/tips-card"
@@ -58,6 +59,8 @@ export default function FeedingPage() {
             onRefresh={refreshFeedings}
         >
             <FeedingStats summary={summary} />
+
+            <FeedingChart feedings={feedings ?? []} />
 
             <TipsCard {...feedingTips} />
 

--- a/frontend/components/feeding/FeedingChart.tsx
+++ b/frontend/components/feeding/FeedingChart.tsx
@@ -1,0 +1,127 @@
+"use client"
+import {
+    ComposedChart,
+    Bar,
+    Line,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+    Legend,
+} from "recharts"
+import { useTheme } from "next-themes"
+import { useMemo } from "react"
+import { StatsCard } from "@/components/ui/stats-card"
+import { calculateDailyStats, NormalizedFeeding } from "@/lib/feedingUtils"
+import { normalizeFeedingFromEntity } from "@/lib/feedingUtils"
+import type { Feeding } from "@/types/feeding"
+
+interface FeedingChartProps {
+    feedings: Feeding[]
+}
+
+export function FeedingChart({ feedings }: FeedingChartProps) {
+    const { resolvedTheme } = useTheme()
+    const isDark = resolvedTheme === "dark"
+
+    const data = useMemo(() => {
+        const normalized = feedings.map(normalizeFeedingFromEntity)
+        return calculateDailyStats(normalized, 7)
+    }, [feedings])
+
+    const hasAny = data.some(d => d.count > 0)
+
+    const gridColor = isDark ? "#3f3f46" : "#e5e7eb"
+    const textColor = isDark ? "#a1a1aa" : "#6b7280"
+    const tooltipBg = isDark ? "#18181b" : "#ffffff"
+    const tooltipBorder = isDark ? "#3f3f46" : "#e5e7eb"
+
+    const hasBreast = data.some(d => d.breastMin > 0)
+    const hasBottle = data.some(d => d.bottleMl > 0)
+
+    return (
+        <StatsCard>
+            <p className="text-xs font-medium text-gray-500 dark:text-zinc-400 mb-3">7日間の推移</p>
+            {!hasAny ? (
+                <p className="text-sm text-gray-400 dark:text-zinc-500 text-center py-8">記録がありません</p>
+            ) : (
+                <ResponsiveContainer width="100%" height={200}>
+                    <ComposedChart data={data} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+                        <XAxis
+                            dataKey="date"
+                            tick={{ fontSize: 11, fill: textColor }}
+                            axisLine={false}
+                            tickLine={false}
+                        />
+                        <YAxis
+                            yAxisId="count"
+                            allowDecimals={false}
+                            tick={{ fontSize: 11, fill: textColor }}
+                            axisLine={false}
+                            tickLine={false}
+                            width={24}
+                        />
+                        {(hasBreast || hasBottle) && (
+                            <YAxis
+                                yAxisId="amount"
+                                orientation="right"
+                                tick={{ fontSize: 11, fill: textColor }}
+                                axisLine={false}
+                                tickLine={false}
+                                width={32}
+                            />
+                        )}
+                        <Tooltip
+                            contentStyle={{
+                                backgroundColor: tooltipBg,
+                                border: `1px solid ${tooltipBorder}`,
+                                borderRadius: "8px",
+                                fontSize: "12px",
+                            }}
+                            formatter={(value, name) => {
+                                const v = value as number
+                                if (name === "回数") return [`${v}回`, name]
+                                if (name === "母乳(分)") return [`${v}分`, name]
+                                if (name === "ミルク(ml)") return [`${v}ml`, name]
+                                return [v, name as string]
+                            }}
+                        />
+                        <Legend
+                            wrapperStyle={{ fontSize: "11px", paddingTop: "8px" }}
+                        />
+                        <Bar
+                            yAxisId="count"
+                            dataKey="count"
+                            name="回数"
+                            fill={isDark ? "#fb7185" : "#f43f5e"}
+                            radius={[3, 3, 0, 0]}
+                            maxBarSize={32}
+                        />
+                        {hasBreast && (
+                            <Line
+                                yAxisId="amount"
+                                dataKey="breastMin"
+                                name="母乳(分)"
+                                stroke={isDark ? "#818cf8" : "#6366f1"}
+                                dot={false}
+                                strokeWidth={2}
+                            />
+                        )}
+                        {hasBottle && (
+                            <Line
+                                yAxisId="amount"
+                                dataKey="bottleMl"
+                                name="ミルク(ml)"
+                                stroke={isDark ? "#fbbf24" : "#f59e0b"}
+                                dot={false}
+                                strokeWidth={2}
+                            />
+                        )}
+                    </ComposedChart>
+                </ResponsiveContainer>
+            )}
+        </StatsCard>
+    )
+}

--- a/frontend/lib/feedingUtils.ts
+++ b/frontend/lib/feedingUtils.ts
@@ -3,6 +3,7 @@ import { Feeding, FeedingType, BreastSide, FeedingCreate, BottleContentType, Fee
 import { formatElapsed } from "@/lib/ageUtils"
 import { isToday } from "@/lib/dateUtils"
 import { FeedingFormValues } from "@/schemas/feeding"
+import { format, subDays, isSameDay } from "date-fns"
 
 export interface NormalizedFeeding {
     id: number
@@ -118,6 +119,33 @@ export function calculateFeedingStats(feedings: NormalizedFeeding[]): FeedingSta
         lastBottleContentType,
         lastElapsed: lastFeeding ? formatElapsed(lastFeeding.timestamp) : null
     }
+}
+
+export interface DailyFeedingData {
+    date: string    // "M/d" 表示用
+    count: number
+    breastMin: number
+    bottleMl: number
+}
+
+export function calculateDailyStats(feedings: NormalizedFeeding[], days = 7): DailyFeedingData[] {
+    const today = new Date()
+    return Array.from({ length: days }, (_, i) => {
+        const day = subDays(today, days - 1 - i)
+        const dayFeedings = feedings.filter(f => isSameDay(new Date(f.timestamp), day))
+        let breastMin = 0
+        let bottleMl = 0
+        for (const f of dayFeedings) {
+            if (f.type === 'BREAST' || f.type === 'MIXED') breastMin += f.duration
+            if (f.type === 'BOTTLE' || f.type === 'MIXED') bottleMl += f.amount
+        }
+        return {
+            date: format(day, 'M/d'),
+            count: dayFeedings.length,
+            breastMin,
+            bottleMl,
+        }
+    })
 }
 
 interface BuildFeedingPayloadOptions {


### PR DESCRIPTION
## 変更内容
- 授乳記録統計（FeedingStats）の下に過去7日間のグラフを追加
- 棒グラフ: 1日の授乳回数（rose色）
- 折れ線: 母乳合計時間（分、indigo色）
- 折れ線: ミルク合計量（ml、amber色）
- ダークモード対応
- 追加APIなし（既存の feedings データを再利用）

## 変更ファイル
- `frontend/lib/feedingUtils.ts`: `calculateDailyStats` 関数を追加
- `frontend/components/feeding/FeedingChart.tsx`: 新規グラフコンポーネント
- `frontend/app/(dashboard)/feeding/page.tsx`: FeedingChart を挿入