### PR TITLE
✍️ Scribe: 同期 API 仕様と実装 (ページネーション、統合レコード)

### DIFF
--- a/.specify/specs/auth/superadmin.md
+++ b/.specify/specs/auth/superadmin.md
@@ -86,12 +86,12 @@ def get_current_superadmin(
 以下のエンドポイントを `app/routers/admin.py` に実装する。
 
 - `GET /api/admin/stats`: システム全体の統計情報（ユーザー数、家族数、記録数、アクティブユーザー数）を取得
-- `GET /api/admin/families`: 家族一覧を取得（ページネーション、検索対応）
+- `GET /api/admin/families?skip={skip}&limit={limit}&search={search}`: 家族一覧を取得（ページネーション、検索対応。デフォルト: skip=0, limit=100）
 - `POST /api/admin/families`: 管理者による家族の新規作成
 - `GET /api/admin/families/{family_id}`: 家族の詳細情報（メンバー、赤ちゃん一覧）を取得
-- `GET /api/admin/users`: ユーザー一覧を取得（ページネーション、検索対応）
+- `GET /api/admin/users?skip={skip}&limit={limit}`: ユーザー一覧を取得（ページネーション対応。デフォルト: skip=0, limit=100）
 - `PATCH /api/admin/users/{user_id}/superadmin`: SuperAdmin 権限を切り替え
-- `GET /api/admin/audit-logs`: システム全体の監査ログを取得
+- `GET /api/admin/audit-logs?skip={skip}&limit={limit}`: システム全体の監査ログを取得（ページネーション対応。デフォルト: skip=0, limit=100）
 
 ---
 

--- a/.specify/specs/infrastructure/system_design.md
+++ b/.specify/specs/infrastructure/system_design.md
@@ -98,6 +98,8 @@ baby-app/
 - **`type`**: 記録種別 (`feeding`, `sleep`, `diaper`, `growth`, `contraction`, `note`)
 - **`timestamp`**: 記録の主たる日時
 - **`details`**: 種別ごとの詳細データ（`notes` など）を格納するオブジェクト
+- **`comment_count`**: 記録に対するコメント数
+- **`recorded_by_display_name`**: 記録者の表示名
 
 ## 権限管理
 

--- a/.specify/specs/social/record_comments.md
+++ b/.specify/specs/social/record_comments.md
@@ -95,6 +95,7 @@ class UnifiedRecord(BaseModel):
     timestamp: datetime
     details: dict
     comment_count: int = 0  # 追加
+    recorded_by_display_name: Optional[str] = None
 ```
 
 ### API エンドポイント

--- a/.specify/specs/ui/dashboard.md
+++ b/.specify/specs/ui/dashboard.md
@@ -160,7 +160,7 @@ Botoro のメイン画面（ホーム）となるダッシュボードの仕様�
 
 - **GET /api/babies/{baby_id}/records**
     - **Query Params**:
-        - `limit`: 取得件数 (default: 50, min: 1, max: 1000)
+        - `limit`: 取得件数 (default: 20, min: 1, max: 100)
     - **Response**: `List[UnifiedRecord]`
 
 **レスポンススキーマ (`UnifiedRecord`)**


### PR DESCRIPTION
### 💡 何を: 修正した仕様書の箇所と内容
* `superadmin.md` および `dashboard.md`: ページネーションパラメータ (`skip`, `limit`) のデフォルト値と最大値を、バックエンドの実装（`app/core/constants.py`）に合わせて修正しました。
* `record_comments.md` および `system_design.md`: 統合レコード (`UnifiedRecord`) を返す API のレスポンススキーマ仕様に、`comment_count`（コメント数）と `recorded_by_display_name`（記録者の表示名）を追加しました。

### 🔍 発見: 実際のコードと仕様書がどのように乖離していたか
* **ページネーション**: 仕様書で任意に設定されていた `limit` の最大値 (例: 1000) やデフォルト値 (例: 50) が、実際の `app/core/constants.py` で定義されている定数（`MAX_PAGINATION_LIMIT = 100`, `DEFAULT_PAGINATION_LIMIT = 20`）やルーターの実装 (`app/routers/admin.py`, `app/routers/baby.py`) と乖離していました。
* **スキーマ拡充**: フロントエンドの UI で利用するためにルーター側 (`app/routers/baby.py`) で結合されている動的な計算フィールド (`comment_count`, `recorded_by_display_name`) が、仕様書上のレスポンススキーマ定義から漏れていました。

### 🎯 影響: この更新によって防げる誤解や、開発者体験の向上
* スキーマ定義が実装と一致したため、フロントエンド開発者がタイムラインコンポーネントを実装・修正する際、これらのフィールドを安全に参照できるようになります。
* ページネーションの限界値が明確になり、不正なクエリ設計による API のエラー（422 Validation Error）を未然に防ぐことができます。

---
*PR created automatically by Jules for task [5827245057546767356](https://jules.google.com/task/5827245057546767356) started by @eburairu*