### PR TITLE
feat: 授乳・おむつ・睡眠チャートに生活リズムビューを追加

### DIFF
--- a/frontend/__tests__/rhythmUtils.test.ts
+++ b/frontend/__tests__/rhythmUtils.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect } from 'vitest'
 import { buildRhythmData, calcMedianIntervalMin } from '../lib/rhythmUtils'
 
 // テスト用の固定日時: 2026-03-05 (今日) として各テストで使う
+// タイムスタンプは JST (+09:00) で記述する
 const TODAY = '2026-03-05'
 
 function ts(date: string, time: string) {
-  return `${date}T${time}:00.000Z`
+  return `${date}T${time}:00+09:00`
 }
 
 describe('buildRhythmData', () => {
@@ -44,9 +45,9 @@ describe('buildRhythmData', () => {
     expect(result).toHaveLength(0)
   })
 
-  it('timeMinutes が正しく計算される (UTC 09:30 → 570)', () => {
+  it('timeMinutes が JST で正しく計算される (09:30 JST → 570)', () => {
     const items = [
-      { timestamp: '2026-03-05T09:30:00.000Z', label: 'テスト' },
+      { timestamp: '2026-03-05T09:30:00+09:00', label: 'テスト' },
     ]
     const result = buildRhythmData(items, TODAY)
     expect(result[0].timeMinutes).toBe(9 * 60 + 30) // 570
@@ -82,47 +83,45 @@ describe('buildRhythmData', () => {
 describe('calcMedianIntervalMin', () => {
   it('2件の記録から間隔を計算する', () => {
     const timestamps = [
-      '2026-03-05T06:00:00Z',
-      '2026-03-05T09:00:00Z', // 3時間後
+      '2026-03-05T06:00:00+09:00',
+      '2026-03-05T09:00:00+09:00', // 3時間後
     ]
     const result = calcMedianIntervalMin(timestamps)
-    expect(result).toBe(180) // 3時間
+    expect(result).toBe(180)
   })
 
   it('3件の記録から中央値を返す', () => {
     // 間隔: 120分, 180分 → 中央値 150分
     const timestamps = [
-      '2026-03-05T06:00:00Z',
-      '2026-03-05T08:00:00Z', // +120min
-      '2026-03-05T11:00:00Z', // +180min
+      '2026-03-05T06:00:00+09:00',
+      '2026-03-05T08:00:00+09:00', // +120min
+      '2026-03-05T11:00:00+09:00', // +180min
     ]
     const result = calcMedianIntervalMin(timestamps)
     expect(result).toBe(150)
   })
 
-  it('4件の記録から中央値（偶数）を返す', () => {
-    // 間隔: 60, 120, 180 → 中央値 = (120+60)/2... wait
-    // sorted intervals: [60, 120, 180] → length=3, mid=1 → 120
+  it('4件の記録から中央値（奇数個の間隔）を返す', () => {
+    // intervals: [60, 120, 180] → sorted → mid=1 → 120
     const timestamps = [
-      '2026-03-05T06:00:00Z',
-      '2026-03-05T07:00:00Z', // +60
-      '2026-03-05T09:00:00Z', // +120
-      '2026-03-05T12:00:00Z', // +180
+      '2026-03-05T06:00:00+09:00',
+      '2026-03-05T07:00:00+09:00', // +60
+      '2026-03-05T09:00:00+09:00', // +120
+      '2026-03-05T12:00:00+09:00', // +180
     ]
     const result = calcMedianIntervalMin(timestamps)
-    // intervals: [60, 120, 180] → sorted → mid=1 → 120
     expect(result).toBe(120)
   })
 
   it('1件以下の場合は null を返す', () => {
     expect(calcMedianIntervalMin([])).toBeNull()
-    expect(calcMedianIntervalMin(['2026-03-05T06:00:00Z'])).toBeNull()
+    expect(calcMedianIntervalMin(['2026-03-05T06:00:00+09:00'])).toBeNull()
   })
 
   it('順不同のタイムスタンプでも正しく計算する', () => {
     const timestamps = [
-      '2026-03-05T09:00:00Z',
-      '2026-03-05T06:00:00Z', // 順番が逆
+      '2026-03-05T09:00:00+09:00',
+      '2026-03-05T06:00:00+09:00', // 順番が逆
     ]
     const result = calcMedianIntervalMin(timestamps)
     expect(result).toBe(180)

--- a/frontend/components/charts/RhythmChartView.tsx
+++ b/frontend/components/charts/RhythmChartView.tsx
@@ -69,7 +69,7 @@ export function RhythmChartView({
         const last = new Date(lastTimestampISO)
         const predMs = last.getTime() + medianIntervalMin * 60 * 1000
         const pred = new Date(predMs)
-        predictionMinutes = pred.getUTCHours() * 60 + pred.getUTCMinutes()
+        predictionMinutes = pred.getHours() * 60 + pred.getMinutes()
     }
 
     const xTicks = [0, 360, 720, 1080, 1440]

--- a/frontend/lib/rhythmUtils.ts
+++ b/frontend/lib/rhythmUtils.ts
@@ -34,7 +34,7 @@ export function buildRhythmData(
 
         if (dayOffset === -1) continue
 
-        const timeMinutes = dt.getUTCHours() * 60 + dt.getUTCMinutes()
+        const timeMinutes = dt.getHours() * 60 + dt.getMinutes()
 
         result.push({
             dayOffset,


### PR DESCRIPTION
## 概要

授乳・おむつ・睡眠の各記録ページに「生活リズム」チャートビューを追加。
既存の「7日間の推移」棒グラフと同一カード内のタブで切り替えできます。

## 変更内容

### 新規
- `rhythmUtils.ts`: buildRhythmData / calcMedianIntervalMin（時刻はローカル時刻=JST）
- `ChartViewToggle.tsx`: 推移/リズム切り替えトグル
- `RhythmChartView.tsx`: Recharts ScatterChart ベースのドット散布図
- `SleepChart.tsx`: 睡眠ページ用チャート（推移+リズム）
- `rhythmUtils.test.ts`: ユニットテスト（+09:00 タイムスタンプ使用）

### 変更
- `FeedingChart.tsx` / `DiaperChart.tsx`: タブ切り替えとリズムビューを追加
- `sleep/page.tsx`: SleepChart を組み込み

## リズムビューの仕様
- X=時刻（0:00〜24:00 JST）、Y=日付（今日〜6日前）のドット散布図
- 授乳は母乳（Rose）とミルク（Amber）で色分け
- 5件以上の記録がある場合、中央値間隔から次回予測ラインを表示
- タブ選択状態を localStorage に保存

## テスト計画
- [ ] 授乳/おむつ/睡眠ページでリズムタブへの切り替えが動作する
- [ ] ドットの時刻が JST で正しく表示される
- [ ] 5件以上の記録がある場合に予測ラインが表示される
- [ ] タブ選択はリロード後も保持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)