### PR TITLE
✍️ Scribe: 授乳記録API仕様のレスポンスモデルとバックエンド実装の継承構造の同期

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -196,3 +196,15 @@
 
 - `schedule_tracker.md` を更新し、「リクエスト/レスポンススキーマ」セクションを新設。`ScheduleCreate` と `ScheduleResponse` のTypeScriptインターフェースを、既存のPydanticモデルに合わせて正確に定義しました（`extends` を使用した継承パターンの適用を含む）。
 - 今後の仕様書のレビューや新規作成においては、エンドポイントのパスやメソッドだけでなく、対応する完全なデータモデル（Request/Response Schema）が記述されているかを徹底して確認します。
+
+## 2026-03-05 - [授乳記録API仕様のレスポンスモデルとバックエンド実装の継承構造の同期]
+
+**学び:**
+
+- 授乳記録（`app/routers/feeding.py`）において、バックエンドのPydanticモデル（`app/schemas/feeding.py`）ではレスポンススキーマ（`FeedingResponse`）がリクエストスキーマ（`FeedingCreate`）を継承（`class FeedingResponse(FeedingCreate):`）して重複フィールドを省略しているにもかかわらず、仕様書（`.specify/specs/tracking/breastfeeding_tracker.md`）ではすべてのプロパティが再定義されており、冗長になっていた。
+- これは他ドメイン（Growth, Milestone, Scheduleなど）でも頻出している、仕様書のTypeScriptインターフェースと実装モデルの継承構造の乖離パターンである。
+
+**アクション:**
+
+- `breastfeeding_tracker.md` の `FeedingResponse` インターフェースを更新し、バックエンドの実装に合わせて `extends FeedingCreate` を使用して冗長なフィールドを削除し、一貫性を持たせた。
+- 今後仕様書をレビューする際は、レスポンススキーマがリクエストスキーマを継承している場合、TypeScriptインターフェース側でも適切に `extends` を用いて冗長な記述を避けることを徹底する。

--- a/.specify/specs/tracking/breastfeeding_tracker.md
+++ b/.specify/specs/tracking/breastfeeding_tracker.md
@@ -191,21 +191,9 @@ interface FeedingUpdate {
 ### レスポンススキーマ (`FeedingResponse`)
 
 ```typescript
-interface FeedingResponse {
+interface FeedingResponse extends FeedingCreate {
   id: number
-  baby_id: number
   user_id: number
-  feeding_time: string
-  feeding_type: "BREAST" | "BOTTLE" | "MIXED"
-  amount_ml: number | null
-  duration_minutes: number | null
-  left_breast_minutes: number | null
-  right_breast_minutes: number | null
-  last_breast_side: "LEFT" | "RIGHT" | "BOTH" | null
-  bottle_content_type: "FORMULA" | "EXPRESSED_MILK" | "MIXED" | null
-  feeding_completion: "FULL" | "PARTIAL" | null
-  burped: boolean | null
-  notes: string | null
   // 以下はRouterで付与される計算フィールド
   recorded_by_display_name: string | null // 記録者の表示名
   comment_count: number // コメント数（デフォルト: 0）


### PR DESCRIPTION
* 💡 何を: `breastfeeding_tracker.md` の `FeedingResponse` インターフェースを `extends FeedingCreate` を用いて更新し、重複するフィールドを削除した。
* 🔍 発見: バックエンド (`app/schemas/feeding.py`) の `FeedingResponse` が `FeedingCreate` を継承しているにもかかわらず、仕様書では全フィールドが再定義され冗長になっていた。
* 🎯 影響: 仕様書が実際のバックエンドの実装の継承構造と正確に一致するようになり、将来フィールドが追加された際の一貫性が向上した。

---
*PR created automatically by Jules for task [10531535611177334279](https://jules.google.com/task/10531535611177334279) started by @eburairu*