### PR TITLE
feat: 授乳・おむつ・睡眠チャートに生活リズムビューを追加

### DIFF
--- a/frontend/components/charts/RhythmChartView.tsx
+++ b/frontend/components/charts/RhythmChartView.tsx
@@ -78,8 +78,8 @@ function DropShape({ cx = 0, cy = 0, fill, opacity }: ShapeProps) {
     // 上が尖り下が丸い水滴形（teardrop）
     const d = [
         `M ${cx},${cy - R}`,
-        `C ${cx + R * 0.6},${cy - R * 0.3} ${cx + R},${cy + R * 0.3} ${cx},${cy + R}`,
-        `C ${cx - R},${cy + R * 0.3} ${cx - R * 0.6},${cy - R * 0.3} ${cx},${cy - R} Z`,
+        `C ${cx + R * 0.6},${cy - R * 0.3} ${cx + R},${cy + R * 0.7} ${cx},${cy + R}`,
+        `C ${cx - R},${cy + R * 0.7} ${cx - R * 0.6},${cy - R * 0.3} ${cx},${cy - R} Z`,
     ].join(" ")
     return <path d={d} fill={fill} opacity={opacity} />
 }

--- a/frontend/components/feeding/FeedingChart.tsx
+++ b/frontend/components/feeding/FeedingChart.tsx
@@ -162,7 +162,7 @@ export function FeedingChart({ feedings }: FeedingChartProps) {
                                     yAxisId="amount"
                                     dataKey="bottleMl"
                                     name="ミルク(ml)"
-                                    stroke={isDark ? "#fbbf24" : "#f59e0b"}
+                                    stroke={isDark ? "#60a5fa" : "#3b82f6"}
                                     dot={false}
                                     strokeWidth={2}
                                 />
@@ -174,7 +174,7 @@ export function FeedingChart({ feedings }: FeedingChartProps) {
                 <RhythmChartView
                     groups={[
                         { data: breastPoints, fill: isDark ? "#fb7185" : "#f43f5e", name: "母乳", shape: "heart" },
-                        { data: bottlePoints, fill: isDark ? "#fbbf24" : "#f59e0b", name: "ミルク", shape: "drop" },
+                        { data: bottlePoints, fill: isDark ? "#60a5fa" : "#3b82f6", name: "ミルク", shape: "drop" },
                     ]}
                     medianIntervalMin={medianIntervalMin}
                     lastTimestampISO={lastTimestamp}


### PR DESCRIPTION
## 概要

授乳・おむつ・睡眠の各記録ページに「生活リズムビュー」を追加。既存の7日間推移グラフと同一カード内でタブ切り替えできるようにする。

## 変更内容

### 新機能
- 授乳・おむつ・睡眠チャートに「推移 / リズム」トグルを追加
- リズムビュー: 過去7日間の記録を時刻×日付のシェイプ散布図で表示
- 種別別シェイプ: 母乳=ハート、ミルク=雫（青）、おしっこ=雫（空色）、うんち=上向き三角
- 次回予測ライン（中央値間隔）と「平均間隔: 約X時間」サマリー表示
- タブ選択状態を localStorage に保存・復元

### バグ修正・調整
- 時刻計算を UTC から JST（ローカル時刻）に修正
- ReactコンポーネントのdisplayNameを追加（Fast Refreshエラー対策）
- ミルクの色を Amber から Blue に変更（授乳記録リストのアイコン色と統一）
- 雫シェイプの下部をより丸みのある形状に修正

## テスト

- 授乳・おむつ・睡眠ページで「リズム」タブを切り替えて散布図が表示されることを確認
- 各シェイプ（ハート・雫・三角）が正しく描画されることを確認
- 記録が5件以上ある場合のみ予測ラインが表示されることを確認
- モバイル幅（375px）でも崩れないことを確認