### PR TITLE
fix: おむつ記録編集時のAPI Errorを修正

### DIFF
--- a/frontend/components/diaper/DiaperForm.tsx
+++ b/frontend/components/diaper/DiaperForm.tsx
@@ -139,7 +139,7 @@ export function DiaperForm({ babyId, initialData, defaultDiaperType, onSuccess, 
                  if (onUpdate) {
                      return await onUpdate(initialData.id, updatePayload)
                  } else {
-                     return await api.patch<Diaper>(`/diapers/${initialData.id}`, updatePayload)
+                     return await api.put<Diaper>(`/diapers/${initialData.id}`, updatePayload)
                  }
             } : undefined)
         } catch (e) {


### PR DESCRIPTION
## 原因

編集フォームが `PATCH /api/diapers/{id}` を呼んでいたが、バックエンドは `PUT` エンドポイントのみ存在するため 405 Method Not Allowed が発生していた。

## 修正内容

`DiaperForm.tsx` の更新リクエストを `api.patch` から `api.put` に変更。

## テスト手順

1. おむつ記録ページで既存記録の編集ボタンをクリック
2. 内容を変更して「更新する」を押す
3. API Errorが出ずに更新されることを確認