### PR TITLE
✍️ Scribe: 赤ちゃん権限設定APIのスキーマ定義を仕様書に同期

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -208,3 +208,12 @@
 
 - `breastfeeding_tracker.md` の `FeedingResponse` インターフェースを更新し、バックエンドの実装に合わせて `extends FeedingCreate` を使用して冗長なフィールドを削除し、一貫性を持たせた。
 - 今後仕様書をレビューする際は、レスポンススキーマがリクエストスキーマを継承している場合、TypeScriptインターフェース側でも適切に `extends` を用いて冗長な記述を避けることを徹底する。
+
+## 2026-03-05 - [赤ちゃん権限設定仕様書におけるスキーマ定義の欠落]
+
+**学び:**
+- 家族設定や赤ちゃん設定（Settings）の仕様書において、APIエンドポイントのパスやアクセス制御の記述はあるものの、リクエスト/レスポンススキーマ（TypeScriptインターフェース）の定義が完全に欠落しているパターンが見つかりました（例：`baby_permissions.md` における `BabyPermissionsResponse`, `BabyPermissionUpdate` など）。
+- トラッカー機能（Growth, Milestone等）だけでなく、設定画面ドメインでも同様の乖離（スキーマ定義の漏れ）が発生しやすいことが判明しました。
+
+**アクション:**
+- 今後はトラッカー機能に限らず、Settings関連の仕様書（`baby_permissions.md`, `family_settings.md` など）をレビュー・更新する際にも、APIエンドポイントに対応する完全なデータモデル（Request/Response Schema）が TypeScript インターフェース形式で記述されているかを徹底して確認・補完します。

--- a/.specify/specs/settings/baby_permissions.md
+++ b/.specify/specs/settings/baby_permissions.md
@@ -239,6 +239,44 @@ for record_type in VALID_RECORD_TYPES:
 
 **権限**: admin のみ
 
+### リクエスト/レスポンススキーマ
+
+```typescript
+type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule";
+
+// 単一の権限レコード（1ユーザー × 1record_type）
+interface BabyPermissionItem {
+  record_type: string;
+  can_view: boolean;
+}
+
+// 1ユーザーに対するすべての record_type の権限セット
+interface UserPermissionSet {
+  user_id: number;
+  username: string;
+  permissions: BabyPermissionItem[];
+}
+
+// GET レスポンス: 赤ちゃん 1 体の全メンバー権限
+interface BabyPermissionsResponse {
+  baby_id: number;
+  baby_name: string;
+  members: UserPermissionSet[];
+}
+
+// PUT 用: 1ユーザー × 1record_type の更新エントリ
+interface UserPermissionEntry {
+  user_id: number;
+  record_type: string;  // 有効値は ValidRecordType
+  can_view: boolean;
+}
+
+// PUT リクエストボディ: 赤ちゃん 1 体の全権限を一括更新
+interface BabyPermissionUpdate {
+  permissions: UserPermissionEntry[];
+}
+```
+
 ---
 
 ## フロントエンド実装


### PR DESCRIPTION
💡 何を: `.specify/specs/settings/baby_permissions.md` に `BabyPermissionsResponse` や `BabyPermissionUpdate` などのTypeScriptインターフェース定義を追記しました。

🔍 発見: `app/schemas/baby_permission.py` にはPydanticモデルが詳細に定義されていましたが、仕様書側にはリクエスト・レスポンススキーマのセクション自体が存在せず、フロントエンド向けの実装インターフェースが不明瞭な状態でした。

🎯 影響: これにより、フロントエンドエンジニアが権限管理ページを実装・改修する際に、バックエンドとの型定義のズレを防ぎ、シームレスな型連携が可能になります。

---
*PR created automatically by Jules for task [1504314694433408757](https://jules.google.com/task/1504314694433408757) started by @eburairu*