### PR TITLE
✍️ Scribe: 赤ちゃん管理設定API仕様と実装のスキーマ定義の同期

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -217,3 +217,12 @@
 
 **アクション:**
 - 今後はトラッカー機能に限らず、Settings関連の仕様書（`baby_permissions.md`, `family_settings.md` など）をレビュー・更新する際にも、APIエンドポイントに対応する完全なデータモデル（Request/Response Schema）が TypeScript インターフェース形式で記述されているかを徹底して確認・補完します。
+
+## 2026-03-06 - [赤ちゃん管理設定API仕様のTypeScriptスキーマ欠如の発見]
+
+**学び:**
+- 設定画面に関する仕様書（`baby_settings.md`）では、バックエンドのモデル（`BabyUpdate`など）を直接Pythonコードで示す記述のみがあり、フロントエンド向けに設計された共通の `BabyBase`, `BabyCreate`, `BabyUpdate`, `BabyResponse` の完全なTypeScriptインターフェース定義が欠如していた。
+- 他の設定関連ドキュメント（`baby_permissions.md` など）でも見られた傾向だが、トラッカー（記録系機能）に比べて、設定画面に関する仕様書はスキーマ定義が省略される、またはバックエンドのモデル定義のみで済まされる傾向が強い。
+
+**アクション:**
+- 設定仕様書や新規機能ドキュメントにおいて、バックエンドのPythonモデルだけでなく、対応する完全なデータモデル（Request/Response Schema）がフロントエンド側からどう扱われるかを示すTypeScriptインターフェースとして `extends` などを用いて正しく記述されているかを必ず確認・補完する。

--- a/.specify/specs/settings/baby_settings.md
+++ b/.specify/specs/settings/baby_settings.md
@@ -188,6 +188,8 @@ const babySchema = z.object({
 
 #### スキーマ定義
 
+**バックエンド (Pydantic Models)**
+
 `app/schemas/baby.py`
 
 ```python
@@ -206,6 +208,40 @@ class BabyUpdate(BaseModel):
         if v is None:
             raise ValueError('Name cannot be null')
         return v
+```
+
+**フロントエンド (TypeScript Interfaces)**
+
+```typescript
+type Gender = "boy" | "girl" | "unknown";
+
+interface BabyBase {
+  name: string;
+  birthday?: string | null;  // ISO 8601 YYYY-MM-DD
+  due_date?: string | null;  // ISO 8601 YYYY-MM-DD
+  gender?: Gender | null;
+  characteristics?: string | null;
+  feeding_threshold_minutes?: number | null;
+  diaper_threshold_minutes?: number | null;
+}
+
+interface BabyCreate extends BabyBase {}
+
+interface BabyUpdate {
+  name?: string;
+  birthday?: string | null;
+  due_date?: string | null;
+  gender?: Gender | null;
+  characteristics?: string | null;
+  feeding_threshold_minutes?: number | null;
+  diaper_threshold_minutes?: number | null;
+}
+
+interface BabyResponse extends BabyBase {
+  id: number;
+  family_id: number;
+  created_at: string; // ISO 8601
+}
 ```
 
 #### 削除時のカスケード仕様


### PR DESCRIPTION
💡 何を:
- `baby_settings.md` にフロントエンドで必要なTypeScriptインターフェースの定義を追加しました。
- `.jules/scribe.md` に、設定画面に関する仕様書はバックエンドのモデル記述に留まりやすく、フロントエンド側のスキーマが欠落しやすいという学びを追記しました。

🔍 発見:
- `app/schemas/baby.py` などのバックエンドのPydanticモデルは仕様書に記載されていましたが、それに対応するフロントエンド向けのTypeScriptインターフェース定義（`BabyBase`, `BabyCreate`, `BabyUpdate`, `BabyResponse` 等）が完全に欠如していました。
- これは以前の `baby_permissions.md` などでも見られた傾向であり、トラッカー系の仕様書と比べて設定・管理系の仕様書で発生しやすい乖離パターンでした。

🎯 影響:
- 完全なTypeScriptのインターフェース仕様が記載されたことで、フロントエンドエンジニアが赤ちゃん情報の編集や取得を実装する際、APIのレスポンスやリクエストの型定義（継承関係を含む）を迷いなく参照できるようになり、開発効率の向上とバグの防止につながります。

---
*PR created automatically by Jules for task [7516865118685524137](https://jules.google.com/task/7516865118685524137) started by @eburairu*