### PR TITLE
✍️ Scribe: 予防接種機能の権限設定の実装との同期

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -226,3 +226,7 @@
 
 **アクション:**
 - 設定仕様書や新規機能ドキュメントにおいて、バックエンドのPythonモデルだけでなく、対応する完全なデータモデル（Request/Response Schema）がフロントエンド側からどう扱われるかを示すTypeScriptインターフェースとして `extends` などを用いて正しく記述されているかを必ず確認・補完する。
+
+## 2024-05-19 - 予防接種機能などの新しい記録タイプの権限設定漏れ
+**学び:** 新しい記録タイプ（例：`vaccination`）をシステムに追加し、API側で `verify_baby_access(..., record_type="vaccination")` と呼び出す実装がされても、`app/schemas/baby_permission.py` の `VALID_RECORD_TYPES` や `.specify/specs/settings/baby_permissions.md` の仕様に追記することが漏れやすい。これにより、フロントエンドや権限設定画面から新しい記録タイプの可視性を制御できなくなるバグが発生しうる。
+**アクション:** 新規の記録・トラッカー機能を追加する際は、必ず権限設定（`VALID_RECORD_TYPES` と `baby_permissions.md`）にもその新しい `record_type` を追加するよう、仕様書レビューやプルリクエストのチェックリストに含める。

--- a/.specify/specs/settings/baby_permissions.md
+++ b/.specify/specs/settings/baby_permissions.md
@@ -49,6 +49,7 @@ Baby（赤ちゃん全体の可視性）
        ├── growth（成長）
        ├── contraction（陣痛）
        ├── schedule（スケジュール）
+       ├── vaccination（予防接種）
        └── note（汎用メモ）
 ```
 
@@ -63,6 +64,7 @@ Baby（赤ちゃん全体の可視性）
 | `"growth"` | 成長記録 | `growth_records` |
 | `"contraction"` | 陣痛記録 | `contractions` |
 | `"schedule"` | スケジュール | `schedules` |
+| `"vaccination"` | 予防接種記録 | `vaccinations` |
 | `"note"` | 汎用メモ | `notes` |
 
 ### 権限判定ロジック
@@ -242,7 +244,7 @@ for record_type in VALID_RECORD_TYPES:
 ### リクエスト/レスポンススキーマ
 
 ```typescript
-type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule";
+type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination";
 
 // 単一の権限レコード（1ユーザー × 1record_type）
 interface BabyPermissionItem {

--- a/app/schemas/baby_permission.py
+++ b/app/schemas/baby_permission.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 from typing import List, Literal
 
 
-VALID_RECORD_TYPES = Literal["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule"]
+VALID_RECORD_TYPES = Literal["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination"]
 
 
 class BabyPermissionItem(BaseModel):


### PR DESCRIPTION
💡 何を:
`app/schemas/baby_permission.py` の `VALID_RECORD_TYPES` および、`.specify/specs/settings/baby_permissions.md` の権限リストに `vaccination`（予防接種）を追加しました。

🔍 発見:
APIバックエンド（`app/routers/vaccinations.py`）では、権限チェックの際に `record_type="vaccination"` として `verify_baby_access` が呼ばれています。しかし、`app/schemas/baby_permission.py` に定義されている `VALID_RECORD_TYPES` や `.specify/specs/settings/baby_permissions.md` には `vaccination` が含まれておらず、仕様と実装の間に乖離が生じていました。

🎯 影響:
`VALID_RECORD_TYPES` に含まれない `record_type` が指定された場合、フロントエンドからの権限一括更新（PUT /api/babies/{baby_id}/permissions）のバリデーションエラーを引き起こす可能性があります。この同期により、予防接種機能における権限管理が正しく動作し、フロントエンドが新しい記録タイプの可視性設定を安全に扱えるようになります。

---
*PR created automatically by Jules for task [9337077775933885049](https://jules.google.com/task/9337077775933885049) started by @eburairu*