### PR TITLE
✍️ Scribe: 権限設定APIの有効なrecord_typeにnoteを追加

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -230,3 +230,7 @@
 ## 2024-05-19 - 予防接種機能などの新しい記録タイプの権限設定漏れ
 **学び:** 新しい記録タイプ（例：`vaccination`）をシステムに追加し、API側で `verify_baby_access(..., record_type="vaccination")` と呼び出す実装がされても、`app/schemas/baby_permission.py` の `VALID_RECORD_TYPES` や `.specify/specs/settings/baby_permissions.md` の仕様に追記することが漏れやすい。これにより、フロントエンドや権限設定画面から新しい記録タイプの可視性を制御できなくなるバグが発生しうる。
 **アクション:** 新規の記録・トラッカー機能を追加する際は、必ず権限設定（`VALID_RECORD_TYPES` と `baby_permissions.md`）にもその新しい `record_type` を追加するよう、仕様書レビューやプルリクエストのチェックリストに含める。
+
+## 2026-03-07 - [Settings UI/Tracker] ValidRecordType の仕様ドリフト
+**学び:** 新規のレコードタイプ（例: `note`, `vaccination`など）が追加され、バックエンドのルーターロジック(`app/routers/baby_permissions.py`)に権限対象として組み込まれた際、`.specify/specs/settings/baby_permissions.md` などのフロントエンド向けTypeScriptインターフェース定義(`ValidRecordType`等)から漏れやすい。
+**アクション:** 権限・設定機能の仕様書を更新する際は、必ずバックエンドルーター内の有効なリスト（例: `valid_types`）と突合し、型定義を同期させる。

--- a/.specify/specs/settings/baby_permissions.md
+++ b/.specify/specs/settings/baby_permissions.md
@@ -244,7 +244,7 @@ for record_type in VALID_RECORD_TYPES:
 ### リクエスト/レスポンススキーマ
 
 ```typescript
-type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination";
+type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note";
 
 // 単一の権限レコード（1ユーザー × 1record_type）
 interface BabyPermissionItem {


### PR DESCRIPTION
💡 何を: `.specify/specs/settings/baby_permissions.md` の `ValidRecordType` 一覧に `note` を追加。
🔍 発見: `app/routers/baby_permissions.py` の実装では `note` を許可し権限リストに含めて返しているが、仕様書のTypeScript型定義から漏れていた。
🎯 影響: 新しく追加されたメモ機能（`note`）の権限設定において、ドキュメントとの矛盾を解消。

---
*PR created automatically by Jules for task [4414610418828299651](https://jules.google.com/task/4414610418828299651) started by @eburairu*