### PR TITLE
perf: フロントエンド初期表示速度を改善（Stage 1）

### DIFF
--- a/frontend/components/ui/splash-screen.tsx
+++ b/frontend/components/ui/splash-screen.tsx
@@ -22,7 +22,7 @@ export function SplashScreen() {
         if (isMounted && !isLoading) {
             const timer = setTimeout(() => {
                 setIsVisible(false)
-            }, 600) // 余韻を持たせてフェードアウト
+            }, 200)
             return () => clearTimeout(timer)
         }
     }, [isMounted, isLoading])

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -9,7 +9,6 @@ export function useUser() {
         shouldRetryOnError: false,
         revalidateOnFocus: true, // PWAに戻ったときに再チェック
         revalidateOnMount: true, // マウント時に必ず実行
-        dedupingInterval: 0, // 重複排除を無効化して確実に実行
     });
 
     return {

--- a/frontend/hooks/useSelectedBaby.ts
+++ b/frontend/hooks/useSelectedBaby.ts
@@ -6,20 +6,27 @@ export function useSelectedBaby() {
   const { babies, isLoading, isError, mutate } = useBabies()
   const { selectedBabyId, setSelectedBabyId } = useBabyStore()
 
+  // storeに未保存でもbabiesが取得できていれば同期的にIDを確定させる。
+  // useEffect経由のsetState→再レンダリング待ちをなくすことで、
+  // babies取得と同じレンダリングサイクルでuseRecordsのフェッチを開始できる。
+  const effectiveSelectedBabyId =
+    selectedBabyId ?? (babies && babies.length > 0 ? String(babies[0].id) : null)
+
+  // storeへの永続化は引き続き行う（次回マウント時にuseEffect待ちを省くため）
   useEffect(() => {
     if (babies && babies.length > 0 && !selectedBabyId) {
       setSelectedBabyId(String(babies[0].id))
     }
   }, [babies, selectedBabyId, setSelectedBabyId])
 
-  const selectedBaby = babies?.find(b => String(b.id) === selectedBabyId)
+  const selectedBaby = babies?.find(b => String(b.id) === effectiveSelectedBabyId)
 
   return {
     babies,
     isLoading,
     isError,
     mutate,
-    selectedBabyId,
+    selectedBabyId: effectiveSelectedBabyId,
     setSelectedBabyId,
     selectedBaby,
   }


### PR DESCRIPTION
## 概要

ページ初期表示の体感速度を改善する3つの修正。

## 変更内容

- SplashScreen 最小表示時間を 600ms -> 200ms に短縮（splash-screen.tsx）
- useUser の dedupingInterval: 0 を削除し SWR デフォルト重複排除を復活（useAuth.ts）
  - ダッシュボードで Layout と DashboardPage の両方から useUser が呼ばれ、/auth/me が複数回発行されていた
- useSelectedBaby で selectedBabyId を同期的に確定するよう変更（useSelectedBaby.ts）
  - 変更前: babies 取得 -> useEffect -> setState -> 再レンダリング -> useRecords フェッチ
  - 変更後: babies 取得と同一レンダリングサイクルで selectedBabyId 確定 -> useRecords フェッチ開始

## テスト

sh scripts/verify_all.sh 通過（168 passed, 1 skipped）