### PR TITLE
perf: /family/members フェッチを廃止し初回APIコールを削減（Stage 2）

### DIFF
--- a/frontend/__tests__/hooks/usePermissions.test.ts
+++ b/frontend/__tests__/hooks/usePermissions.test.ts
@@ -1,0 +1,103 @@
+import { renderHook } from '@testing-library/react'
+import { usePermissions } from '@/hooks/usePermissions'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import useSWR from 'swr'
+
+vi.mock('swr', () => ({
+    default: vi.fn(),
+}))
+
+const mockUseSWR = vi.mocked(useSWR)
+
+describe('usePermissions', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('admin ロールのとき isAdmin=true canWrite=true', () => {
+        mockUseSWR.mockReturnValue({
+            data: { id: 1, username: 'alice', role: 'admin', is_superadmin: false, created_at: '' },
+            error: undefined,
+            isLoading: false,
+            isValidating: false,
+            mutate: vi.fn(),
+        } as ReturnType<typeof useSWR>)
+
+        const { result } = renderHook(() => usePermissions())
+
+        expect(result.current.isAdmin).toBe(true)
+        expect(result.current.canWrite).toBe(true)
+        expect(result.current.isViewer).toBe(false)
+        expect(result.current.isMember).toBe(false)
+    })
+
+    it('member ロールのとき isMember=true canWrite=true', () => {
+        mockUseSWR.mockReturnValue({
+            data: { id: 2, username: 'bob', role: 'member', is_superadmin: false, created_at: '' },
+            error: undefined,
+            isLoading: false,
+            isValidating: false,
+            mutate: vi.fn(),
+        } as ReturnType<typeof useSWR>)
+
+        const { result } = renderHook(() => usePermissions())
+
+        expect(result.current.isMember).toBe(true)
+        expect(result.current.canWrite).toBe(true)
+        expect(result.current.isAdmin).toBe(false)
+        expect(result.current.isViewer).toBe(false)
+    })
+
+    it('viewer ロールのとき isViewer=true canWrite=false', () => {
+        mockUseSWR.mockReturnValue({
+            data: { id: 3, username: 'carol', role: 'viewer', is_superadmin: false, created_at: '' },
+            error: undefined,
+            isLoading: false,
+            isValidating: false,
+            mutate: vi.fn(),
+        } as ReturnType<typeof useSWR>)
+
+        const { result } = renderHook(() => usePermissions())
+
+        expect(result.current.isViewer).toBe(true)
+        expect(result.current.canWrite).toBe(false)
+        expect(result.current.isAdmin).toBe(false)
+        expect(result.current.isMember).toBe(false)
+    })
+
+    it('ローディング中のとき isLoading=true', () => {
+        mockUseSWR.mockReturnValue({
+            data: undefined,
+            error: undefined,
+            isLoading: true,
+            isValidating: true,
+            mutate: vi.fn(),
+        } as ReturnType<typeof useSWR>)
+
+        const { result } = renderHook(() => usePermissions())
+
+        expect(result.current.isLoading).toBe(true)
+        expect(result.current.isAdmin).toBe(false)
+        expect(result.current.canWrite).toBe(false)
+    })
+
+    it('/family/members への SWR コールが発生しない', () => {
+        mockUseSWR.mockReturnValue({
+            data: { id: 1, username: 'alice', role: 'admin', is_superadmin: false, created_at: '' },
+            error: undefined,
+            isLoading: false,
+            isValidating: false,
+            mutate: vi.fn(),
+        } as ReturnType<typeof useSWR>)
+
+        renderHook(() => usePermissions())
+
+        // useSWR は /auth/me の1回だけ呼ばれるはず
+        expect(mockUseSWR).toHaveBeenCalledTimes(1)
+        const firstCallKey = mockUseSWR.mock.calls[0][0]
+        expect(firstCallKey).toBe('/auth/me')
+        // /family/members が呼ばれていないことを確認
+        const allKeys = mockUseSWR.mock.calls.map(call => call[0])
+        expect(allKeys).not.toContain('/family/members')
+    })
+})

--- a/frontend/hooks/useBabies.ts
+++ b/frontend/hooks/useBabies.ts
@@ -7,7 +7,6 @@ export function useBabies(options?: { fallbackData?: Baby[] }) {
         ...options,
         shouldRetryOnError: false,
         revalidateOnFocus: true,
-        revalidateOnMount: true,
         keepPreviousData: true,
     });
     return {

--- a/frontend/hooks/usePermissions.ts
+++ b/frontend/hooks/usePermissions.ts
@@ -1,18 +1,15 @@
 import { useUser } from "./useAuth";
-import { useFamilyMembers } from "./useFamily";
 import { UserRole } from "@/lib/constants";
 
+// /auth/me がユーザーのロールを返すため、/family/members への追加フェッチは不要。
 export function usePermissions() {
-    const { user, isLoading: userLoading } = useUser();
-    const { members, isLoading: membersLoading } = useFamilyMembers();
-
-    const currentMember = members?.find((m) => m.username === user?.username);
-    const role = currentMember?.role;
+    const { user, isLoading } = useUser();
+    const role = user?.role;
 
     const isAdmin = role === UserRole.ADMIN;
     const isViewer = role === UserRole.VIEWER;
     const isMember = role === UserRole.MEMBER;
-    
+
     // admin and member can write
     const canWrite = isAdmin || isMember;
 
@@ -21,6 +18,6 @@ export function usePermissions() {
         isViewer,
         isMember,
         canWrite,
-        isLoading: userLoading || membersLoading,
+        isLoading,
     };
 }


### PR DESCRIPTION
## 概要

ダッシュボード初回表示時のAPIコール数を削減する2つの修正。

## 変更内容

**usePermissions: /family/members フェッチを廃止（usePermissions.ts）**
- /auth/me が既に role フィールドを返しているため、usePermissions で改めて /family/members を呼ぶ必要がなかった
- useFamilyMembers 依存を削除し user.role を直接参照するよう変更
- ダッシュボード初回表示時の API コールが 7 本 → 5 本に削減
- usePermissions のユニットテストを新規追加（usePermissions.test.ts）

**useBabies: revalidateOnMount: true を削除（useBabies.ts）**
- SWR のデフォルト動作（キャッシュがあれば再検証を遅延）に戻す
- ページ遷移のたびに /babies/ を再フェッチしていた問題を解消

## 補足

バックエンドの変更なし（/auth/me は既に role を返していた）

## テスト

sh scripts/verify_all.sh 通過（168 passed, 1 skipped）
usePermissions.test.ts: 5 tests passed