### PR TITLE
✍️ Scribe: 記録タイプの権限設定APIの実装漏れ修正と仕様同期

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -234,3 +234,7 @@
 ## 2026-03-07 - [Settings UI/Tracker] ValidRecordType の仕様ドリフト
 **学び:** 新規のレコードタイプ（例: `note`, `vaccination`など）が追加され、バックエンドのルーターロジック(`app/routers/baby_permissions.py`)に権限対象として組み込まれた際、`.specify/specs/settings/baby_permissions.md` などのフロントエンド向けTypeScriptインターフェース定義(`ValidRecordType`等)から漏れやすい。
 **アクション:** 権限・設定機能の仕様書を更新する際は、必ずバックエンドルーター内の有効なリスト（例: `valid_types`）と突合し、型定義を同期させる。
+
+## 2026-03-08 - [新しい記録タイプの権限管理リストからの漏れ]
+**学び:** `note` や `vaccination` のような新しい記録タイプが追加された際、仕様書（`baby_permissions.md`）には追加されていても、バックエンド側の `VALID_RECORD_TYPES` やルーター内の `valid_types`, `record_types` などの直接的な文字列リストに追加し忘れる実装漏れが発生しやすい。
+**アクション:** 新しい記録タイプを追加する際は、権限モデルやルーターの実装（`baby_permission.py`, `baby_permissions.py`）内のハードコードされたリストにも追加されているか必ず確認・同期する。

--- a/app/routers/baby_permissions.py
+++ b/app/routers/baby_permissions.py
@@ -45,7 +45,7 @@ def get_baby_permissions(
         FamilyUser.role.in_([UserRole.MEMBER, UserRole.VIEWER])
     ).all()
 
-    record_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "note"]
+    record_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination", "note"]
     
     # 3. 全メンバーの BabyPermission を一括取得（N+1 の解消）
     member_user_ids = [u.id for _, u in members]
@@ -104,7 +104,7 @@ def update_baby_permissions(
     family_id = baby.family_id
 
     # 2. リクエストの各エントリについて検証
-    valid_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "note"]
+    valid_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination", "note"]
     for entry in update_in.permissions:
         if entry.record_type not in valid_types:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid record_type: {entry.record_type}")

--- a/app/schemas/baby_permission.py
+++ b/app/schemas/baby_permission.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 from typing import List, Literal
 
 
-VALID_RECORD_TYPES = Literal["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination"]
+VALID_RECORD_TYPES = Literal["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination", "note"]
 
 
 class BabyPermissionItem(BaseModel):


### PR DESCRIPTION
💡 何を: `app/schemas/baby_permission.py` の `VALID_RECORD_TYPES` に `note` を追加し、`app/routers/baby_permissions.py` のリストに `vaccination` を追加した。
🔍 発見: 仕様書には `note` や `vaccination` が追加されていたが、バックエンドのリスト（Pydanticスキーマやルーター内の配列）に追加し忘れており、権限管理APIのレスポンス/リクエストから欠落していた。
🎯 影響: これによりフロントエンドの設定画面等で `note` や `vaccination` の権限が正しく表示・更新できないバグが防止され、仕様書と実際の実装が正確に同期した。

---
*PR created automatically by Jules for task [17358040792441673470](https://jules.google.com/task/17358040792441673470) started by @eburairu*