### PR TITLE
fix: uv pip install の --system を外しvirtualenvにインストール

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -7,7 +7,7 @@ services:
     plan: free
     buildCommand: >-
       pip install uv &&
-      uv pip install --system -r requirements.txt &&
+      uv pip install -r requirements.txt &&
       cd frontend &&
       corepack enable pnpm &&
       pnpm install --frozen-lockfile --store-dir /opt/render/.pnpm-store &&


### PR DESCRIPTION
## 概要

Render デプロイ時に `alembic: command not found` でクラッシュするバグを修正。

## 原因

`uv pip install --system` を指定していたため、Render の Python native runtime が
用意した virtualenv を無視してシステムにインストールされていた。
起動時に virtualenv が activate された状態では `alembic`・`uvicorn` が PATH に入らず
exit 127 で落ちていた。

## 修正

`--system` フラグを削除し、virtualenv 内にインストールされるようにした。