### PR TITLE
chore: サービス名をbaby-app-nextに統一しURLを一本化

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,7 +1,6 @@
 services:
-  # 1. バックエンド: FastAPI (Python Native Web Service)
   - type: web
-    name: baby-api-next
+    name: baby-app-next
     runtime: python
     autoDeploy: false
     plan: free


### PR DESCRIPTION
## 概要

FastAPI（バックエンド）と Next.js 静的ファイル（フロントエンド）をシングルサービスに統合し、
`baby-app-next.onrender.com` に一本化する。

## 変更内容

- サービス名を `baby-api-next` → `baby-app-next` に変更

## Render ダッシュボード側の対応（手動）

Blueprint sync 後、以下の環境変数を新サービスに再設定してください:
- `DATABASE_URL`（Neon 接続文字列）
- `LLM_API_KEY`