### PR TITLE
fix: uvを廃止しpip installに戻す（alembic not foundを修正）

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,11 @@ services:
     runtime: python
     autoDeploy: false
     plan: free
+    # NOTE: pip を使用している理由
+    # uv pip install に切り替えたところ、Render の Python native runtime が
+    # ビルド時に有効化する virtualenv を uv が認識できず、alembic/uvicorn が
+    # 起動時の PATH に含まれず exit 127 でクラッシュした（2026-03-07）。
+    # uv --system オプションも同様に失敗。pip はこの問題が発生しないため pip を維持する。
     buildCommand: >-
       pip install -r requirements.txt &&
       cd frontend &&


### PR DESCRIPTION
## 原因

`uv pip install` が Render の virtualenv を認識できず、ビルドは成功するが
起動時に `alembic: command not found` で落ちていた。

## 修正

`pip install uv && uv pip install` → `pip install` に戻す。
pnpm store キャッシュ（`/opt/render/.pnpm-store`）と Node v22 固定は維持。