### PR TITLE
✍️ Scribe: 家族メンバー設定スキーマのPydantic V2/拡張対応漏れを修正

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -242,3 +242,7 @@
 ## $(date +%Y-%m-%d) - baby_permissions.md の ValidRecordType 更新
 **学び:** 新しい記録タイプ（今回は vaccination, note）が追加された場合、対応するスキーマ（`VALID_RECORD_TYPES`）やルーターでリストが更新されても、関連する仕様書（`baby_permissions.md` など）の型定義やサンプルJSONへの追記が漏れやすい。
 **アクション:** 新たな機能や列挙型（定数）を追加・更新した際には、`.specify/specs/` 配下の関連ドキュメントの型定義やJSONレスポンス例の記載が追随しているか、必ず確認するようにする。
+
+## 2024-03-05 - 家族メンバー設定スキーマのPydantic V2/拡張対応漏れ
+**学び:** `app/schemas/family.py` で `FamilyMemberResponse` に `display_name` が追加され、Pydantic V2 に合わせて `model_config = ConfigDict(from_attributes=True)` へ移行されたにもかかわらず、対応する `.specify/specs/settings/family_settings.md` の仕様書が V1 構文および古いフィールド構成のままになっていた。モデル拡張やPydanticメジャーアップデート時は、仕様書側も同様にアップデートする必要がある。
+**アクション:** 今後の仕様書更新では、各ドメインの `Response` モデルにフィールドが追加されていないか、Pydantic v2 の `model_config` 表記に移行されていないかを優先的に確認する。

--- a/.specify/specs/settings/family_settings.md
+++ b/.specify/specs/settings/family_settings.md
@@ -196,14 +196,14 @@ class FamilyUpdate(BaseModel):
 class FamilyMemberResponse(BaseModel):
     user_id: int
     username: str
-    role: str  # "admin" | "member"
+    display_name: Optional[str] = None
+    role: UserRole
     joined_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 class MemberRoleUpdate(BaseModel):
-    role: str  # "admin" | "member"
+    role: UserRole
 
 class PasswordResetResponse(BaseModel):
     temporary_password: str  # バックエンドが生成した平文仮パスワード（1度だけ返す）


### PR DESCRIPTION
💡 何を:
`.specify/specs/settings/family_settings.md` に記載されている `FamilyMemberResponse` と `MemberRoleUpdate` インターフェース定義を、現在のバックエンドの実装に合わせて修正しました。

🔍 発見:
バックエンドの `app/schemas/family.py` では `display_name` フィールドが追加され、`role` フィールドの型が `UserRole` に変更され、さらにPydantic V2の `model_config = ConfigDict(...)` に移行されていましたが、設定画面仕様書が旧実装（Pydantic V1の `class Config` と不足しているフィールド）のままになっていました。

🎯 影響:
設定UIや権限周りのフロントエンド開発者がAPIのレスポンススキーマを正しく認識できるようになり、`display_name` の表示漏れや型の不一致によるバグを防ぎます。

---
*PR created automatically by Jules for task [14976751297510653453](https://jules.google.com/task/14976751297510653453) started by @eburairu*