### PR TITLE
🧹 Tidy: [RecordIconの共通化とUI定数の統合]

### DIFF
--- a/.jules/tidy.md
+++ b/.jules/tidy.md
@@ -137,3 +137,6 @@ out` として共通化することで保守性が向上した。
 ## 2026-03-02 - [Tidy: リファクタリング - 編集ダイアログのUI共通化]
 学び: 各種フォーム（GrowthRecordForm, VaccinationForm, MilestoneForm, ContractionEditDialog）において、Dialogコンポーネントが個別に直接使用されており、共通のEditDialogBaseが活用されていないアンチパターンを発見しました。これにより、ダイアログのUIや挙動に一貫性が欠け、冗長なコードが存在していました。
 アクション: これらのフォームをEditDialogBaseを使用するようにリファクタリングし、UIの一貫性を確保しました。今後新しいダイアログを作成する際は、必ずEditDialogBaseを使用することを徹底します。
+## 2026-03-02 - [Tidy: リファクタリング - RecordIconの共通化とUI定数の統合]
+**学び:** `ActivityItem` コンポーネント内で、背景色やアイコンの表示ロジック（`Hexagon` の利用や色の出し分け）が手動で記述されており、これは既存の `RecordIcon` コンポーネントと責務が完全に重複していました。また、`RecordIcon` 内部でも独自の `styles` オブジェクトが定義されており、`frontend/constants/ui.ts` の定数と二重管理（アンチパターン）になっていました。
+**アクション:** `RecordIcon` を `ui.ts` の定数（`RECORD_TYPE_COLORS`, `RECORD_TYPE_BG_COLORS`）を利用するようにリファクタリングし、特定のアクション用アイコンを上書きできるように `icon` プロップを追加しました。そして `ActivityItem` から冗長なマークアップを削除し、`RecordIcon` を再利用するように修正しました。今後もUI要素の重複を見つけた際は、既存のコンポーネントを拡張して共通化できないか検討します。また、未使用に見える `tick` プロップに対して、再レンダリングをトリガーするハックである旨のJSDocコメントを追加し、将来の誤削除を防ぎました。

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,1 +1,0 @@
-public/worker-*.js

--- a/frontend/components/dashboard/ActivityItem.tsx
+++ b/frontend/components/dashboard/ActivityItem.tsx
@@ -3,22 +3,23 @@ import React from "react"
 import { BabyRecord } from "@/types/record"
 import { formatElapsed } from "@/lib/ageUtils"
 import { MessageCircle, User, StickyNote } from "lucide-react"
-import { RECORD_TYPE_LABELS, RECORD_TYPE_LUCIDE_ICONS, RECORD_TYPE_COLORS, RECORD_TYPE_BG_COLORS } from "@/constants/ui"
+import { RECORD_TYPE_LABELS, RECORD_TYPE_LUCIDE_ICONS } from "@/constants/ui"
 import { AppIcons } from "@/constants/icons"
-import { Hexagon } from "@/components/ui/hexagon"
-import { cn } from "@/lib/utils"
+import { RecordIcon, RecordType } from "@/components/records/RecordIcon"
 
 interface ActivityItemProps {
     record: BabyRecord
     onClick: (record: BabyRecord) => void
+    /**
+     * React.memoの再レンダリングをトリガーするためのダミープロップ。
+     * 時間経過（formatElapsed）を定期的に更新するために使用されます。
+     */
     tick: number
 }
 
-export const ActivityItem = React.memo(function ActivityItem({ record, onClick, tick: _tick }: ActivityItemProps) {
+export const ActivityItem = React.memo(function ActivityItem({ record, onClick }: ActivityItemProps) {
     const recordType = record.type as keyof typeof RECORD_TYPE_LABELS
     const label = RECORD_TYPE_LABELS[recordType] || record.type
-    const colorClass = RECORD_TYPE_COLORS[recordType as keyof typeof RECORD_TYPE_COLORS] || 'text-muted-foreground'
-    const bgColorClass = RECORD_TYPE_BG_COLORS[recordType] || 'text-gray-100 dark:text-zinc-800'
 
     let LucideIcon = RECORD_TYPE_LUCIDE_ICONS[recordType]
 
@@ -42,9 +43,7 @@ export const ActivityItem = React.memo(function ActivityItem({ record, onClick, 
                 className="w-full flex items-center gap-3 text-left hover:bg-gray-50 dark:hover:bg-zinc-800 active:bg-gray-100 dark:active:bg-zinc-700 p-1 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-indigo-500 dark:focus-visible:ring-indigo-400"
                 onClick={() => onClick(record)}
             >
-                <Hexagon size={36} cornerRadius={6} className={cn("shrink-0", bgColorClass)}>
-                    <IconComponent className={cn("h-4 w-4", colorClass)} aria-hidden="true" />
-                </Hexagon>
+                <RecordIcon type={recordType as RecordType} icon={IconComponent} />
                 <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-gray-800 dark:text-zinc-200">
                         {label}

--- a/frontend/components/records/RecordIcon.tsx
+++ b/frontend/components/records/RecordIcon.tsx
@@ -1,25 +1,21 @@
 import { AppIcons } from "@/constants/icons";
+import { RECORD_TYPE_COLORS, RECORD_TYPE_BG_COLORS } from "@/constants/ui";
 import { cn } from "@/lib/utils";
 import { Hexagon } from "@/components/ui/hexagon";
+import { type LucideIcon } from "lucide-react";
 
-export type RecordType = 'feeding' | 'sleep' | 'diaper' | 'note' | 'growth';
+export type RecordType = 'feeding' | 'sleep' | 'diaper' | 'note' | 'growth' | 'contraction';
 
 interface RecordIconProps {
   type: RecordType;
   className?: string;
+  icon?: LucideIcon;
 }
 
-const styles: Record<RecordType, { bg: string, icon: string }> = {
-  feeding: { bg: "text-orange-100 dark:text-orange-950/40", icon: "text-orange-500 dark:text-orange-400" },
-  sleep: { bg: "text-indigo-100 dark:text-indigo-950/40", icon: "text-indigo-500 dark:text-indigo-400" },
-  diaper: { bg: "text-amber-100 dark:text-amber-950/40", icon: "text-amber-500 dark:text-amber-400" },
-  note: { bg: "text-amber-100 dark:text-amber-950/40", icon: "text-amber-500 dark:text-amber-400" },
-  growth: { bg: "text-green-100 dark:text-green-950/40", icon: "text-green-500 dark:text-green-400" },
-};
-
-export function RecordIcon({ type, className }: RecordIconProps) {
-  const Icon = AppIcons[type];
-  const style = styles[type];
+export function RecordIcon({ type, className, icon: OverrideIcon }: RecordIconProps) {
+  const Icon = OverrideIcon ?? AppIcons[type];
+  const bg = RECORD_TYPE_BG_COLORS[type] || 'text-gray-100 dark:text-zinc-800';
+  const iconColor = RECORD_TYPE_COLORS[type as keyof typeof RECORD_TYPE_COLORS] || 'text-muted-foreground';
 
   if (!Icon) return null;
 
@@ -27,9 +23,9 @@ export function RecordIcon({ type, className }: RecordIconProps) {
     <Hexagon
       size={36}
       cornerRadius={6}
-      className={cn("shrink-0", style.bg, className)}
+      className={cn("shrink-0", bg, className)}
     >
-      <Icon className={cn("w-4 h-4", style.icon)} />
+      <Icon className={cn("w-4 h-4", iconColor)} />
     </Hexagon>
   );
 }

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -12,6 +12,7 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    "public/worker-*.js",
   ]),
 ]);
 


### PR DESCRIPTION
💡 **何を:**
* `RecordIcon` コンポーネントが使用する色定義を、`frontend/constants/ui.ts` にある定数 (`RECORD_TYPE_COLORS`, `RECORD_TYPE_BG_COLORS`) を直接参照するように統合しました。
* `RecordIcon` に `icon` プロップを追加し、デフォルトのアイコンを上書きできるようにしました。
* `ActivityItem` コンポーネントで手動実装されていたアイコンと背景色の描画ロジックを削除し、`RecordIcon` を呼び出すように置き換えました。
* 未使用として Lint 警告が出ていた `tick` プロップに対して、再レンダリング用のハックである旨の JSDoc コメントを追加し、意図を明確にしました。
* 合わせて、ESLint の flat config にて `public/worker-*.js` を無視する設定を追加し、Lint 警告を解消しました。

🎯 **なぜ:**
* **DRY原則:** `ActivityItem` と `RecordIcon` で、レコードの種類に応じた色やアイコンの出し分けロジックが完全に重複していました。これを統合することで、将来的なデザイン変更時に修正箇所を1つに絞ることができます。
* **可読性向上:** `ActivityItem` からマークアップとUIの装飾ロジックを減らすことで、本来の責務である「レコードの情報を表示する」部分に集中できるようにしました。
* **保守性向上:** 一見不要に見える `tick` プロップにドキュメントを追加することで、他の開発者が誤って削除し、経過時間のリアルタイム更新が壊れるバグ（機能後退）を防ぎます。

🛡️ **安全性:**
* コンポーネントのロジックや DOM 構造自体に破壊的な変更は加えていません。
* `pnpm lint`, `pnpm test`, `pnpm build` を実行し、既存のテストがすべて通過すること、およびビルドが正常に完了することを確認済みです。

---
*PR created automatically by Jules for task [4418609253808083009](https://jules.google.com/task/4418609253808083009) started by @eburairu*