### PR TITLE
chore: git hooks / ガードレールの冗長な制約を整理

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -9,7 +9,7 @@
   "hooks": {
     "BeforeTool": [
       {
-        "matcher": "^(write_file|replace|edit)$",
+        "matcher": "^(write_file|replace)$",
         "hooks": [
           {
             "name": "ai-worktree-guardrail",

--- a/scripts/check_root_edit.sh
+++ b/scripts/check_root_edit.sh
@@ -15,13 +15,17 @@ if [ -d "$TOPLEVEL/.git" ] && { [ "$CURRENT_BRANCH" = "develop" ] || [ "$CURRENT
 
   # 絶対パスをリポジトリルートからの相対パスに変換
   if [ -n "$TOPLEVEL" ]; then
+    # プロジェクトルート外のファイルは保護対象外 → 許可
+    if [[ -n "$FILE_PATH" && "$FILE_PATH" != "$TOPLEVEL"* ]]; then
+      exit 0
+    fi
     FILE_PATH="${FILE_PATH#$TOPLEVEL/}"
   fi
 
-  # .planning/ / .specify/ / scripts/ 配下は develop での直接編集を許可
+  # .planning/ / .specify/ / scripts/ / .gemini/ / .claude/ 配下は develop での直接編集を許可
   # worktrees/ 配下はワークツリーでの作業なので許可
   # ルート直下の設定ファイル（CLAUDE.md / GEMINI.md）も直接編集を許可
-  if echo "$FILE_PATH" | grep -qE '^(\.planning|\.specify|scripts|worktrees)/' || echo "$FILE_PATH" | grep -qE '^(CLAUDE|GEMINI)\.md$'; then
+  if echo "$FILE_PATH" | grep -qE '^(\.planning|\.specify|scripts|worktrees|\.gemini|\.claude)/' || echo "$FILE_PATH" | grep -qE '^(CLAUDE|GEMINI)\.md$'; then
     exit 0
   fi
 

--- a/scripts/check_staged_files.sh
+++ b/scripts/check_staged_files.sh
@@ -21,7 +21,7 @@ if [ -z "$STAGED_FILES" ]; then
   ONLY_SPECS=false
 else
   for file in $STAGED_FILES; do
-    if [[ ! "$file" =~ ^\.specify/specs/ ]] && [[ ! "$file" =~ ^\.planning/ ]] && [[ ! "$file" =~ ^scripts/ ]] && [[ "$file" != "GEMINI.md" ]]; then
+    if [[ ! "$file" =~ ^\.specify/specs/ ]] && [[ ! "$file" =~ ^\.planning/ ]] && [[ ! "$file" =~ ^scripts/ ]] && [[ ! "$file" =~ ^\.gemini/ ]] && [[ "$file" != "GEMINI.md" ]] && [[ "$file" != "CLAUDE.md" ]]; then
       ONLY_SPECS=false
       break
     fi

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -39,17 +39,7 @@ cat > "$HOOK_FILE" <<EOF
 # pre-commit hook: ステージング済みファイルの自動チェック
 sh "$CHECK_SCRIPT"
 sh "$CHECK_OPENAPI_SCRIPT"
-
-# フロントエンドの変更が含まれる場合、Lint を実行する
-STAGED_FILES=\$(git diff --cached --name-only)
-if echo "\$STAGED_FILES" | grep -q "^frontend/"; then
-  echo "🔍 フロントエンドの Lint を実行中..."
-  # ルートディレクトリ配下の frontend ではなく、現在の git-dir に対応する frontend を取得
-  GIT_ROOT=\$(git rev-parse --show-toplevel)
-  if [ -d "\$GIT_ROOT/frontend" ]; then
-    cd "\$GIT_ROOT/frontend" && pnpm lint || exit 1
-  fi
-fi
+# lint は CI (validate-frontend-build) で実施 → pre-commit からは除外
 EOF
 
 chmod +x "$HOOK_FILE"


### PR DESCRIPTION
## 概要

Claude Code + Gemini CLI を使った開発で冗長・バグのある制約を整理。

## 変更内容

- **check_root_edit.sh**: プロジェクト外パス（`~/.claude/plans/` 等）を誤ってブロックするバグを修正。`.gemini/`、`.claude/` を許可リストに追加
- **check_staged_files.sh**: `.gemini/`、`CLAUDE.md` を develop 直接コミット許可対象に追加
- **install_hooks.sh**: pre-commit から `pnpm lint` を除去（CI の `validate-frontend-build` で代替済み）
- **.gemini/settings.json**: BeforeTool matcher から `edit`（ai_guardrail.js 内で常時 allow のため不要）を除去

## 効果

- フロントエンドファイルのコミットが 15〜30秒 → 数秒以内に高速化
- 外部パスへの書き込みがブロックされるバグを修正
- lint は CI が安全網として維持