### PR TITLE
chore: 保護ブランチへの直接コミットを例外なく一律ブロック

### DIFF
--- a/scripts/check_staged_files.sh
+++ b/scripts/check_staged_files.sh
@@ -4,43 +4,21 @@
 # コミット対象（ステージング済み）のファイルに禁止ファイルが含まれていないかチェックする
 
 # ============================================================
-# ルートリポジトリの保護ブランチへの直接コミットをブロック
-# ただし、仕様書（.specify/specs/）・設計ドキュメント（.planning/）・スクリプト（scripts/）
-# のみの変更の場合は許可する
+# ルートリポジトリの保護ブランチへの直接コミットを一律ブロック
 # ============================================================
 TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null)
 CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 PROTECTED_BRANCHES=("develop" "main")
 
-# ステージングされたファイル一覧を取得
-STAGED_FILES=$(git diff --cached --name-only)
-
-# すべてが仕様書（.specify/specs/）・設計ドキュメント（.planning/）・スクリプト（scripts/）配下かどうかを判定
-ONLY_SPECS=true
-if [ -z "$STAGED_FILES" ]; then
-  ONLY_SPECS=false
-else
-  for file in $STAGED_FILES; do
-    if [[ ! "$file" =~ ^\.specify/specs/ ]] && [[ ! "$file" =~ ^\.planning/ ]] && [[ ! "$file" =~ ^scripts/ ]] && [[ ! "$file" =~ ^\.gemini/ ]] && [[ "$file" != "GEMINI.md" ]] && [[ "$file" != "CLAUDE.md" ]]; then
-      ONLY_SPECS=false
-      break
-    fi
-  done
-fi
-
-if [ "$ONLY_SPECS" = "false" ] && [ -d "$TOPLEVEL/.git" ]; then
+if [ -d "$TOPLEVEL/.git" ]; then
   for branch in "${PROTECTED_BRANCHES[@]}"; do
     if [ "$CURRENT_BRANCH" = "$branch" ]; then
-      echo "❌ エラー: ルートリポジトリの '$branch' ブランチに直接コミットできません（コード変更が含まれています）。"
+      echo "❌ エラー: ルートリポジトリの '$branch' ブランチに直接コミットできません。"
       echo "   ワークツリーを作成してから作業してください:"
       echo "   sh scripts/setup_worktree.sh feat/your-feature-name"
       exit 1
     fi
   done
-fi
-
-if [ "$ONLY_SPECS" = "true" ] && [ -d "$TOPLEVEL/.git" ]; then
-  echo "ℹ️  通知: 仕様書・設計ドキュメント・スクリプトの更新のみであるため、'$CURRENT_BRANCH' ブランチへの直接コミットを許可します。"
 fi
 
 FORBIDDEN_PATTERNS=(".venv" "node_modules" "worktrees/")


### PR DESCRIPTION
scripts/ 等のファイル種別による例外ロジックを廃止し、develop/main への直接コミットを全てブロックする。常にワークツリー経由でPRを作成することを強制する。