### PR TITLE
feat: 育児コラムのダークモード対応

### DIFF
--- a/frontend/app/column/[slug]/page.tsx
+++ b/frontend/app/column/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
-import { ARTICLES, getArticle } from "@/lib/column-data"
+import { ARTICLES, getArticle, CATEGORY_COLORS } from "@/lib/column-data"
 import { Clock, ChevronRight, Lightbulb } from "lucide-react"
 
 type Props = {
@@ -22,32 +22,24 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     }
 }
 
-const CATEGORY_COLORS: Record<string, string> = {
-    "授乳・ミルク": "bg-rose-50 text-rose-600",
-    "睡眠": "bg-indigo-50 text-indigo-600",
-    "おむつ・健康": "bg-amber-50 text-amber-600",
-    "夫婦・家族": "bg-emerald-50 text-emerald-600",
-    "成長記録": "bg-blue-50 text-blue-600",
-}
-
 export default async function ColumnArticlePage({ params }: Props) {
     const { slug } = await params
     const article = getArticle(slug)
     if (!article) notFound()
 
-    const colorClass = CATEGORY_COLORS[article.category] ?? "bg-slate-100 text-slate-600"
+    const colorClass = CATEGORY_COLORS[article.category] ?? "bg-slate-100 text-slate-600 dark:bg-zinc-800 dark:text-slate-400"
     const otherArticles = ARTICLES.filter((a) => a.slug !== article.slug).slice(0, 3)
 
     return (
-        <div className="min-h-screen bg-slate-50">
+        <div className="min-h-screen bg-slate-50 dark:bg-zinc-950">
             <div className="max-w-3xl mx-auto px-4 py-16 space-y-12">
                 {/* パンくず */}
-                <nav className="flex items-center gap-1 text-sm text-slate-400">
-                    <Link href="/" className="hover:text-indigo-600 transition-colors">トップ</Link>
+                <nav className="flex items-center gap-1 text-sm text-slate-400 dark:text-slate-500">
+                    <Link href="/" className="hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">トップ</Link>
                     <ChevronRight className="w-3 h-3" />
-                    <Link href="/column" className="hover:text-indigo-600 transition-colors">育児コラム</Link>
+                    <Link href="/column" className="hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">育児コラム</Link>
                     <ChevronRight className="w-3 h-3" />
-                    <span className="text-slate-600 line-clamp-1">{article.title}</span>
+                    <span className="text-slate-600 dark:text-slate-300 line-clamp-1">{article.title}</span>
                 </nav>
 
                 {/* ヘッダー */}
@@ -56,43 +48,43 @@ export default async function ColumnArticlePage({ params }: Props) {
                         <span className={`text-xs font-bold px-2.5 py-1 rounded-full ${colorClass}`}>
                             {article.category}
                         </span>
-                        <span className="text-xs text-slate-400 flex items-center gap-1">
+                        <span className="text-xs text-slate-400 dark:text-slate-500 flex items-center gap-1">
                             <Clock className="w-3 h-3" />
                             {article.readingTime}
                         </span>
-                        <span className="text-xs text-slate-400">{article.publishedAt}</span>
+                        <span className="text-xs text-slate-400 dark:text-slate-500">{article.publishedAt}</span>
                     </div>
-                    <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-slate-900 leading-snug">
+                    <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100 leading-snug">
                         {article.title}
                     </h1>
                 </header>
 
                 {/* リード文 */}
-                <div className="bg-white rounded-2xl p-6 border border-slate-100 shadow-sm">
-                    <p className="text-slate-600 leading-relaxed">{article.lead}</p>
+                <div className="bg-white dark:bg-zinc-900 rounded-2xl p-6 border border-slate-100 dark:border-zinc-800 shadow-sm dark:shadow-none">
+                    <p className="text-slate-600 dark:text-slate-400 leading-relaxed">{article.lead}</p>
                 </div>
 
                 {/* 本文 */}
                 <article className="space-y-10">
                     {article.sections.map((section, i) => (
                         <section key={i} className="space-y-4">
-                            <h2 className="text-xl font-bold text-slate-800 border-l-4 border-indigo-500 pl-4">
+                            <h2 className="text-xl font-bold text-slate-800 dark:text-slate-100 border-l-4 border-indigo-500 pl-4">
                                 {section.heading}
                             </h2>
                             <div className="space-y-3">
                                 {section.body.map((para, j) => (
-                                    <p key={j} className="text-slate-600 leading-relaxed">
+                                    <p key={j} className="text-slate-600 dark:text-slate-400 leading-relaxed">
                                         {para}
                                     </p>
                                 ))}
                             </div>
                             {section.appTip && (
-                                <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-5 space-y-2">
-                                    <div className="flex items-center gap-2 text-indigo-700 font-bold text-sm">
+                                <div className="bg-indigo-50 dark:bg-indigo-950/30 border border-indigo-100 dark:border-indigo-900/50 rounded-xl p-5 space-y-2">
+                                    <div className="flex items-center gap-2 text-indigo-700 dark:text-indigo-300 font-bold text-sm">
                                         <Lightbulb className="w-4 h-4" />
                                         {section.appTip.title}
                                     </div>
-                                    <p className="text-indigo-800 text-sm leading-relaxed">
+                                    <p className="text-indigo-800 dark:text-indigo-200 text-sm leading-relaxed">
                                         {section.appTip.body}
                                     </p>
                                 </div>
@@ -101,19 +93,19 @@ export default async function ColumnArticlePage({ params }: Props) {
                     ))}
 
                     {/* まとめ */}
-                    <section className="bg-slate-800 text-white rounded-2xl p-6 space-y-3">
+                    <section className="bg-slate-800 dark:bg-zinc-800 text-white rounded-2xl p-6 space-y-3">
                         <h2 className="text-lg font-bold">まとめ</h2>
-                        <p className="text-slate-200 leading-relaxed text-sm">{article.conclusion}</p>
+                        <p className="text-slate-200 dark:text-slate-300 leading-relaxed text-sm">{article.conclusion}</p>
                     </section>
                 </article>
 
                 {/* CTA */}
-                <div className="bg-indigo-600 rounded-2xl p-6 text-center space-y-3 text-white">
+                <div className="bg-indigo-600 dark:bg-indigo-950/40 rounded-2xl p-6 text-center space-y-3 text-white dark:border dark:border-indigo-900/50">
                     <p className="font-bold text-lg">Botoroで育児記録を始める</p>
-                    <p className="text-indigo-100 text-sm">授乳・睡眠・おむつ・成長を記録して家族と共有。完全無料・登録1分。</p>
+                    <p className="text-indigo-100 dark:text-indigo-200 text-sm">授乳・睡眠・おむつ・成長を記録して家族と共有。完全無料・登録1分。</p>
                     <Link
                         href="/register"
-                        className="inline-flex items-center justify-center px-6 py-3 bg-white text-indigo-600 rounded-xl font-bold hover:bg-indigo-50 transition-colors text-sm"
+                        className="inline-flex items-center justify-center px-6 py-3 bg-white dark:bg-indigo-600 text-indigo-600 dark:text-white rounded-xl font-bold hover:bg-indigo-50 dark:hover:bg-indigo-700 transition-colors text-sm"
                     >
                         無料で始める
                     </Link>
@@ -122,25 +114,25 @@ export default async function ColumnArticlePage({ params }: Props) {
                 {/* 関連記事 */}
                 {otherArticles.length > 0 && (
                     <section className="space-y-4">
-                        <h2 className="text-lg font-bold text-slate-800">他のコラムを読む</h2>
+                        <h2 className="text-lg font-bold text-slate-800 dark:text-slate-100">他のコラムを読む</h2>
                         <div className="grid gap-4">
                             {otherArticles.map((a) => {
-                                const c = CATEGORY_COLORS[a.category] ?? "bg-slate-100 text-slate-600"
+                                const c = CATEGORY_COLORS[a.category] ?? "bg-slate-100 text-slate-600 dark:bg-zinc-800 dark:text-slate-400"
                                 return (
                                     <Link
                                         key={a.slug}
                                         href={`/column/${a.slug}`}
-                                        className="group flex items-center gap-4 bg-white rounded-xl p-4 border border-slate-100 shadow-sm hover:shadow-md transition-shadow"
+                                        className="group flex items-center gap-4 bg-white dark:bg-zinc-900 rounded-xl p-4 border border-slate-100 dark:border-zinc-800 shadow-sm dark:shadow-none hover:shadow-md dark:hover:bg-zinc-800 transition-all"
                                     >
                                         <div className="flex-1 space-y-1">
                                             <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${c}`}>
                                                 {a.category}
                                             </span>
-                                            <p className="text-sm font-bold text-slate-700 group-hover:text-indigo-600 transition-colors leading-snug">
+                                            <p className="text-sm font-bold text-slate-700 dark:text-slate-200 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors leading-snug">
                                                 {a.title}
                                             </p>
                                         </div>
-                                        <ChevronRight className="w-4 h-4 text-slate-300 shrink-0" />
+                                        <ChevronRight className="w-4 h-4 text-slate-300 dark:text-zinc-700 shrink-0" />
                                     </Link>
                                 )
                             })}

--- a/frontend/app/column/page.tsx
+++ b/frontend/app/column/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import type { Metadata } from "next"
-import { ARTICLES } from "@/lib/column-data"
+import { ARTICLES, CATEGORY_COLORS } from "@/lib/column-data"
 import { Clock, ChevronRight } from "lucide-react"
 
 export const metadata: Metadata = {
@@ -8,27 +8,19 @@ export const metadata: Metadata = {
     description: "授乳・睡眠・おむつ・成長記録など、育児に役立つ情報をまとめたコラム集。記録と共有で育児がもっと楽になるヒントをお届けします。",
 }
 
-const CATEGORY_COLORS: Record<string, string> = {
-    "授乳・ミルク": "bg-rose-50 text-rose-600",
-    "睡眠": "bg-indigo-50 text-indigo-600",
-    "おむつ・健康": "bg-amber-50 text-amber-600",
-    "夫婦・家族": "bg-emerald-50 text-emerald-600",
-    "成長記録": "bg-blue-50 text-blue-600",
-}
-
 export default function ColumnIndexPage() {
     return (
-        <div className="min-h-screen bg-slate-50">
+        <div className="min-h-screen bg-slate-50 dark:bg-zinc-950">
             <div className="max-w-4xl mx-auto px-4 py-16 space-y-12">
                 <div className="space-y-3">
                     <Link
                         href="/"
-                        className="text-sm text-slate-500 hover:text-indigo-600 transition-colors inline-flex items-center gap-1"
+                        className="text-sm text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors inline-flex items-center gap-1"
                     >
                         ← トップページに戻る
                     </Link>
-                    <h1 className="text-3xl font-bold tracking-tight text-slate-900">育児コラム</h1>
-                    <p className="text-slate-600 leading-relaxed">
+                    <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100">育児コラム</h1>
+                    <p className="text-slate-600 dark:text-slate-400 leading-relaxed">
                         授乳・睡眠・おむつ・成長記録など、毎日の育児に役立つ情報をお届けします。
                         記録と家族間の共有がどのように育児を楽にするか、具体的なヒントとともに紹介します。
                     </p>
@@ -36,12 +28,12 @@ export default function ColumnIndexPage() {
 
                 <div className="grid gap-6">
                     {ARTICLES.map((article) => {
-                        const colorClass = CATEGORY_COLORS[article.category] ?? "bg-slate-100 text-slate-600"
+                        const colorClass = CATEGORY_COLORS[article.category] ?? "bg-slate-100 text-slate-600 dark:bg-zinc-800 dark:text-slate-400"
                         return (
                             <Link
                                 key={article.slug}
                                 href={`/column/${article.slug}`}
-                                className="group block bg-white rounded-2xl p-6 shadow-sm hover:shadow-md transition-shadow border border-slate-100"
+                                className="group block bg-white dark:bg-zinc-900 rounded-2xl p-6 shadow-sm hover:shadow-md dark:shadow-none transition-all border border-slate-100 dark:border-zinc-800"
                             >
                                 <div className="flex flex-col sm:flex-row sm:items-start gap-4">
                                     <div className="flex-1 space-y-3">
@@ -49,31 +41,31 @@ export default function ColumnIndexPage() {
                                             <span className={`text-xs font-bold px-2.5 py-1 rounded-full ${colorClass}`}>
                                                 {article.category}
                                             </span>
-                                            <span className="text-xs text-slate-400 flex items-center gap-1">
+                                            <span className="text-xs text-slate-400 dark:text-slate-500 flex items-center gap-1">
                                                 <Clock className="w-3 h-3" />
                                                 {article.readingTime}
                                             </span>
                                         </div>
-                                        <h2 className="text-lg font-bold text-slate-800 group-hover:text-indigo-600 transition-colors leading-snug">
+                                        <h2 className="text-lg font-bold text-slate-800 dark:text-slate-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors leading-snug">
                                             {article.title}
                                         </h2>
-                                        <p className="text-sm text-slate-500 leading-relaxed line-clamp-2">
+                                        <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed line-clamp-2">
                                             {article.description}
                                         </p>
                                     </div>
-                                    <ChevronRight className="w-5 h-5 text-slate-300 group-hover:text-indigo-400 transition-colors shrink-0 mt-1 hidden sm:block" />
+                                    <ChevronRight className="w-5 h-5 text-slate-300 dark:text-zinc-700 group-hover:text-indigo-400 transition-colors shrink-0 mt-1 hidden sm:block" />
                                 </div>
                             </Link>
                         )
                     })}
                 </div>
 
-                <div className="bg-indigo-50 rounded-2xl p-6 text-center space-y-4 border border-indigo-100">
-                    <p className="font-bold text-slate-800">育児記録をアプリで管理してみませんか？</p>
-                    <p className="text-sm text-slate-600">授乳・睡眠・おむつ・成長を記録して家族と共有。Botoroは完全無料です。</p>
+                <div className="bg-indigo-50 dark:bg-indigo-950/30 rounded-2xl p-6 text-center space-y-4 border border-indigo-100 dark:border-indigo-900/50">
+                    <p className="font-bold text-slate-800 dark:text-slate-200">育児記録をアプリで管理してみませんか？</p>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">授乳・睡眠・おむつ・成長を記録して家族と共有。Botoroは完全無料です。</p>
                     <Link
                         href="/register"
-                        className="inline-flex items-center justify-center px-6 py-3 bg-indigo-600 text-white rounded-xl font-bold hover:bg-indigo-700 transition-colors text-sm"
+                        className="inline-flex items-center justify-center px-6 py-3 bg-indigo-600 dark:bg-indigo-600 text-white rounded-xl font-bold hover:bg-indigo-700 dark:hover:bg-indigo-700 transition-colors text-sm"
                     >
                         無料で始める
                     </Link>

--- a/frontend/components/landing/LandingColumnTeaser.tsx
+++ b/frontend/components/landing/LandingColumnTeaser.tsx
@@ -3,15 +3,7 @@
 import Link from "next/link"
 import { motion } from "framer-motion"
 import { ChevronRight, Clock } from "lucide-react"
-import { ARTICLES } from "@/lib/column-data"
-
-const CATEGORY_COLORS: Record<string, string> = {
-    "授乳・ミルク": "bg-rose-50 text-rose-600",
-    "睡眠": "bg-indigo-50 text-indigo-600",
-    "おむつ・健康": "bg-amber-50 text-amber-600",
-    "夫婦・家族": "bg-emerald-50 text-emerald-600",
-    "成長記録": "bg-blue-50 text-blue-600",
-}
+import { ARTICLES, CATEGORY_COLORS } from "@/lib/column-data"
 
 const FEATURED = ARTICLES.slice(0, 3)
 

--- a/frontend/lib/column-data.ts
+++ b/frontend/lib/column-data.ts
@@ -19,6 +19,14 @@ export type Article = {
     conclusion: string
 }
 
+export const CATEGORY_COLORS: Record<string, string> = {
+    "授乳・ミルク": "bg-rose-50 text-rose-600 dark:bg-rose-950/30 dark:text-rose-400",
+    "睡眠": "bg-indigo-50 text-indigo-600 dark:bg-indigo-950/30 dark:text-indigo-400",
+    "おむつ・健康": "bg-amber-50 text-amber-600 dark:bg-amber-950/30 dark:text-amber-400",
+    "夫婦・家族": "bg-emerald-50 text-emerald-600 dark:bg-emerald-950/30 dark:text-emerald-400",
+    "成長記録": "bg-blue-50 text-blue-600 dark:bg-blue-950/30 dark:text-blue-400",
+}
+
 export const ARTICLES: Article[] = [
     {
         slug: "nursing-interval",


### PR DESCRIPTION
## 概要
LP上の育児コラムティーザー、およびコラム一覧ページ・詳細ページをダークモードに対応させました。

## 変更内容
- `frontend/lib/column-data.ts`: `CATEGORY_COLORS` を集約し、ダークモード用のカラークラスを追加。
- `frontend/components/landing/LandingColumnTeaser.tsx`: 集約されたカラーを使用するようにリファクタリングし、ダークモード対応。
- `frontend/app/column/page.tsx`: 一覧ページ（背景、テキスト、カード、CTA）のダークモード対応。
- `frontend/app/column/[slug]/page.tsx`: 詳細ページ（パンくず、記事ヘッダー、リード文、本文、AIアドバイス、まとめ、CTA、関連記事）のダークモード対応。

## 検証結果
`sh scripts/verify_all.sh` を実行し、ビルド、型チェック、Lint がすべてパスすることを確認済み。
