### PR TITLE
feat: コンテンツ幅をmax-w-5xlに拡大（iPad mini横画面対応）

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -92,7 +92,7 @@ export default function DashboardPage() {
     return (
         <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 transition-colors pb-24">
             <PullToRefresh onRefresh={handleRefresh}>
-                <main className="px-4 py-6 max-w-3xl mx-auto space-y-6">
+                <main className="px-4 py-6 max-w-5xl mx-auto space-y-6">
                     {!born && canWrite && selectedBaby && (
                         <BirthRegistrationDialog
                             babyId={actualBabyId}

--- a/frontend/app/(dashboard)/settings/babies/page.tsx
+++ b/frontend/app/(dashboard)/settings/babies/page.tsx
@@ -64,7 +64,7 @@ export default function BabySettingsPage() {
             </SettingsHeader>
 
             <PullToRefresh onRefresh={handleRefresh}>
-                <div className="max-w-3xl mx-auto p-4 space-y-4 pb-20">
+                <div className="max-w-5xl mx-auto p-4 space-y-4 pb-20">
                     {!babies || babies.length === 0 ? (
                         <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-8 text-center transition-colors">
                             <p className="text-gray-400 dark:text-zinc-500 text-sm mb-4 flex items-center justify-center gap-1"><BabyIcon className="w-4 h-4" /> まだ赤ちゃんが登録されていません</p>

--- a/frontend/app/(dashboard)/settings/family/page.tsx
+++ b/frontend/app/(dashboard)/settings/family/page.tsx
@@ -48,7 +48,7 @@ export default function FamilySettingsPage() {
             <SettingsHeader title="家族設定" />
 
             <PullToRefresh onRefresh={handleRefresh}>
-                <div className="max-w-3xl mx-auto p-4 space-y-4 pb-20">
+                <div className="max-w-5xl mx-auto p-4 space-y-4 pb-20">
                     {/* 家族名 */}
                     <FamilyNameForm
                         name={family.name}

--- a/frontend/app/(dashboard)/settings/notifications/page.tsx
+++ b/frontend/app/(dashboard)/settings/notifications/page.tsx
@@ -154,7 +154,7 @@ export default function NotificationsPage() {
     <div className="min-h-screen bg-slate-50 dark:bg-zinc-950">
       <SettingsHeader title="通知設定" />
 
-      <div className="max-w-3xl mx-auto p-4 space-y-6 pb-20">
+      <div className="max-w-5xl mx-auto p-4 space-y-6 pb-20">
         <Card className="dark:bg-zinc-900 dark:border-zinc-800">
           <CardHeader>
             <CardTitle className="text-lg flex items-center gap-2">

--- a/frontend/app/(dashboard)/settings/page.tsx
+++ b/frontend/app/(dashboard)/settings/page.tsx
@@ -105,7 +105,7 @@ export default function SettingsPage() {
                 <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100">設定</h1>
             </header>
 
-            <div className="max-w-3xl mx-auto p-4 space-y-3 pb-20">
+            <div className="max-w-5xl mx-auto p-4 space-y-3 pb-20">
                 {user?.is_superadmin && (
                     <section className="space-y-3">
                         <h2 className="text-xs font-semibold text-gray-500 dark:text-zinc-500 uppercase tracking-wider ml-1 mb-1">システム管理</h2>

--- a/frontend/app/(dashboard)/settings/permissions/page.tsx
+++ b/frontend/app/(dashboard)/settings/permissions/page.tsx
@@ -40,7 +40,7 @@ export default function PermissionsPage() {
     <div className="min-h-screen bg-slate-50 dark:bg-zinc-950">
       <SettingsHeader title="権限管理" icon={ShieldCheck} />
 
-      <div className="max-w-3xl mx-auto p-4 space-y-4 pb-20">
+      <div className="max-w-5xl mx-auto p-4 space-y-4 pb-20">
         <p className="text-xs text-gray-500 dark:text-zinc-500">
           メンバーがどの赤ちゃんの情報を閲覧できるか管理します。新規参加者はデフォルトでアクセスなしです。
         </p>

--- a/frontend/components/ui/record-page-layout.tsx
+++ b/frontend/components/ui/record-page-layout.tsx
@@ -68,7 +68,7 @@ export function RecordPageLayout({
     }
 
     const content = (
-        <main className="max-w-3xl mx-auto p-4 space-y-6 pb-24">
+        <main className="max-w-5xl mx-auto p-4 space-y-6 pb-24">
             {renderContent()}
         </main>
     )
@@ -77,7 +77,7 @@ export function RecordPageLayout({
         <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 transition-colors">
             {/* 共通ヘッダー */}
             <header className="sticky top-0 z-40 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-sm border-b border-gray-100 dark:border-zinc-800 shadow-sm">
-                <div className="flex items-center justify-center h-14 px-4 max-w-3xl mx-auto">
+                <div className="flex items-center justify-center h-14 px-4 max-w-5xl mx-auto">
                     <h1 className="text-base font-semibold text-gray-800 dark:text-zinc-100 flex items-center gap-1.5">
                         <Icon className={`h-4 w-4 ${iconColorClass}`} />
                         {title}


### PR DESCRIPTION
## 変更内容
- コンテンツ最大幅を max-w-3xl(768px) → max-w-5xl(1024px) に変更
- ナビバーの max-w-5xl と同幅に統一
- iPad mini横画面（1024px）での余白を解消

## 対象ファイル
- `components/ui/record-page-layout.tsx`（全記録ページ共通）
- `app/(dashboard)/dashboard/page.tsx`
- `app/(dashboard)/settings/` 配下5ページ