### PR TITLE
fix: Service Worker タイムアウトの改善（60s→20s＋未登録の即座検出）

### DIFF
--- a/frontend/hooks/usePushNotification.ts
+++ b/frontend/hooks/usePushNotification.ts
@@ -46,13 +46,32 @@ export function usePushNotification() {
     if (!("serviceWorker" in navigator)) return null;
 
     try {
-      // Service Worker が active になるまで最大 60 秒待機
-      const registration = await Promise.race([
-        navigator.serviceWorker.ready,
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("Service Worker の準備がタイムアウトしました。ページを再読み込みして再試行してください。")), 60000)
-        ),
-      ]);
+      // まず登録済み SW を確認する（ready より先に呼ぶことで「未登録」を即座に検出）
+      const existingReg = await navigator.serviceWorker.getRegistration("/");
+      if (!existingReg) {
+        throw new Error(
+          "Service Worker が登録されていません。ページを再読み込みして再試行してください。"
+        );
+      }
+
+      // active な SW が既にあればそのまま使う。インストール中の場合のみ ready を待機する
+      const registration = existingReg.active
+        ? existingReg
+        : await Promise.race([
+            navigator.serviceWorker.ready,
+            new Promise<never>((_, reject) =>
+              setTimeout(
+                () =>
+                  reject(
+                    new Error(
+                      "Service Worker の準備がタイムアウトしました。ページを再読み込みして再試行してください。"
+                    )
+                  ),
+                20000
+              )
+            ),
+          ]);
+
       if (!registration.pushManager) {
         throw new Error("プッシュ通知はこのブラウザ/環境では使用できません（PushManager が見つかりません）。");
       }


### PR DESCRIPTION
## 問題

navigator.serviceWorker.ready が resolve しない場合に 60 秒間ブロックされ、その後ユーザーに「タイムアウトした」エラーが表示されていた。

## 原因

ready は active な SW が存在しない限り永遠に待機する Promise。次のケースで長時間ブロックが発生:
- SW が初回インストール中（precache の fetch が完了するまで activate しない）
- SW が登録されていない（開発環境や SW が失敗した直後など）

## 修正内容

usePushNotification.ts の subscribeUser を変更:

1. getRegistration() で事前チェック: ready を待つ前に SW が登録済みかを確認。未登録なら即座にエラーを throw（以前は 60 秒後にタイムアウト）
2. active 確認で ready をスキップ: 既に active な SW があればそのまま使用し、不要な待機を排除
3. タイムアウトを 60s から 20s に短縮: インストール中の場合のみ適用されるため、より現実的な値に変更

## 影響範囲

frontend/hooks/usePushNotification.ts のみ。バックエンド変更なし。