### PR TITLE
fix: iOS PWA の通知購読失敗を修正＋購読解除UIを追加

### DIFF
--- a/frontend/app/(dashboard)/settings/notifications/page.tsx
+++ b/frontend/app/(dashboard)/settings/notifications/page.tsx
@@ -20,7 +20,7 @@ interface NotificationSettings {
 }
 
 export default function NotificationsPage() {
-  const { permission, requestPermission, subscribeUser, sendSubscriptionToBackend } = usePushNotification();
+  const { permission, subscription, requestPermission, subscribeUser, unsubscribeUser, sendSubscriptionToBackend } = usePushNotification();
   const [settings, setSettings] = useState<NotificationSettings | null>(null);
   const [loading, setLoading] = useState(true);
   const [dndInputsVisible, setDndInputsVisible] = useState(false);
@@ -177,7 +177,7 @@ export default function NotificationsPage() {
                 </Button>
               )}
             </div>
-            {permission === "granted" && (
+            {permission === "granted" && subscription && (
               <div className="flex items-center justify-between pt-2 border-t">
                 <div className="space-y-0.5">
                   <p className="text-sm font-medium">テスト通知を送信</p>
@@ -214,6 +214,40 @@ export default function NotificationsPage() {
                   }}
                 >
                   送信
+                </Button>
+              </div>
+            )}
+            {permission === "granted" && subscription && (
+              <div className="flex items-center justify-between pt-2 border-t">
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">このデバイスの通知を無効にする</p>
+                  <p className="text-xs text-muted-foreground">このデバイスへのプッシュ通知を停止します</p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  onClick={async () => {
+                    try {
+                      await unsubscribeUser(subscription);
+                      toast.success("このデバイスの通知を無効にしました");
+                    } catch {
+                      toast.error("通知の無効化に失敗しました");
+                    }
+                  }}
+                >
+                  無効にする
+                </Button>
+              </div>
+            )}
+            {permission === "granted" && !subscription && (
+              <div className="flex items-center justify-between pt-2 border-t">
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">このデバイスで通知を受け取る</p>
+                  <p className="text-xs text-muted-foreground">プッシュ通知の購読を登録します</p>
+                </div>
+                <Button size="sm" onClick={handleEnableNotifications}>
+                  購読する
                 </Button>
               </div>
             )}

--- a/frontend/hooks/usePushNotification.ts
+++ b/frontend/hooks/usePushNotification.ts
@@ -10,6 +10,17 @@ export function usePushNotification() {
     if ("Notification" in window) {
       setPermission(Notification.permission);
     }
+    // 既存の購読状態をSWから読み込む
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.getRegistrations().then((regs) => {
+        const reg = regs.find((r) => r.active) ?? regs[0];
+        if (reg?.pushManager) {
+          reg.pushManager.getSubscription().then((sub) => {
+            if (sub) setSubscription(sub);
+          });
+        }
+      });
+    }
   }, []);
 
   const requestPermission = async () => {
@@ -46,8 +57,11 @@ export function usePushNotification() {
     if (!("serviceWorker" in navigator)) return null;
 
     try {
-      // まず登録済み SW を確認する（ready より先に呼ぶことで「未登録」を即座に検出）
-      const existingReg = await navigator.serviceWorker.getRegistration("/");
+      // getRegistrations() で全登録を取得し active なものを選ぶ
+      // iOS PWA では getRegistration("/") がスコープ不一致で undefined を返すことがある
+      const regs = await navigator.serviceWorker.getRegistrations();
+      const existingReg = regs.find((r) => r.active) ?? regs[0];
+
       if (!existingReg) {
         throw new Error(
           "Service Worker が登録されていません。ページを再読み込みして再試行してください。"
@@ -79,6 +93,7 @@ export function usePushNotification() {
 
       if (existingSubscription) {
         await sendSubscriptionToBackend(existingSubscription);
+        setSubscription(existingSubscription);
         return existingSubscription;
       }
 
@@ -93,6 +108,20 @@ export function usePushNotification() {
       const msg = error instanceof Error ? error.message : String(error);
       console.error("Failed to subscribe user:", msg);
       throw new Error(msg);
+    }
+  };
+
+  const unsubscribeUser = async (sub: PushSubscription) => {
+    try {
+      await sub.unsubscribe();
+      await fetch(
+        `/api/notifications/unsubscribe?endpoint=${encodeURIComponent(sub.endpoint)}`,
+        { method: "POST" }
+      );
+      setSubscription(null);
+    } catch (error) {
+      console.error("Failed to unsubscribe:", error);
+      throw error;
     }
   };
 
@@ -127,6 +156,7 @@ export function usePushNotification() {
     subscription,
     requestPermission,
     subscribeUser,
+    unsubscribeUser,
     sendSubscriptionToBackend,
   };
 }


### PR DESCRIPTION
## 問題

1. iOS PWA で「有効にする」を押しても購読が登録されない
2. 通知を無効にする方法がない

## 原因（iOS PWA 購読失敗）

PR #729 で追加した `getRegistration("/")` が iOS PWA ではスコープ不一致のため `undefined` を返し、即エラーになっていた。iOS の SW はスコープが "/" と完全一致しないことがある。

## 修正内容

**`usePushNotification.ts`**
- `getRegistration("/")` → `getRegistrations()` に変更し、active な登録を探す
- マウント時に既存購読状態を SW から読み込み `subscription` state に反映
- `unsubscribeUser()` を追加（`pushManager.unsubscribe()` + バックエンドの購読レコード削除）

**`settings/notifications/page.tsx`**
- 購読済みのとき「このデバイスの通知を無効にする」ボタンを表示
- `permission === "granted"` かつ未購読のとき「購読する」ボタンを表示（再登録用）