### PR TITLE
fix: ServiceWorkerRegisterを追加してSWを手動登録（next-pwa Turbopack未対応の回避）

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "sonner";
 import { ThemeProvider } from "@/components/theme-provider";
 import { SplashScreen } from "@/components/ui/splash-screen";
 import Script from "next/script";
+import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -82,6 +83,7 @@ export default function RootLayout({
               strategy="afterInteractive"
             />
           )}
+          <ServiceWorkerRegister />
           <SplashScreen />
           {children}
           <Toaster />

--- a/frontend/components/ServiceWorkerRegister.tsx
+++ b/frontend/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js").catch((err) => {
+        console.error("Service Worker registration failed:", err);
+      });
+    }
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## 問題

next-pwaがTurbopack環境でSW登録スクリプトをHTMLに注入しない。`navigator.serviceWorker.register('/sw.js')`が呼ばれないためSWが未登録のまま。`navigator.serviceWorker.ready`は登録済みSWがない場合は解決せず、20秒タイムアウトになっていた。

## 修正

`ServiceWorkerRegister`クライアントコンポーネントを追加し、RootLayoutで全ページ共通でSWを登録するようにした。

## 関連

- #733: getRegistrations()でiOS PWA対応
- #735: sw.jsをprecacheなし最小構成に変更

## テスト

- デプロイ後にiOS PWAで通知設定 > 購読するボタンを押して登録できることを確認