### PR TITLE
fix: useBaseRecordのupdate/deleteのURL末尾スラッシュを除去（405エラー修正）

### DIFF
--- a/frontend/hooks/useBaseRecord.ts
+++ b/frontend/hooks/useBaseRecord.ts
@@ -27,14 +27,14 @@ export function useBaseRecord<T, TCreate, TUpdate>(
 
   // レコード更新
   const update = async (id: number, record: TUpdate): Promise<T | undefined> => {
-    const updatedRecord = await api.patch<T, TUpdate>(`/${endpoint}/${id}/`, record);
+    const updatedRecord = await api.patch<T, TUpdate>(`/${endpoint}/${id}`, record);
     mutate();
     return updatedRecord;
   };
 
   // レコード削除
   const remove = async (id: number) => {
-    await api.delete(`/${endpoint}/${id}/`);
+    await api.delete(`/${endpoint}/${id}`);
     mutate();
   };
 


### PR DESCRIPTION
## 問題

`useBaseRecord`の`update`と`remove`が末尾スラッシュ付きURL（例: `/feedings/1/`）でAPIを呼び出していた。FastAPIはPATCH/DELETEの末尾スラッシュを307リダイレクトせず405 Method Not Allowedを返す。

結果として授乳・おむつ記録の更新・削除が全件失敗していた。

## 修正

`///` → `//` に変更（末尾スラッシュ除去）。

## 影響範囲

- 授乳記録（feedings）更新・削除
- おむつ記録（diapers）更新・削除
- 睡眠記録（sleeps）更新・削除

## テスト

- 授乳記録の編集→保存が成功すること
- 授乳記録の削除が成功すること