### PR TITLE
✍️ Scribe: [新しい記録タイプ 'milestone' のアクセス権限設定・仕様書への追加漏れの修正]

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -250,3 +250,7 @@
 ## 2026-03-08 - [Pydantic v2形式(ConfigDict)への仕様書の追随漏れ]
 **学び:** `app/schemas/` 以下の多くのモデルが Pydantic v2 の `model_config = ConfigDict(from_attributes=True)` 構文に移行されているが、仕様書（`profile_settings.md` や `record_comments.md`）では依然として v1 時代の `class Config:\n    from_attributes = True` が残存している。ライブラリのメジャーバージョンアップに伴う記法変更は、ドキュメントに一括で反映されずドリフトしやすい。
 **アクション:** 今後の仕様書の更新やレビューでは、モデルのフィールド追加や削除だけでなく、ライブラリの構文（Pydantic v2 `ConfigDict` 等）が最新のバックエンド実装と一致しているかを定期的に確認し、古くなっている場合は同期を行う。
+
+## 2026-03-08 - [新しい記録タイプ 'milestone' のアクセス権限設定・仕様書への追加漏れ]
+**学び:** マイルストーン機能（`app/routers/milestones.py`）などの新しい記録タイプを追加し、API側で `verify_baby_access(..., record_type="milestone")` を呼び出す実装がされても、権限管理のリスト（`app/schemas/baby_permission.py` の `VALID_RECORD_TYPES` や `app/routers/baby_permissions.py` 内のバリデーションリスト、フロントエンドの `ALL_RECORD_TYPES`）および仕様書 `.specify/specs/settings/baby_permissions.md` に追記することが漏れやすい。
+**アクション:** 新しい機能・記録タイプを追加した際は、API実装だけでなく、権限管理APIのバリデーションや設定画面の表示ロジック、および対応する仕様書（UIモデルやTypeScriptインターフェース）すべてにその `record_type` が追加されているかを検証する。

--- a/.specify/specs/settings/baby_permissions.md
+++ b/.specify/specs/settings/baby_permissions.md
@@ -50,7 +50,8 @@ Baby（赤ちゃん全体の可視性）
        ├── contraction（陣痛）
        ├── schedule（スケジュール）
        ├── vaccination（予防接種）
-       └── note（汎用メモ）
+       ├── note（汎用メモ）
+       └── milestone（マイルストーン）
 ```
 
 ### `record_type` の有効値一覧
@@ -66,6 +67,7 @@ Baby（赤ちゃん全体の可視性）
 | `"schedule"` | スケジュール | `schedules` |
 | `"vaccination"` | 予防接種記録 | `vaccinations` |
 | `"note"` | 汎用メモ | `notes` |
+| `"milestone"` | 発育発達マイルストーン記録 | `milestones` |
 
 ### 権限判定ロジック
 
@@ -233,7 +235,8 @@ for record_type in VALID_RECORD_TYPES:
         { "record_type": "contraction", "can_view": false },
         { "record_type": "schedule",    "can_view": true  },
         { "record_type": "vaccination", "can_view": true  },
-        { "record_type": "note",        "can_view": true  }
+        { "record_type": "note",        "can_view": true  },
+        { "record_type": "milestone",   "can_view": true  }
       ]
     }
   ]
@@ -249,7 +252,7 @@ for record_type in VALID_RECORD_TYPES:
 ### リクエスト/レスポンススキーマ
 
 ```typescript
-type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note";
+type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone";
 
 // 単一の権限レコード（1ユーザー × 1record_type）
 interface BabyPermissionItem {

--- a/app/routers/baby_permissions.py
+++ b/app/routers/baby_permissions.py
@@ -45,7 +45,7 @@ def get_baby_permissions(
         FamilyUser.role.in_([UserRole.MEMBER, UserRole.VIEWER])
     ).all()
 
-    record_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination", "note"]
+    record_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination", "note", "milestone"]
     
     # 3. 全メンバーの BabyPermission を一括取得（N+1 の解消）
     member_user_ids = [u.id for _, u in members]
@@ -104,7 +104,7 @@ def update_baby_permissions(
     family_id = baby.family_id
 
     # 2. リクエストの各エントリについて検証
-    valid_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination", "note"]
+    valid_types = ["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination", "note", "milestone"]
     for entry in update_in.permissions:
         if entry.record_type not in valid_types:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid record_type: {entry.record_type}")

--- a/app/schemas/baby_permission.py
+++ b/app/schemas/baby_permission.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 from typing import List, Literal
 
 
-VALID_RECORD_TYPES = Literal["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination", "note"]
+VALID_RECORD_TYPES = Literal["baby", "feeding", "sleep", "diaper", "growth", "contraction", "schedule", "vaccination", "note", "milestone"]
 
 
 class BabyPermissionItem(BaseModel):

--- a/frontend/hooks/usePermissionsPage.ts
+++ b/frontend/hooks/usePermissionsPage.ts
@@ -40,7 +40,9 @@ const ALL_RECORD_TYPES = [
   "growth",
   "contraction",
   "schedule",
+  "vaccination",
   "note",
+  "milestone",
 ]
 
 export function usePermissionsPage() {


### PR DESCRIPTION
💡 何を:
- マイルストーン機能（`milestone`）のアクセス権限設定について、バックエンドのバリデーション、フロントエンドの表示ロジック、および対応する仕様書（`.specify/specs/settings/baby_permissions.md`）へ追記・同期しました。

🔍 発見:
- バックエンドのAPI実装（`app/routers/milestones.py`）では権限チェックに `verify_baby_access(..., record_type="milestone")` を呼び出しているものの、権限設定を司る `VALID_RECORD_TYPES` や `ALL_RECORD_TYPES` などの各種ハードコードされたリストから `"milestone"` が漏れていました。
- これにより、仕様書（`baby_permissions.md`）の `ValidRecordType` 等にも `"milestone"` が存在せず、権限管理画面でマイルストーンの可視性を明示的に制御・確認できないバグ（仕様書の不整合）が生じていました。

🎯 影響:
- 開発者とユーザーが権限設定機能を通して「マイルストーン」の表示/非表示を正確に把握・制御できるようになります。
- 新しいトラッカー機能（`vaccination`, `note`, `milestone`など）を追加した際に、システム全体で権限の定義リストが同期されることの重要性をジャーナルに記録し、将来の同様の追加漏れ（仕様ドリフト）を防ぎます。

---
*PR created automatically by Jules for task [4324709616995094981](https://jules.google.com/task/4324709616995094981) started by @eburairu*