### PR TITLE
✍️ Scribe: [AI Chatbot仕様のPydantic V2構文への更新]

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -254,3 +254,6 @@
 ## 2026-03-08 - [新しい記録タイプ 'milestone' のアクセス権限設定・仕様書への追加漏れ]
 **学び:** マイルストーン機能（`app/routers/milestones.py`）などの新しい記録タイプを追加し、API側で `verify_baby_access(..., record_type="milestone")` を呼び出す実装がされても、権限管理のリスト（`app/schemas/baby_permission.py` の `VALID_RECORD_TYPES` や `app/routers/baby_permissions.py` 内のバリデーションリスト、フロントエンドの `ALL_RECORD_TYPES`）および仕様書 `.specify/specs/settings/baby_permissions.md` に追記することが漏れやすい。
 **アクション:** 新しい機能・記録タイプを追加した際は、API実装だけでなく、権限管理APIのバリデーションや設定画面の表示ロジック、および対応する仕様書（UIモデルやTypeScriptインターフェース）すべてにその `record_type` が追加されているかを検証する。
+## 2024-05-19 - [Pydantic V2構文への移行]
+**学び:** バックエンドのPydanticモデルがV2構文（`model_config = ConfigDict(...)`）にアップデートされても、Markdown仕様書（`.specify/specs/`）内のコードブロックが古いV1構文（`class Config:`）のまま放置されやすい。
+**アクション:** 仕様書内のPythonコードブロックにV1構文が残っていないか定期的にgrepして確認し、実装と同期させる。

--- a/.specify/specs/ai/ai_chatbot.md
+++ b/.specify/specs/ai/ai_chatbot.md
@@ -133,8 +133,7 @@ class ChatMessageResponse(BaseModel):
     content: str
     created_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ChatSessionResponse(BaseModel):
@@ -145,8 +144,7 @@ class ChatSessionResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ChatSessionDetailResponse(BaseModel):
@@ -159,8 +157,7 @@ class ChatSessionDetailResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ChatSendResponse(BaseModel):


### PR DESCRIPTION
💡 何を (What):
`.specify/specs/ai/ai_chatbot.md` 内のPythonコードブロックに記載されていた `class Config: from_attributes = True` という古いPydantic V1構文を、現在のバックエンド実装（Pydantic V2）に合わせて `model_config = ConfigDict(from_attributes=True)` に更新しました。

対象のモデル:
- `ChatSessionResponse`
- `ChatSessionDetailResponse`
- `ChatSendResponse`
- `ChatMessageResponse`

🔍 発見 (Discovery):
バックエンドのPydanticモデルは全体的にV2構文に移行済みでしたが、AIチャットボット機能の仕様書内のサンプルコードブロックには古いV1構文が残存しているという仕様ドリフト（乖離）を発見しました。

🎯 影響 (Impact):
仕様書に記載されているコードブロックが実際のバックエンド実装（Pydantic V2）と完全に同期されるため、今後の開発者が古い記法を参照して混乱したり、誤った実装をコピペしたりするリスクを防ぐことができます。

---
*PR created automatically by Jules for task [5250664354149074190](https://jules.google.com/task/5250664354149074190) started by @eburairu*