### PR TITLE
feat: 体温記録機能を追加

### DIFF
--- a/alembic/versions/h1i2j3k4_add_temperature_records.py
+++ b/alembic/versions/h1i2j3k4_add_temperature_records.py
@@ -1,0 +1,45 @@
+"""add_temperature_records
+
+Revision ID: h1i2j3k4
+Revises: g1h2i3j4
+Create Date: 2026-03-09
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'h1i2j3k4'
+down_revision: Union[str, Sequence[str], None] = 'g1h2i3j4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE temperaturemethod AS ENUM ('AXILLARY', 'EAR', 'FOREHEAD', 'RECTAL');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$
+    """)
+    op.execute("""
+        CREATE TABLE temperature_records (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            baby_id INTEGER NOT NULL REFERENCES babies(id),
+            measured_at TIMESTAMP NOT NULL,
+            temperature FLOAT NOT NULL,
+            method temperaturemethod NOT NULL DEFAULT 'AXILLARY',
+            notes TEXT
+        )
+    """)
+    op.execute("CREATE INDEX ix_temperature_records_id ON temperature_records (id)")
+    op.execute("CREATE INDEX ix_temperature_records_user_id ON temperature_records (user_id)")
+    op.execute("CREATE INDEX ix_temperature_records_measured_at ON temperature_records (measured_at)")
+    op.execute("CREATE INDEX idx_temperature_baby_time ON temperature_records (baby_id, measured_at)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS temperature_records")
+    op.execute("DROP TYPE IF EXISTS temperaturemethod")

--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,7 @@ from app.routers import auth, family, baby, notifications, admin
 from app.routers import feeding, sleep, diaper, growth, contraction, schedule, note, baby_permissions, ai_summary, upload, comments, ai_feedback, ai_settings
 from app.routers import version, vaccinations, milestones
 from app.routers import timer
+from app.routers import temperatures
 
 app.include_router(version.router)
 app.include_router(auth.router)
@@ -71,6 +72,7 @@ app.include_router(ai_settings.router)
 app.include_router(upload.router)
 app.include_router(comments.router)
 app.include_router(timer.router)
+app.include_router(temperatures.router)
 
 frontend_build_path = os.path.join(os.path.dirname(__file__), "../frontend/out")
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -17,3 +17,4 @@ from .notification import AppNotification, PushSubscription, NotificationSetting
 from .system_settings import SystemSetting
 from .audit_log import AuditLog
 from .timer import ContractionTimerState, FeedingTimerState
+from .temperature import TemperatureRecord, TemperatureMethod

--- a/app/models/temperature.py
+++ b/app/models/temperature.py
@@ -1,0 +1,30 @@
+import enum
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, DateTime, Enum, Index
+from .base import Base
+
+
+class TemperatureMethod(str, enum.Enum):
+    AXILLARY = "AXILLARY"   # わきの下
+    EAR = "EAR"             # 耳
+    FOREHEAD = "FOREHEAD"   # 額
+    RECTAL = "RECTAL"       # 直腸
+
+
+class TemperatureRecord(Base):
+    __tablename__ = "temperature_records"
+
+    id = Column(Integer, primary_key=True, autoincrement=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    baby_id = Column(Integer, ForeignKey("babies.id"), nullable=False)
+    measured_at = Column(DateTime, nullable=False, index=True)
+    temperature = Column(Float, nullable=False)
+    method = Column(
+        Enum(TemperatureMethod, name="temperaturemethod"),
+        nullable=False,
+        default=TemperatureMethod.AXILLARY,
+    )
+    notes = Column(String, nullable=True)
+
+    __table_args__ = (
+        Index("idx_temperature_baby_time", "baby_id", "measured_at"),
+    )

--- a/app/routers/temperatures.py
+++ b/app/routers/temperatures.py
@@ -1,0 +1,147 @@
+from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from typing import List
+from app.core.constants import MAX_PAGINATION_LIMIT
+
+from app.dependencies import get_db, get_current_user, verify_baby_access
+from app.models.user import User
+from app.models.temperature import TemperatureRecord
+from app.models.comment import RecordComment
+from app.schemas.temperature import TemperatureCreate, TemperatureResponse, TemperatureUpdate
+from app.utils.timezone import to_jst_naive
+from app.utils.notifications import notify_family_members_bg
+from app.models.baby import Baby
+
+router = APIRouter(prefix="/api/temperatures", tags=["temperatures"])
+
+
+def _build_response(
+    record: TemperatureRecord, user_map: dict, comment_count_map: dict
+) -> TemperatureResponse:
+    r = TemperatureResponse.model_validate(record)
+    r.recorded_by_display_name = user_map.get(record.user_id)
+    r.comment_count = comment_count_map.get(record.id, 0)
+    return r
+
+
+@router.get("/", response_model=List[TemperatureResponse])
+def get_temperatures(
+    baby_id: int,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(MAX_PAGINATION_LIMIT, ge=1, le=MAX_PAGINATION_LIMIT),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    verify_baby_access(db, baby_id, current_user.id, record_type="temperature")
+    records = (
+        db.query(TemperatureRecord)
+        .filter(TemperatureRecord.baby_id == baby_id)
+        .order_by(TemperatureRecord.measured_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    record_ids = [r.id for r in records]
+    comment_count_map: dict = {}
+    if record_ids:
+        rows = (
+            db.query(RecordComment.record_id, func.count(RecordComment.id).label("cnt"))
+            .filter(
+                RecordComment.record_type == "temperature",
+                RecordComment.record_id.in_(record_ids),
+            )
+            .group_by(RecordComment.record_id)
+            .all()
+        )
+        comment_count_map = {row.record_id: row.cnt for row in rows}
+    user_ids = {r.user_id for r in records if r.user_id is not None}
+    users = db.query(User).filter(User.id.in_(user_ids)).all() if user_ids else []
+    user_map = {u.id: u.display_name or u.username for u in users}
+    return [_build_response(r, user_map, comment_count_map) for r in records]
+
+
+@router.post("/", response_model=TemperatureResponse)
+def create_temperature(
+    temp_in: TemperatureCreate,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    verify_baby_access(db, temp_in.baby_id, current_user.id, record_type="temperature", require_write=True)
+    record = TemperatureRecord(
+        user_id=current_user.id,
+        baby_id=temp_in.baby_id,
+        measured_at=to_jst_naive(temp_in.measured_at),
+        temperature=temp_in.temperature,
+        method=temp_in.method,
+        notes=temp_in.notes,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+
+    baby = db.query(Baby).filter(Baby.id == record.baby_id).first()
+    display_name = current_user.display_name or current_user.username
+    if baby:
+        notify_family_members_bg(
+            background_tasks,
+            baby.family_id,
+            current_user.id,
+            title="体温の記録",
+            body=f"{display_name}さんが{baby.name}の体温を記録しました（{record.temperature}°C）。",
+            url=f"/temperature?baby_id={baby.id}",
+            category="family_record",
+        )
+
+    response = TemperatureResponse.model_validate(record)
+    response.recorded_by_display_name = display_name
+    return response
+
+
+@router.put("/{record_id}", response_model=TemperatureResponse)
+def update_temperature(
+    record_id: int,
+    temp_in: TemperatureUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    record = db.query(TemperatureRecord).filter(TemperatureRecord.id == record_id).first()
+    if not record:
+        raise HTTPException(status_code=404, detail="Temperature record not found")
+    verify_baby_access(db, record.baby_id, current_user.id, record_type="temperature", require_write=True)
+
+    if temp_in.measured_at is not None:
+        record.measured_at = to_jst_naive(temp_in.measured_at)
+    if temp_in.temperature is not None:
+        record.temperature = temp_in.temperature
+    if temp_in.method is not None:
+        record.method = temp_in.method
+    if temp_in.notes is not None:
+        record.notes = temp_in.notes
+
+    db.commit()
+    db.refresh(record)
+    recorder = db.query(User).filter(User.id == record.user_id).first()
+    response = TemperatureResponse.model_validate(record)
+    response.recorded_by_display_name = (recorder.display_name or recorder.username) if recorder else None
+    return response
+
+
+@router.delete("/{record_id}")
+def delete_temperature(
+    record_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    record = db.query(TemperatureRecord).filter(TemperatureRecord.id == record_id).first()
+    if not record:
+        raise HTTPException(status_code=404, detail="Temperature record not found")
+    verify_baby_access(db, record.baby_id, current_user.id, record_type="temperature", require_write=True)
+    db.query(RecordComment).filter(
+        RecordComment.record_type == "temperature",
+        RecordComment.record_id == record_id,
+    ).delete()
+    db.delete(record)
+    db.commit()
+    return {"message": "Deleted"}

--- a/app/schemas/temperature.py
+++ b/app/schemas/temperature.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from typing import Optional
+from datetime import datetime
+from app.models.temperature import TemperatureMethod
+from app.core.constants import NOTE_MAX_LENGTH
+
+TEMPERATURE_MIN = 34.0
+TEMPERATURE_MAX = 42.0
+
+
+class TemperatureCreate(BaseModel):
+    baby_id: int
+    measured_at: datetime
+    temperature: float = Field(..., ge=TEMPERATURE_MIN, le=TEMPERATURE_MAX)
+    method: TemperatureMethod = TemperatureMethod.AXILLARY
+    notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
+
+
+class TemperatureUpdate(BaseModel):
+    measured_at: Optional[datetime] = None
+    temperature: Optional[float] = Field(None, ge=TEMPERATURE_MIN, le=TEMPERATURE_MAX)
+    method: Optional[TemperatureMethod] = None
+    notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
+
+
+class TemperatureResponse(TemperatureCreate):
+    id: int
+    user_id: int
+    recorded_by_display_name: Optional[str] = None
+    comment_count: int = 0
+
+    model_config = ConfigDict(from_attributes=True)

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -46,6 +46,7 @@ const ALL_NAV_ITEMS: {
     { label: "成長",         href: "/growth",      Icon: AppIcons.growth,      color: "text-emerald-500", prenatal: false, postnatal: true  },
     { label: "予防接種",     href: "/vaccinations",Icon: AppIcons.vaccination,    color: "text-sky-500",     prenatal: false, postnatal: true  },
     { label: "発育発達マイルストーン",href: "/milestones",  Icon: AppIcons.milestone,     color: "text-yellow-500",  prenatal: false, postnatal: true  },
+    { label: "体温",         href: "/temperature", Icon: AppIcons.temperature,   color: "text-orange-500",  prenatal: false, postnatal: true  },
     { label: "メモ",         href: "/note",        Icon: AppIcons.note, color: "text-blue-500",  prenatal: false, postnatal: true  },
     { label: "日誌",         href: "/diary",       Icon: AppIcons.diary,   color: "text-purple-500",  prenatal: false, postnatal: true  },
     { label: "陣痛タイマー", href: "/contraction", Icon: AppIcons.contraction,      color: "text-red-500",     prenatal: true,  postnatal: false },

--- a/frontend/app/(dashboard)/temperature/page.tsx
+++ b/frontend/app/(dashboard)/temperature/page.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { AppIcons } from "@/constants/icons"
+import { useTemperatures } from "@/hooks/useTemperatures"
+import { useRecordPage } from "@/hooks/useRecordPage"
+import { TemperatureStats } from "@/components/temperature/TemperatureStats"
+import { TemperatureChart } from "@/components/temperature/TemperatureChart"
+import { TemperatureForm } from "@/components/temperature/TemperatureForm"
+import { TemperatureHistory } from "@/components/temperature/TemperatureHistory"
+import { RecordPageLayout } from "@/components/ui/record-page-layout"
+
+/**
+ * 体温記録ページ
+ */
+export default function TemperaturePage() {
+    const {
+        babyId,
+        isLoading: babiesLoading,
+        canWrite,
+        triggerFeedback,
+        commentRecordId,
+    } = useRecordPage()
+
+    const {
+        temperatures,
+        isLoading: temperaturesLoading,
+        isError: temperatureError,
+        mutate,
+        deleteTemperature,
+    } = useTemperatures(babyId ?? null)
+
+    const handleRefresh = async () => {
+        await mutate()
+    }
+
+    return (
+        <RecordPageLayout
+            title="体温記録"
+            icon={AppIcons.temperature}
+            iconColorClass="text-orange-500 dark:text-orange-400"
+            isLoading={babiesLoading}
+            isDataLoading={temperaturesLoading}
+            apiError={temperatureError}
+            babyId={babyId}
+            onRefresh={handleRefresh}
+        >
+            <TemperatureStats temperatures={temperatures || []} />
+
+            <TemperatureChart temperatures={temperatures || []} />
+
+            {canWrite && babyId && (
+                <TemperatureForm
+                    babyId={babyId}
+                    onSuccess={(recordId) => {
+                        mutate()
+                        if (recordId) triggerFeedback("temperature", recordId)
+                    }}
+                />
+            )}
+
+            <TemperatureHistory
+                temperatures={temperatures || []}
+                onDelete={deleteTemperature}
+                onRefresh={handleRefresh}
+                canWrite={canWrite}
+                initialCommentRecordId={commentRecordId ?? null}
+            />
+        </RecordPageLayout>
+    )
+}

--- a/frontend/components/temperature/TemperatureChart.tsx
+++ b/frontend/components/temperature/TemperatureChart.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import {
+    LineChart,
+    Line,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+    ReferenceLine,
+} from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Temperature, FEVER_THRESHOLD, HIGH_FEVER_THRESHOLD, getFeverStatus } from "@/types/temperature"
+import { useMemo, useState } from "react"
+import { useTheme } from "next-themes"
+import { getChartGridColor, getChartTextColor, getChartTooltipStyle } from "@/components/charts/ChartStyles"
+import { formatDateTime, formatTime, subtractDays } from "@/lib/dateUtils"
+
+interface Props {
+    temperatures: Temperature[]
+}
+
+type QuickRange = "1d" | "3d" | "7d" | "1m" | "all"
+
+const QUICK_RANGES: { label: string; value: QuickRange }[] = [
+    { label: "24h", value: "1d" },
+    { label: "3日", value: "3d" },
+    { label: "7日", value: "7d" },
+    { label: "1ヶ月", value: "1m" },
+    { label: "全期間", value: "all" },
+]
+
+function getStartTime(range: QuickRange, now: Date): Date | null {
+    switch (range) {
+        case "1d": return subtractDays(now, 1)
+        case "3d": return subtractDays(now, 3)
+        case "7d": return subtractDays(now, 7)
+        case "1m": return subtractDays(now, 30)
+        case "all": return null
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function CustomDot(props: any) {
+    const { cx, cy, payload } = props
+    if (!payload || cx == null || cy == null) return null
+    const status = getFeverStatus(payload.temperature)
+    const fill = status === "high_fever" ? "#ef4444" : status === "fever" ? "#f97316" : "#10b981"
+    return <circle cx={cx} cy={cy} r={4} fill={fill} stroke="white" strokeWidth={1.5} />
+}
+
+export function TemperatureChart({ temperatures }: Props) {
+    const { resolvedTheme } = useTheme()
+    const isDark = resolvedTheme === "dark"
+    const [range, setRange] = useState<QuickRange>("7d")
+
+    const chartData = useMemo(() => {
+        const now = new Date()
+        const start = getStartTime(range, now)
+        const filtered = start
+            ? temperatures.filter((t) => new Date(t.measured_at) >= start)
+            : temperatures
+
+        return [...filtered]
+            .sort((a, b) => new Date(a.measured_at).getTime() - new Date(b.measured_at).getTime())
+            .map((t) => ({
+                time: new Date(t.measured_at).getTime(),
+                temperature: t.temperature,
+            }))
+    }, [temperatures, range])
+
+    const tooltipStyle = getChartTooltipStyle(isDark)
+
+    if (temperatures.length === 0) return null
+
+    return (
+        <Card className="dark:bg-zinc-900 rounded-2xl shadow-sm border-0 mb-6 transition-colors">
+            <CardHeader className="pb-2">
+                <div className="flex items-center justify-between flex-wrap gap-2">
+                    <CardTitle className="text-sm font-semibold text-gray-700 dark:text-zinc-300">
+                        体温の推移
+                    </CardTitle>
+                    <div className="flex gap-1 flex-wrap">
+                        {QUICK_RANGES.map((r) => (
+                            <Button
+                                key={r.value}
+                                variant={range === r.value ? "default" : "outline"}
+                                size="sm"
+                                className={`h-6 px-2 text-xs rounded-lg ${
+                                    range === r.value
+                                        ? "bg-orange-500 hover:bg-orange-600 text-white border-orange-500"
+                                        : ""
+                                }`}
+                                onClick={() => setRange(r.value)}
+                            >
+                                {r.label}
+                            </Button>
+                        ))}
+                    </div>
+                </div>
+            </CardHeader>
+            <CardContent>
+                {chartData.length === 0 ? (
+                    <p className="text-center text-sm text-muted-foreground py-8">
+                        この期間の記録がありません
+                    </p>
+                ) : (
+                    <ResponsiveContainer width="100%" height={200}>
+                        <LineChart data={chartData} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+                            <CartesianGrid
+                                strokeDasharray="3 3"
+                                stroke={getChartGridColor(isDark)}
+                                vertical={false}
+                            />
+                            <XAxis
+                                dataKey="time"
+                                type="number"
+                                domain={["dataMin", "dataMax"]}
+                                scale="time"
+                                tickFormatter={(v) => formatDateTime(v)}
+                                tick={{ fontSize: 10, fill: getChartTextColor(isDark) }}
+                            />
+                            <YAxis
+                                domain={[35, "auto"]}
+                                tickFormatter={(v) => `${v}`}
+                                tick={{ fontSize: 10, fill: getChartTextColor(isDark) }}
+                                width={32}
+                            />
+                            <Tooltip
+                                contentStyle={tooltipStyle}
+                                labelFormatter={(v) => formatDateTime(v)}
+                                formatter={(value) => value != null ? [`${(value as number).toFixed(1)}°C`, "体温"] : ["—", "体温"]}
+                            />
+                            <ReferenceLine
+                                y={FEVER_THRESHOLD}
+                                stroke="#f97316"
+                                strokeDasharray="4 4"
+                                label={{
+                                    value: "発熱",
+                                    position: "insideTopRight",
+                                    fontSize: 10,
+                                    fill: "#f97316",
+                                }}
+                            />
+                            <ReferenceLine
+                                y={HIGH_FEVER_THRESHOLD}
+                                stroke="#ef4444"
+                                strokeDasharray="4 4"
+                                label={{
+                                    value: "高熱",
+                                    position: "insideTopRight",
+                                    fontSize: 10,
+                                    fill: "#ef4444",
+                                }}
+                            />
+                            <Line
+                                type="monotone"
+                                dataKey="temperature"
+                                stroke="#10b981"
+                                strokeWidth={2}
+                                dot={<CustomDot />}
+                                activeDot={{ r: 6 }}
+                                connectNulls
+                            />
+                        </LineChart>
+                    </ResponsiveContainer>
+                )}
+            </CardContent>
+        </Card>
+    )
+}

--- a/frontend/components/temperature/TemperatureEditDialog.tsx
+++ b/frontend/components/temperature/TemperatureEditDialog.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { Temperature } from "@/types/temperature"
+import { EditDialogBase } from "@/components/records/EditDialogBase"
+import { TemperatureForm } from "./TemperatureForm"
+
+interface Props {
+    temperature: Temperature | null
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    onSuccess: () => void
+}
+
+export function TemperatureEditDialog({ temperature, open, onOpenChange, onSuccess }: Props) {
+    if (!temperature) return null
+
+    return (
+        <EditDialogBase open={open} onOpenChange={onOpenChange} title="体温の編集">
+            <TemperatureForm
+                babyId={temperature.baby_id}
+                initialData={temperature}
+                onSuccess={() => {
+                    onSuccess()
+                    onOpenChange(false)
+                }}
+            />
+        </EditDialogBase>
+    )
+}

--- a/frontend/components/temperature/TemperatureForm.tsx
+++ b/frontend/components/temperature/TemperatureForm.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { formatDateTimeLocal } from "@/lib/dateUtils"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { ErrorMessage } from "@/components/ui/error-message"
+import { UI_BUTTONS } from "@/constants/ui-colors"
+import { cn } from "@/lib/utils"
+import { temperatureSchema, TemperatureFormValues } from "@/schemas/temperature"
+import { useBaseRecordForm } from "@/hooks/useBaseRecordForm"
+import { api } from "@/lib/api"
+import {
+    Temperature,
+    TemperatureCreate,
+    TemperatureUpdate,
+    TemperatureMethod,
+    TEMPERATURE_METHOD_LABELS,
+} from "@/types/temperature"
+
+interface Props {
+    babyId: string | number
+    initialData?: Temperature
+    onSuccess: (recordId?: number) => void
+    onUpdate?: (id: number, data: TemperatureUpdate) => Promise<Temperature | undefined>
+}
+
+export function TemperatureForm({ babyId, initialData, onSuccess, onUpdate }: Props) {
+    const isEditing = !!initialData
+
+    const form = useForm<TemperatureFormValues>({
+        resolver: zodResolver(temperatureSchema),
+        defaultValues: {
+            measured_at: initialData?.measured_at
+                ? formatDateTimeLocal(initialData.measured_at)
+                : formatDateTimeLocal(new Date()),
+            temperature: initialData?.temperature != null ? String(initialData.temperature) : "",
+            method: initialData?.method ?? TemperatureMethod.AXILLARY,
+            notes: initialData?.notes ?? "",
+        },
+    })
+
+    const { submitRecord, isSubmitting, error } = useBaseRecordForm<TemperatureFormValues>({
+        endpoint: "/temperatures/",
+        babyId,
+        onSuccess: (data) => {
+            if (!isEditing) {
+                form.reset({
+                    measured_at: formatDateTimeLocal(new Date()),
+                    temperature: "",
+                    method: TemperatureMethod.AXILLARY,
+                    notes: "",
+                })
+            }
+            onSuccess((data as { id?: number })?.id)
+        },
+        errorMessage: "エラーが発生しました。もう一度お試しください。",
+        successMessage: isEditing ? "更新しました" : undefined,
+    })
+
+    const onSubmit = async (values: TemperatureFormValues) => {
+        try {
+            await submitRecord<TemperatureCreate, Temperature | undefined>(
+                values,
+                (vals) => ({
+                    baby_id: Number(babyId),
+                    measured_at: new Date(vals.measured_at).toISOString(),
+                    temperature: parseFloat(vals.temperature),
+                    method: vals.method,
+                    notes: vals.notes?.trim() || null,
+                }),
+                isEditing && initialData
+                    ? async (payload: TemperatureCreate) => {
+                          const updatePayload: TemperatureUpdate = {
+                              measured_at: payload.measured_at,
+                              temperature: payload.temperature,
+                              method: payload.method,
+                              notes: payload.notes,
+                          }
+                          if (onUpdate) {
+                              return await onUpdate(initialData.id, updatePayload)
+                          } else {
+                              return await api.put<Temperature>(
+                                  `/temperatures/${initialData.id}`,
+                                  updatePayload
+                              )
+                          }
+                      }
+                    : undefined
+            )
+        } catch (e) {
+            console.error(e)
+        }
+    }
+
+    return (
+        <Card
+            className={cn(
+                "rounded-2xl shadow-sm border-0 mb-6 transition-colors",
+                isEditing && "mb-0 shadow-none"
+            )}
+        >
+            <CardContent className={cn("pt-6", isEditing && "p-0")}>
+                <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                        <div className="grid grid-cols-2 gap-3">
+                            <FormField
+                                control={form.control}
+                                name="temperature"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel className="text-xs text-muted-foreground">
+                                            体温 (°C)
+                                        </FormLabel>
+                                        <FormControl>
+                                            <div className="relative">
+                                                <Input
+                                                    type="number"
+                                                    step="0.1"
+                                                    min="34.0"
+                                                    max="42.0"
+                                                    placeholder="36.5"
+                                                    {...field}
+                                                />
+                                                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
+                                                    °C
+                                                </span>
+                                            </div>
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={form.control}
+                                name="method"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel className="text-xs text-muted-foreground">
+                                            測定部位
+                                        </FormLabel>
+                                        <FormControl>
+                                            <select
+                                                {...field}
+                                                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                                            >
+                                                {Object.entries(TEMPERATURE_METHOD_LABELS).map(
+                                                    ([value, label]) => (
+                                                        <option key={value} value={value}>
+                                                            {label}
+                                                        </option>
+                                                    )
+                                                )}
+                                            </select>
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+
+                        <FormField
+                            control={form.control}
+                            name="measured_at"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel className="text-xs text-muted-foreground">
+                                        測定日時
+                                    </FormLabel>
+                                    <FormControl>
+                                        <Input type="datetime-local" {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="notes"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel className="text-xs text-muted-foreground">
+                                        メモ
+                                    </FormLabel>
+                                    <FormControl>
+                                        <Input placeholder="症状、薬の服用など..." {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        {error && <ErrorMessage message={error} />}
+
+                        <Button
+                            type="submit"
+                            className={cn("w-full rounded-xl h-11", UI_BUTTONS.primary)}
+                            loading={isSubmitting}
+                            data-sentry-unmask
+                        >
+                            {isEditing ? "更新する" : "保存する"}
+                        </Button>
+                    </form>
+                </Form>
+            </CardContent>
+        </Card>
+    )
+}

--- a/frontend/components/temperature/TemperatureHistory.tsx
+++ b/frontend/components/temperature/TemperatureHistory.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { Thermometer } from "lucide-react"
+import { Temperature, getFeverStatus, TEMPERATURE_METHOD_LABELS } from "@/types/temperature"
+import { formatDateTime } from "@/lib/dateUtils"
+import { cn } from "@/lib/utils"
+import { GenericRecordHistory } from "@/components/records/GenericRecordHistory"
+import { TemperatureEditDialog } from "./TemperatureEditDialog"
+
+interface Props {
+    temperatures: Temperature[]
+    onDelete: (id: number) => Promise<void>
+    onRefresh: () => void
+    canWrite?: boolean
+    initialCommentRecordId?: number | null
+}
+
+function FeverBadge({ temp }: { temp: number }) {
+    const status = getFeverStatus(temp)
+    if (status === "normal") return null
+    return (
+        <span
+            className={cn(
+                "ml-1.5 text-[10px] font-bold px-1.5 py-0.5 rounded-full",
+                status === "high_fever"
+                    ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                    : "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400"
+            )}
+        >
+            {status === "high_fever" ? "高熱" : "発熱"}
+        </span>
+    )
+}
+
+export function TemperatureHistory({
+    temperatures,
+    onDelete,
+    onRefresh,
+    canWrite = true,
+    initialCommentRecordId,
+}: Props) {
+    return (
+        <GenericRecordHistory<Temperature>
+            records={temperatures}
+            recordType="temperature"
+            resourceName="体温記録"
+            canWrite={canWrite}
+            initialCommentRecordId={initialCommentRecordId}
+            onRefresh={onRefresh}
+            onDelete={onDelete}
+            getCommentTitle={(t) =>
+                `${t.temperature.toFixed(1)}°C ${formatDateTime(t.measured_at)}`
+            }
+            itemClassName={() =>
+                "bg-orange-50 border-orange-100 dark:bg-orange-900/10 dark:border-orange-800/30"
+            }
+            renderIcon={() => (
+                <Thermometer className="w-4 h-4 text-orange-500 dark:text-orange-400" />
+            )}
+            renderTitle={(t) => (
+                <div className="text-sm font-bold text-orange-700 dark:text-orange-400">
+                    {t.temperature.toFixed(1)}°C
+                    <FeverBadge temp={t.temperature} />
+                    <span className="text-xs font-normal text-gray-500 dark:text-zinc-500 ml-2">
+                        {TEMPERATURE_METHOD_LABELS[t.method]}
+                    </span>
+                    <span className="text-xs font-normal text-gray-500 dark:text-zinc-500 ml-2">
+                        {formatDateTime(t.measured_at)}
+                    </span>
+                </div>
+            )}
+            renderDetails={(t) =>
+                t.notes ? (
+                    <div className="text-xs text-gray-600 dark:text-zinc-400 mt-0.5">
+                        {t.notes}
+                    </div>
+                ) : null
+            }
+            renderEditDialog={(target, open, setOpen) => (
+                <TemperatureEditDialog
+                    temperature={target}
+                    open={open}
+                    onOpenChange={setOpen}
+                    onSuccess={() => {
+                        setOpen(false)
+                        onRefresh()
+                    }}
+                />
+            )}
+        />
+    )
+}

--- a/frontend/components/temperature/TemperatureStats.tsx
+++ b/frontend/components/temperature/TemperatureStats.tsx
@@ -1,0 +1,87 @@
+import { Thermometer } from "lucide-react"
+import { Temperature, getFeverStatus, HIGH_FEVER_THRESHOLD, FEVER_THRESHOLD } from "@/types/temperature"
+import { StatsCard } from "@/components/ui/stats-card"
+import { StatsBlock } from "@/components/ui/stats-block"
+import { formatElapsed } from "@/lib/ageUtils"
+import { cn } from "@/lib/utils"
+
+interface Props {
+    temperatures: Temperature[]
+}
+
+function FeverBadge({ temp }: { temp: number }) {
+    const status = getFeverStatus(temp)
+    if (status === "normal") return null
+
+    return (
+        <span
+            className={cn(
+                "ml-2 text-xs font-bold px-1.5 py-0.5 rounded-full",
+                status === "high_fever"
+                    ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                    : "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400"
+            )}
+        >
+            {status === "high_fever" ? "高熱" : "発熱"}
+        </span>
+    )
+}
+
+export function TemperatureStats({ temperatures }: Props) {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    const todayTemps = temperatures.filter(
+        (t) => new Date(t.measured_at) >= today
+    )
+    const maxTodayTemp = todayTemps.length > 0
+        ? Math.max(...todayTemps.map((t) => t.temperature))
+        : null
+
+    const latest = temperatures[0] ?? null
+    const latestElapsed = latest ? formatElapsed(latest.measured_at) : null
+
+    return (
+        <StatsCard>
+            <div className="grid grid-cols-2 gap-4">
+                <StatsBlock
+                    icon={Thermometer}
+                    label="直近の体温"
+                    value={
+                        latest ? (
+                            <span className="flex items-center">
+                                {latest.temperature.toFixed(1)}°C
+                                <FeverBadge temp={latest.temperature} />
+                            </span>
+                        ) : "—"
+                    }
+                    color="amber"
+                >
+                    {latestElapsed && (
+                        <p className="text-[10px] text-gray-500 dark:text-zinc-500">
+                            {latestElapsed}
+                        </p>
+                    )}
+                </StatsBlock>
+
+                <StatsBlock
+                    icon={Thermometer}
+                    label="今日の最高体温"
+                    value={
+                        maxTodayTemp != null ? (
+                            <span className="flex items-center">
+                                {maxTodayTemp.toFixed(1)}°C
+                                <FeverBadge temp={maxTodayTemp} />
+                            </span>
+                        ) : "—"
+                    }
+                    color="amber"
+                >
+                    <p className="text-[10px] text-gray-500 dark:text-zinc-500">
+                        {todayTemps.length > 0 ? `${todayTemps.length}回測定` : "本日の記録なし"}
+                    </p>
+                </StatsBlock>
+            </div>
+        </StatsCard>
+    )
+}

--- a/frontend/constants/icons.ts
+++ b/frontend/constants/icons.ts
@@ -13,6 +13,7 @@ import {
   Biohazard,
   HandHeart,
   Bed,
+  Thermometer,
   type LucideIcon,
 } from "lucide-react";
 import { RECORD_TYPES } from "@/types/enums";
@@ -34,6 +35,7 @@ export const AppIcons = {
   diary: BookOpen, // 日誌
   vaccination: Syringe, // 予防接種
   milestone: Trophy, // マイルストーン
+  temperature: Thermometer, // 体温
 
   // 状態やサブアクションのアイコン
   baby: Baby, // 赤ちゃん（プロフィール等）

--- a/frontend/hooks/useRecordFeedback.ts
+++ b/frontend/hooks/useRecordFeedback.ts
@@ -4,7 +4,7 @@ import { api } from "@/lib/api";
 import { useSWRConfig } from "swr";
 import { API_TIMEOUT_MS } from "@/constants";
 
-export type RecordType = typeof RECORD_TYPES.FEEDING | "diaper" | "growth" | "note";
+export type RecordType = typeof RECORD_TYPES.FEEDING | "diaper" | "growth" | "note" | "temperature";
 
 interface FeedbackResponse {
   feedback: string;

--- a/frontend/hooks/useTemperatures.ts
+++ b/frontend/hooks/useTemperatures.ts
@@ -1,0 +1,27 @@
+import { Temperature, TemperatureCreate, TemperatureUpdate } from '@/types/temperature'
+import { useBaseRecord } from './useBaseRecord'
+
+/**
+ * 体温記録を扱うフック
+ */
+export function useTemperatures(babyId: string | number | null) {
+    const {
+        data: temperatures,
+        isLoading,
+        isError,
+        add,
+        update,
+        remove,
+        refresh,
+    } = useBaseRecord<Temperature, TemperatureCreate, TemperatureUpdate>(babyId, 'temperatures')
+
+    return {
+        temperatures,
+        isLoading,
+        isError,
+        addTemperature: add,
+        updateTemperature: update,
+        deleteTemperature: remove,
+        mutate: refresh,
+    }
+}

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3267,6 +3267,179 @@
         "title": "SuperAdminToggleRequest",
         "type": "object"
       },
+      "TemperatureCreate": {
+        "properties": {
+          "baby_id": {
+            "title": "Baby Id",
+            "type": "integer"
+          },
+          "measured_at": {
+            "format": "date-time",
+            "title": "Measured At",
+            "type": "string"
+          },
+          "method": {
+            "$ref": "#/components/schemas/TemperatureMethod",
+            "default": "AXILLARY"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "temperature": {
+            "maximum": 42.0,
+            "minimum": 34.0,
+            "title": "Temperature",
+            "type": "number"
+          }
+        },
+        "required": [
+          "baby_id",
+          "measured_at",
+          "temperature"
+        ],
+        "title": "TemperatureCreate",
+        "type": "object"
+      },
+      "TemperatureMethod": {
+        "enum": [
+          "AXILLARY",
+          "EAR",
+          "FOREHEAD",
+          "RECTAL"
+        ],
+        "title": "TemperatureMethod",
+        "type": "string"
+      },
+      "TemperatureResponse": {
+        "properties": {
+          "baby_id": {
+            "title": "Baby Id",
+            "type": "integer"
+          },
+          "comment_count": {
+            "default": 0,
+            "title": "Comment Count",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "measured_at": {
+            "format": "date-time",
+            "title": "Measured At",
+            "type": "string"
+          },
+          "method": {
+            "$ref": "#/components/schemas/TemperatureMethod",
+            "default": "AXILLARY"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "recorded_by_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recorded By Display Name"
+          },
+          "temperature": {
+            "maximum": 42.0,
+            "minimum": 34.0,
+            "title": "Temperature",
+            "type": "number"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "baby_id",
+          "measured_at",
+          "temperature",
+          "id",
+          "user_id"
+        ],
+        "title": "TemperatureResponse",
+        "type": "object"
+      },
+      "TemperatureUpdate": {
+        "properties": {
+          "measured_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Measured At"
+          },
+          "method": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TemperatureMethod"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "temperature": {
+            "anyOf": [
+              {
+                "maximum": 42.0,
+                "minimum": 34.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temperature"
+          }
+        },
+        "title": "TemperatureUpdate",
+        "type": "object"
+      },
       "UnifiedRecord": {
         "properties": {
           "comment_count": {
@@ -7508,6 +7681,204 @@
         "summary": "Update Sleep",
         "tags": [
           "sleeps"
+        ]
+      }
+    },
+    "/api/temperatures/": {
+      "get": {
+        "operationId": "get_temperatures_api_temperatures__get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "baby_id",
+            "required": true,
+            "schema": {
+              "title": "Baby Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TemperatureResponse"
+                  },
+                  "title": "Response Get Temperatures Api Temperatures  Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Temperatures",
+        "tags": [
+          "temperatures"
+        ]
+      },
+      "post": {
+        "operationId": "create_temperature_api_temperatures__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TemperatureCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemperatureResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Temperature",
+        "tags": [
+          "temperatures"
+        ]
+      }
+    },
+    "/api/temperatures/{record_id}": {
+      "delete": {
+        "operationId": "delete_temperature_api_temperatures__record_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "record_id",
+            "required": true,
+            "schema": {
+              "title": "Record Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Temperature",
+        "tags": [
+          "temperatures"
+        ]
+      },
+      "put": {
+        "operationId": "update_temperature_api_temperatures__record_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "record_id",
+            "required": true,
+            "schema": {
+              "title": "Record Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TemperatureUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemperatureResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Temperature",
+        "tags": [
+          "temperatures"
         ]
       }
     },

--- a/frontend/schemas/temperature.ts
+++ b/frontend/schemas/temperature.ts
@@ -1,0 +1,23 @@
+import * as z from "zod"
+import { TemperatureMethod } from "@/types/temperature"
+
+const TEMPERATURE_MIN = 34.0
+const TEMPERATURE_MAX = 42.0
+
+export const temperatureSchema = z.object({
+    measured_at: z.string().min(1, "日時を選択してください"),
+    temperature: z
+        .string()
+        .min(1, "体温を入力してください")
+        .refine(
+            (val) => {
+                const num = parseFloat(val)
+                return !isNaN(num) && num >= TEMPERATURE_MIN && num <= TEMPERATURE_MAX
+            },
+            { message: `体温は${TEMPERATURE_MIN}〜${TEMPERATURE_MAX}°Cの範囲で入力してください` }
+        ),
+    method: z.nativeEnum(TemperatureMethod),
+    notes: z.string().optional(),
+})
+
+export type TemperatureFormValues = z.infer<typeof temperatureSchema>

--- a/frontend/types/enums.ts
+++ b/frontend/types/enums.ts
@@ -9,6 +9,7 @@ export const RECORD_TYPES = {
   GROWTH: 'growth',
   NOTE: 'note',
   CONTRACTION: 'contraction',
+  TEMPERATURE: 'temperature',
 } as const;
 
 export type RecordType = typeof RECORD_TYPES[keyof typeof RECORD_TYPES];

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -1057,6 +1057,42 @@ export interface paths {
         patch: operations["update_sleep_api_sleeps__sleep_id__patch"];
         trace?: never;
     };
+    "/api/temperatures/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Temperatures */
+        get: operations["get_temperatures_api_temperatures__get"];
+        put?: never;
+        /** Create Temperature */
+        post: operations["create_temperature_api_temperatures__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/temperatures/{record_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update Temperature */
+        put: operations["update_temperature_api_temperatures__record_id__put"];
+        post?: never;
+        /** Delete Temperature */
+        delete: operations["delete_temperature_api_temperatures__record_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/upload/image": {
         parameters: {
             query?: never;
@@ -2192,6 +2228,64 @@ export interface components {
         SuperAdminToggleRequest: {
             /** Is Superadmin */
             is_superadmin: boolean;
+        };
+        /** TemperatureCreate */
+        TemperatureCreate: {
+            /** Baby Id */
+            baby_id: number;
+            /**
+             * Measured At
+             * Format: date-time
+             */
+            measured_at: string;
+            /** @default AXILLARY */
+            method: components["schemas"]["TemperatureMethod"];
+            /** Notes */
+            notes?: string | null;
+            /** Temperature */
+            temperature: number;
+        };
+        /**
+         * TemperatureMethod
+         * @enum {string}
+         */
+        TemperatureMethod: "AXILLARY" | "EAR" | "FOREHEAD" | "RECTAL";
+        /** TemperatureResponse */
+        TemperatureResponse: {
+            /** Baby Id */
+            baby_id: number;
+            /**
+             * Comment Count
+             * @default 0
+             */
+            comment_count: number;
+            /** Id */
+            id: number;
+            /**
+             * Measured At
+             * Format: date-time
+             */
+            measured_at: string;
+            /** @default AXILLARY */
+            method: components["schemas"]["TemperatureMethod"];
+            /** Notes */
+            notes?: string | null;
+            /** Recorded By Display Name */
+            recorded_by_display_name?: string | null;
+            /** Temperature */
+            temperature: number;
+            /** User Id */
+            user_id: number;
+        };
+        /** TemperatureUpdate */
+        TemperatureUpdate: {
+            /** Measured At */
+            measured_at?: string | null;
+            method?: components["schemas"]["TemperatureMethod"] | null;
+            /** Notes */
+            notes?: string | null;
+            /** Temperature */
+            temperature?: number | null;
         };
         /** UnifiedRecord */
         UnifiedRecord: {
@@ -5040,6 +5134,138 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SleepResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_temperatures_api_temperatures__get: {
+        parameters: {
+            query: {
+                baby_id: number;
+                skip?: number;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TemperatureResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_temperature_api_temperatures__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TemperatureCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TemperatureResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_temperature_api_temperatures__record_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                record_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TemperatureUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TemperatureResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_temperature_api_temperatures__record_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                record_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/frontend/types/temperature.ts
+++ b/frontend/types/temperature.ts
@@ -1,0 +1,32 @@
+import type { components } from "@/types/generated/api"
+
+export const TemperatureMethod = {
+    AXILLARY: "AXILLARY",
+    EAR: "EAR",
+    FOREHEAD: "FOREHEAD",
+    RECTAL: "RECTAL",
+} as const
+
+export type TemperatureMethod = components["schemas"]["TemperatureMethod"]
+
+export type Temperature = components["schemas"]["TemperatureResponse"]
+export type TemperatureCreate = components["schemas"]["TemperatureCreate"]
+export type TemperatureUpdate = components["schemas"]["TemperatureUpdate"]
+
+export const TEMPERATURE_METHOD_LABELS: Record<TemperatureMethod, string> = {
+    AXILLARY: "わきの下",
+    EAR: "耳",
+    FOREHEAD: "額",
+    RECTAL: "直腸",
+}
+
+export const FEVER_THRESHOLD = 37.5
+export const HIGH_FEVER_THRESHOLD = 38.0
+
+export type FeverStatus = "high_fever" | "fever" | "normal"
+
+export function getFeverStatus(temp: number): FeverStatus {
+    if (temp >= HIGH_FEVER_THRESHOLD) return "high_fever"
+    if (temp >= FEVER_THRESHOLD) return "fever"
+    return "normal"
+}

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1,0 +1,202 @@
+import pytest
+from fastapi.testclient import TestClient
+from datetime import datetime, timedelta
+from app.models.temperature import TemperatureRecord
+
+
+def test_get_temperatures_unauthorized(client: TestClient):
+    response = client.get("/api/temperatures/?baby_id=1")
+    assert response.status_code == 401
+
+
+def test_get_temperatures_missing_baby_id(client: TestClient, auth_client):
+    client = auth_client()
+    response = client.get("/api/temperatures/")
+    assert response.status_code == 422
+
+
+def test_create_temperature(client: TestClient, auth_client):
+    client = auth_client()
+
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    assert baby_res.status_code == 200
+    baby_id = baby_res.json()["id"]
+
+    # 基本的な体温記録（わきの下）
+    resp = client.post(
+        "/api/temperatures/",
+        json={
+            "baby_id": baby_id,
+            "measured_at": datetime.now().isoformat(),
+            "temperature": 37.2,
+            "method": "AXILLARY",
+            "notes": "測定メモ",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["temperature"] == 37.2
+    assert data["method"] == "AXILLARY"
+    assert data["notes"] == "測定メモ"
+    assert "id" in data
+    assert "recorded_by_display_name" in data
+    assert "comment_count" in data
+
+
+def test_create_temperature_all_methods(client: TestClient, auth_client):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    for method in ["AXILLARY", "EAR", "FOREHEAD", "RECTAL"]:
+        resp = client.post(
+            "/api/temperatures/",
+            json={
+                "baby_id": baby_id,
+                "measured_at": datetime.now().isoformat(),
+                "temperature": 36.5,
+                "method": method,
+            },
+        )
+        assert resp.status_code == 200, f"method={method} failed"
+        assert resp.json()["method"] == method
+
+
+def test_create_temperature_default_method(client: TestClient, auth_client):
+    """method 省略時はデフォルトで AXILLARY になること"""
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    resp = client.post(
+        "/api/temperatures/",
+        json={
+            "baby_id": baby_id,
+            "measured_at": datetime.now().isoformat(),
+            "temperature": 36.8,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["method"] == "AXILLARY"
+
+
+def test_get_temperatures_list(client: TestClient, auth_client):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    # 2件作成
+    for temp in [37.0, 38.2]:
+        client.post(
+            "/api/temperatures/",
+            json={
+                "baby_id": baby_id,
+                "measured_at": datetime.now().isoformat(),
+                "temperature": temp,
+            },
+        )
+
+    response = client.get(f"/api/temperatures/?baby_id={baby_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert "recorded_by_display_name" in data[0]
+    assert "comment_count" in data[0]
+    # 降順（新しい順）であること
+    assert data[0]["temperature"] == 38.2
+    assert data[1]["temperature"] == 37.0
+
+
+def test_update_temperature(client: TestClient, auth_client):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    resp = client.post(
+        "/api/temperatures/",
+        json={
+            "baby_id": baby_id,
+            "measured_at": datetime.now().isoformat(),
+            "temperature": 37.0,
+            "method": "AXILLARY",
+        },
+    )
+    record_id = resp.json()["id"]
+
+    # 更新
+    response = client.put(
+        f"/api/temperatures/{record_id}",
+        json={
+            "temperature": 38.5,
+            "method": "EAR",
+            "notes": "更新後のメモ",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["temperature"] == 38.5
+    assert response.json()["method"] == "EAR"
+    assert response.json()["notes"] == "更新後のメモ"
+
+
+def test_delete_temperature(client: TestClient, auth_client, db):
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    resp = client.post(
+        "/api/temperatures/",
+        json={
+            "baby_id": baby_id,
+            "measured_at": datetime.now().isoformat(),
+            "temperature": 36.9,
+        },
+    )
+    record_id = resp.json()["id"]
+
+    response = client.delete(f"/api/temperatures/{record_id}")
+    assert response.status_code == 200
+    assert db.query(TemperatureRecord).filter(TemperatureRecord.id == record_id).first() is None
+
+
+def test_temperature_access_control(client: TestClient, auth_client):
+    client1 = auth_client(username="user1", family_name="Family1")
+    baby_res = client1.post("/api/babies/", json={"name": "赤ちゃん1", "gender": "girl"})
+    baby_id = baby_res.json()["id"]
+
+    temp_res = client1.post(
+        "/api/temperatures/",
+        json={
+            "baby_id": baby_id,
+            "measured_at": datetime.now().isoformat(),
+            "temperature": 37.0,
+        },
+    )
+    record_id = temp_res.json()["id"]
+
+    client2 = auth_client(username="user2", family_name="Family2")
+
+    # 他の家族の一覧取得 → 403
+    assert client2.get(f"/api/temperatures/?baby_id={baby_id}").status_code == 403
+    # 他の家族の記録を更新 → 403
+    assert client2.put(f"/api/temperatures/{record_id}", json={"notes": "不正"}).status_code == 403
+    # 他の家族の記録を削除 → 403
+    assert client2.delete(f"/api/temperatures/{record_id}").status_code == 403
+
+
+def test_temperature_invalid_range(client: TestClient, auth_client):
+    """34.0〜42.0°C の範囲外はバリデーションエラー"""
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    for temp in [33.9, 42.1]:
+        resp = client.post(
+            "/api/temperatures/",
+            json={
+                "baby_id": baby_id,
+                "measured_at": datetime.now().isoformat(),
+                "temperature": temp,
+            },
+        )
+        assert resp.status_code == 422, f"temperature={temp} should be rejected"


### PR DESCRIPTION
## 概要

体温記録の CRUD 機能をバックエンド・フロントエンドの両面で実装

## 共通化の方針

既存インフラを最大限流用し、新規実装を最小化:
- useBaseRecord → useTemperatures フック（ラッパーのみ）
- RecordPageLayout → ページレイアウトをそのまま流用
- GenericRecordHistory → 履歴表示を共通コンポーネントで実装
- useRecordDelete / useRecordComments → 削除確認・コメント機能を自動適用
- バックエンドの verify_baby_access / notify_family_members_bg パターンをそのまま踏襲

## 変更内容

**バックエンド**
- TemperatureRecord モデル・TemperatureMethod Enum
- Create / Update / Response スキーマ（34〜42°C バリデーション）
- GET / POST / PUT / DELETE エンドポイント
- Alembic マイグレーション追加

**フロントエンド**
- TemperatureForm: 体温・測定部位・日時・メモ
- TemperatureStats: 直近体温・今日の最高体温・発熱バッジ
- TemperatureChart: 折れ線グラフ（37.5°C / 38.0°C 基準線）
- TemperatureHistory: GenericRecordHistory ベース
- ナビゲーションに「体温」を追加

## テスト

- バックエンド: 10件 Green（CRUD・アクセス制御・バリデーション）
- フロントエンド: pnpm build 成功