### PR TITLE
feat: #766 画像URLの署名付きURL化によるセキュア配信

### DIFF
--- a/app/routers/ai_summary.py
+++ b/app/routers/ai_summary.py
@@ -13,6 +13,7 @@ from app.utils.notifications import notify_family_members
 from app.utils.rate_limit import RateLimiter
 from app.utils.timezone import get_jst_today
 from app.core import constants
+from app.utils.s3 import extract_object_key
 
 daily_summary_limiter = RateLimiter(
     requests_limit=constants.RATE_LIMIT_AI_SUMMARY_REQUESTS,
@@ -185,7 +186,7 @@ def edit_daily_summary(
     summary.edited_content = body.edited_content
     summary.is_edited = body.edited_content is not None
     if body.image_urls is not None:
-        summary.image_urls = body.image_urls
+        summary.image_urls = [extract_object_key(url) for url in body.image_urls]
     db.commit()
     db.refresh(summary)
     return summary

--- a/app/routers/milestones.py
+++ b/app/routers/milestones.py
@@ -8,6 +8,7 @@ from app.models.milestone import Milestone
 from app.models.baby import Baby
 from app.schemas.milestone import MilestoneCreate, MilestoneUpdate, MilestoneResponse, MilestoneTimelineGroup
 from datetime import date
+from app.utils.s3 import extract_object_key
 
 router = APIRouter(prefix="/api/milestones", tags=["milestones"])
 
@@ -28,8 +29,13 @@ async def create_milestone(
     current_user: User = Depends(get_current_user)
 ):
     verify_baby_access(db, baby_id, current_user.id, require_write=True)
+    
+    milestone_data = milestone.model_dump()
+    if milestone_data.get("image_urls"):
+        milestone_data["image_urls"] = [extract_object_key(url) for url in milestone_data["image_urls"]]
+        
     db_milestone = Milestone(
-        **milestone.model_dump(),
+        **milestone_data,
         baby_id=baby_id,
         user_id=current_user.id
     )
@@ -52,6 +58,9 @@ async def update_milestone(
     verify_baby_access(db, db_milestone.baby_id, current_user.id, require_write=True)
     
     update_data = milestone_update.model_dump(exclude_unset=True)
+    if "image_urls" in update_data and update_data["image_urls"] is not None:
+        update_data["image_urls"] = [extract_object_key(url) for url in update_data["image_urls"]]
+        
     for key, value in update_data.items():
         setattr(db_milestone, key, value)
     

--- a/app/routers/upload.py
+++ b/app/routers/upload.py
@@ -10,6 +10,7 @@ from app.dependencies import get_db, get_current_user, verify_write_access
 from app.models.user import User
 from app.utils.rate_limit import RateLimiter
 from app.core import constants
+from app.utils.s3 import generate_presigned_url
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ upload_limiter = RateLimiter(
 
 
 class UploadResponse(BaseModel):
-    public_url: str
+    public_url: str  # 署名付きURLを返す（名前は互換性のために保持）
     filename: str
 
 
@@ -119,6 +120,11 @@ async def upload_image(
             detail="画像のアップロードに失敗しました。",
         )
 
-    public_url = f"{public_endpoint.rstrip('/')}/{object_key}"
+    # 署名付きURLを生成（デフォルト1時間）
+    signed_url = generate_presigned_url(object_key)
+    if not signed_url:
+        # フォールバック（通常は起こらないはずだが、設定ミスなどの場合）
+        public_endpoint = os.getenv("R2_PUBLIC_ENDPOINT", "")
+        signed_url = f"{public_endpoint.rstrip('/')}/{object_key}"
 
-    return UploadResponse(public_url=public_url, filename=object_key)
+    return UploadResponse(public_url=signed_url, filename=object_key)

--- a/app/schemas/ai_summary.py
+++ b/app/schemas/ai_summary.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, computed_field, ConfigDict
-from typing import Optional
+from pydantic import BaseModel, computed_field, ConfigDict, field_validator
+from typing import Optional, List
 from datetime import date, datetime
+from app.utils.s3 import sign_image_urls
 
 
 class DailySummaryCreate(BaseModel):
@@ -24,6 +25,11 @@ class DailySummaryResponse(BaseModel):
     image_urls: list[str] = []
     created_at: datetime
     updated_at: datetime
+
+    @field_validator("image_urls", mode="after")
+    @classmethod
+    def secure_image_urls(cls, v: List[str]) -> List[str]:
+        return sign_image_urls(v)
 
     @computed_field
     @property

--- a/app/schemas/milestone.py
+++ b/app/schemas/milestone.py
@@ -1,7 +1,8 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from datetime import date
 from typing import Optional, List
 from app.core.constants import NOTE_MAX_LENGTH
+from app.utils.s3 import sign_image_urls
 
 class MilestoneBase(BaseModel):
     milestone_type: str = Field(..., max_length=50)
@@ -24,6 +25,11 @@ class MilestoneResponse(MilestoneBase):
     id: int
     baby_id: int
     user_id: Optional[int]
+
+    @field_validator("image_urls", mode="after")
+    @classmethod
+    def secure_image_urls(cls, v: List[str]) -> List[str]:
+        return sign_image_urls(v)
 
     model_config = ConfigDict(from_attributes=True)
 class MilestoneTimelineGroup(BaseModel):

--- a/app/utils/s3.py
+++ b/app/utils/s3.py
@@ -1,0 +1,70 @@
+import os
+import boto3
+from botocore.exceptions import ClientError
+from typing import List, Optional
+import logging
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+def _get_s3_client():
+    account_id = os.getenv("R2_ACCOUNT_ID")
+    access_key = os.getenv("R2_ACCESS_KEY_ID")
+    secret_key = os.getenv("R2_SECRET_ACCESS_KEY")
+    if not account_id or not access_key or not secret_key:
+        return None
+    
+    return boto3.client(
+        "s3",
+        endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="auto",
+    )
+
+def generate_presigned_url(object_key: str, expiration: int = 3600) -> Optional[str]:
+    """オブジェクトキーから署名付きURLを生成する。"""
+    client = _get_s3_client()
+    if not client:
+        # 環境変数が設定されていない場合は、元のキーがURLならそのまま、そうでなければNoneを返す
+        if object_key.startswith("http"):
+            return object_key
+        return None
+
+    bucket_name = os.getenv("R2_BUCKET_NAME", "baby-app-images")
+    try:
+        url = client.generate_presigned_url(
+            'get_object',
+            Params={'Bucket': bucket_name, 'Key': object_key},
+            ExpiresIn=expiration
+        )
+        return url
+    except ClientError as e:
+        logger.error(f"Error generating presigned URL for {object_key}: {e}")
+        return None
+
+def extract_object_key(url_or_key: str) -> str:
+    """URLまたはキーからオブジェクトキー（ファイル名）を抽出する。"""
+    if not url_or_key.startswith("http"):
+        return url_or_key
+    
+    parsed_url = urlparse(url_or_key)
+    # パスの最後の部分をキーとして扱う（ディレクトリ構造がある場合は要調整）
+    # 現状の実装ではフラットに保存されているため、path.lstrip('/') で十分
+    return parsed_url.path.lstrip('/')
+
+def sign_image_urls(image_urls: List[str]) -> List[str]:
+    """画像URL（またはキー）のリストを署名付きURLのリストに変換する。"""
+    if not image_urls:
+        return []
+    
+    signed_urls = []
+    for item in image_urls:
+        key = extract_object_key(item)
+        signed_url = generate_presigned_url(key)
+        if signed_url:
+            signed_urls.append(signed_url)
+        else:
+            # フォールバックとして元の値を入れる（キーがそのまま返る可能性があるが、エラーログは出ている）
+            signed_urls.append(item)
+    return signed_urls

--- a/tests/test_secure_image_urls.py
+++ b/tests/test_secure_image_urls.py
@@ -1,0 +1,90 @@
+import pytest
+from datetime import date
+from unittest.mock import patch, MagicMock
+from app.models.baby import Baby
+from app.models.family import FamilyUser
+from app.models.milestone import Milestone
+from app.utils.s3 import extract_object_key
+
+def setup_test_data(auth_client, db):
+    client = auth_client(username="secureuser", password="password123")
+    response_me = client.get("/api/auth/me")
+    user_id = response_me.json()["id"]
+    fu = db.query(FamilyUser).filter(FamilyUser.user_id == user_id).first()
+    
+    baby = Baby(family_id=fu.family_id, name="Secure Baby", birthday=date(2026, 1, 1))
+    db.add(baby)
+    db.commit()
+    db.refresh(baby)
+    return client, baby, user_id
+
+@patch("app.utils.s3._get_s3_client")
+def test_secure_milestone_image_urls(mock_get_s3, auth_client, db):
+    # Mock S3 client and presigned URL generation
+    mock_client = MagicMock()
+    mock_get_s3.return_value = mock_client
+    mock_client.generate_presigned_url.side_effect = lambda operation, Params, ExpiresIn: f"https://signed-url.r2.dev/{Params['Key']}?signature=test"
+
+    client, baby, _ = setup_test_data(auth_client, db)
+    
+    # 1. Create a Milestone with a full URL
+    # Backend should extract the key "uuid123.webp" and store only that.
+    image_url = "https://pub-xxx.r2.dev/uuid123.webp"
+    response = client.post(f"/api/milestones/?baby_id={baby.id}", json={
+        "milestone_type": "crawling",
+        "title": "ハイハイ",
+        "achieved_date": "2026-03-09",
+        "image_urls": [image_url],
+        "notes": "Secure test"
+    })
+    
+    assert response.status_code == 201
+    data = response.json()
+    
+    # The returned URL should be the signed one
+    assert data["image_urls"][0].startswith("https://signed-url.r2.dev/uuid123.webp?signature=")
+    
+    # Verify what's stored in the database
+    db_milestone = db.query(Milestone).filter(Milestone.id == data["id"]).first()
+    # It should store only the key "uuid123.webp"
+    assert db_milestone.image_urls == ["uuid123.webp"]
+
+@patch("app.utils.s3._get_s3_client")
+def test_secure_daily_summary_image_urls(mock_get_s3, auth_client, db):
+    # Mock S3 client and presigned URL generation
+    mock_client = MagicMock()
+    mock_get_s3.return_value = mock_client
+    mock_client.generate_presigned_url.side_effect = lambda operation, Params, ExpiresIn: f"https://signed-url.r2.dev/{Params['Key']}?signature=test"
+
+    client, baby, _ = setup_test_data(auth_client, db)
+    
+    # Create daily summary first (it's created by POST /api/babies/{id}/daily-summary)
+    summary_date = "2026-03-09"
+    # We need to bypass actual AI generation for test or just assume it works.
+    # Here we'll just manually insert a summary to test the PATCH endpoint.
+    from app.models.ai_summary import DailySummary
+    summary = DailySummary(
+        baby_id=baby.id,
+        summary_date=date(2026, 3, 9),
+        generated_content="Test content",
+        is_edited=False
+    )
+    db.add(summary)
+    db.commit()
+
+    # PATCH with image URLs
+    image_url = "https://pub-xxx.r2.dev/summary_img.webp"
+    response = client.patch(f"/api/babies/{baby.id}/daily-summary/{summary_date}", json={
+        "image_urls": [image_url]
+    })
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    # The returned URL should be the signed one
+    assert data["image_urls"][0].startswith("https://signed-url.r2.dev/summary_img.webp?signature=")
+    
+    # Verify what's stored in the database
+    db_summary = db.query(DailySummary).filter(DailySummary.baby_id == baby.id, DailySummary.summary_date == date(2026, 3, 9)).first()
+    # It should store only the key "summary_img.webp"
+    assert db_summary.image_urls == ["summary_img.webp"]


### PR DESCRIPTION
## 概要

Closes #766

## 変更内容

画像URLの署名付きURL化によるセキュア配信

## 実装方法

- Gemini CLIによる自動実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認