### PR TITLE
fix: #771以降の画像保存不具合（extract_object_keyのバケット名除去漏れ）を修正

### DIFF
--- a/app/utils/s3.py
+++ b/app/utils/s3.py
@@ -47,11 +47,15 @@ def extract_object_key(url_or_key: str) -> str:
     """URLまたはキーからオブジェクトキー（ファイル名）を抽出する。"""
     if not url_or_key.startswith("http"):
         return url_or_key
-    
+
     parsed_url = urlparse(url_or_key)
-    # パスの最後の部分をキーとして扱う（ディレクトリ構造がある場合は要調整）
-    # 現状の実装ではフラットに保存されているため、path.lstrip('/') で十分
-    return parsed_url.path.lstrip('/')
+    path = parsed_url.path.lstrip('/')
+    # R2のpresigned URLはパスが <bucket_name>/<object_key> 形式になるため
+    # バケット名プレフィックスを除去する
+    bucket_name = os.getenv("R2_BUCKET_NAME", "baby-app-images")
+    if path.startswith(bucket_name + '/'):
+        return path[len(bucket_name) + 1:]
+    return path
 
 def sign_image_urls(image_urls: List[str]) -> List[str]:
     """画像URL（またはキー）のリストを署名付きURLのリストに変換する。"""

--- a/tests/test_secure_image_urls.py
+++ b/tests/test_secure_image_urls.py
@@ -6,6 +6,25 @@ from app.models.family import FamilyUser
 from app.models.milestone import Milestone
 from app.utils.s3 import extract_object_key
 
+
+def test_extract_object_key_from_r2_presigned_url():
+    """R2のpresigned URL（bucket名がパスに含まれる形式）からオブジェクトキーを正しく抽出できること。"""
+    # R2 presigned URLの形式: https://<account>.r2.cloudflarestorage.com/<bucket>/<key>?signature...
+    presigned = "https://abc123.r2.cloudflarestorage.com/baby-app-images/550e8400.jpg?X-Amz-Algorithm=AWS4"
+    assert extract_object_key(presigned) == "550e8400.jpg"
+
+
+def test_extract_object_key_from_public_domain_url():
+    """カスタムドメインのURL（bucket名がパスに含まれない形式）からオブジェクトキーを正しく抽出できること。"""
+    public = "https://pub.example.com/550e8400.jpg"
+    assert extract_object_key(public) == "550e8400.jpg"
+
+
+def test_extract_object_key_passthrough_for_plain_key():
+    """オブジェクトキーをそのまま渡した場合はそのまま返ること。"""
+    key = "550e8400.jpg"
+    assert extract_object_key(key) == "550e8400.jpg"
+
 def setup_test_data(auth_client, db):
     client = auth_client(username="secureuser", password="password123")
     response_me = client.get("/api/auth/me")


### PR DESCRIPTION
## 問題

PR #771（署名付きURL化）以降、画像がアップロードできなくなっていた。

### 根本原因

`extract_object_key()` が R2 の presigned URL を解析する際、バケット名を含んだパスをオブジェクトキーとして返していた。

- presigned URL の形式: `https://<account>.r2.cloudflarestorage.com/<bucket>/<key>?...`
- `urlparse().path.lstrip('/')` の結果: `baby-app-images/uuid.jpg`（バケット名込み）
- 本来あるべき値: `uuid.jpg`

その結果、DB に不正なキーが保存され、次回の署名付きURL生成で `bucket='baby-app-images', key='baby-app-images/uuid.jpg'` でリクエストされて 404 になっていた。

## 修正内容

`extract_object_key()` でバケット名プレフィックスを除去するよう修正。

## テスト

- R2 presigned URL 形式（バケット名付き）からの抽出テストを追加
- カスタムドメインURL（バケット名なし）の既存動作が維持されることを確認
- 既存テスト 5件全て Green