### PR TITLE
fix: #765 メンバー未存在時の権限取得APIにおける空リスト判定漏れ

### DIFF
--- a/app/routers/baby_permissions.py
+++ b/app/routers/baby_permissions.py
@@ -48,6 +48,13 @@ def get_baby_permissions(
     
     # 3. 全メンバーの BabyPermission を一括取得（N+1 の解消）
     member_user_ids = [u.id for _, u in members]
+    if not member_user_ids:
+        return BabyPermissionsResponse(
+            baby_id=baby.id,
+            baby_name=baby.name,
+            members=[]
+        )
+
     all_perms = db.query(BabyPermission).filter(
         BabyPermission.baby_id == baby_id,
         BabyPermission.user_id.in_(member_user_ids)

--- a/tests/test_baby_permissions.py
+++ b/tests/test_baby_permissions.py
@@ -188,3 +188,31 @@ def test_baby_visible_after_permission_granted(setup_data):
     assert response.status_code == 200
     babies = response.json()
     assert any(b["id"] == baby.id for b in babies)
+
+def test_get_permissions_empty_members(db: Session):
+    """メンバーがいない場合（adminのみの場合）に空リストが返ることを確認し、空のIN句によるエラーを防止する"""
+    global _mock_user
+    suffix = str(uuid.uuid4())[:8]
+    family = Family(name="Solo Family", invite_code=f"SOLO-{suffix}")
+    db.add(family)
+    db.flush()
+
+    admin_user = User(id=4001, username=f"soloadmin-{suffix}", hashed_password="hashed")
+    db.add(admin_user)
+    db.flush()
+    db.add(FamilyUser(family_id=family.id, user_id=admin_user.id, role="admin"))
+
+    baby = Baby(id=5001, family_id=family.id, name="Solo Baby")
+    db.add(baby)
+    db.flush()
+    db.commit()
+
+    _mock_user = admin_user
+    client = TestClient(app)
+    response = client.get(f"/api/babies/{baby.id}/permissions")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["baby_id"] == baby.id
+    assert data["members"] == []
+


### PR DESCRIPTION
## 概要

Closes #765

## 変更内容

メンバー未存在時の権限取得APIにおける空リスト判定漏れ

## 実装方法

- Gemini CLIによる自動実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認