### PR TITLE
fix: #801 AI日誌生成(upsert)時の競合エラーを防ぐ排他ロックの導入

### DIFF
--- a/app/routers/ai_summary.py
+++ b/app/routers/ai_summary.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, text
 from sqlalchemy.orm import Session
+from sqlalchemy.dialects.postgresql import insert
 from typing import List
 from datetime import date, datetime
 import openai
@@ -15,6 +17,29 @@ from app.utils.rate_limit import RateLimiter
 from app.utils.timezone import get_jst_today
 from app.core import constants
 from app.utils.s3 import extract_object_key
+
+
+def acquire_ai_summary_lock(db: Session, baby_id: int, summary_date: date) -> None:
+    """
+    pg_advisory_xact_lock を使って (baby_id, summary_date) の組み合わせに対する
+    排他ロックをトランザクション内で取得する。
+
+    ロックキーは 64-bit 整数 2 つ（baby_id, date を YYYYMMDD 整数に変換）で構成する。
+    トランザクション終了時に自動解放されるため明示的な解放は不要。
+
+    SQLite（テスト環境）では pg_advisory_xact_lock が存在しないため、
+    dialect チェックにより実行をスキップする。
+    """
+    dialect = db.bind.dialect.name if db.bind else "sqlite"
+    if dialect != "postgresql":
+        # SQLite など PostgreSQL 以外では何もしない（テスト環境）
+        return
+
+    date_int = int(summary_date.strftime("%Y%m%d"))
+    db.execute(
+        text("SELECT pg_advisory_xact_lock(:key1, :key2)"),
+        {"key1": baby_id, "key2": date_int},
+    )
 
 daily_summary_limiter = RateLimiter(
     requests_limit=constants.RATE_LIMIT_AI_SUMMARY_REQUESTS,
@@ -45,6 +70,11 @@ def create_or_get_daily_summary(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="未来の日付では日誌を生成できません。",
         )
+
+    # (baby_id, summary_date) への競合書き込みを防ぐ排他ロックを取得。
+    # 同一キーへの並行リクエストはここでブロックされ、先行トランザクション完了後に
+    # 順次処理される（UniqueViolation / SerializationFailure を回避）。
+    acquire_ai_summary_lock(db, baby_id, body.summary_date)
 
     existing = (
         db.query(DailySummary)

--- a/tests/test_issue_801_advisory_lock.py
+++ b/tests/test_issue_801_advisory_lock.py
@@ -1,0 +1,211 @@
+"""
+Issue #801: AI日誌生成(upsert)時の競合エラーを防ぐ排他ロックの導入
+
+テスト対象:
+  - upsert 実行前に acquire_ai_summary_lock() が呼ばれること
+  - acquire_ai_summary_lock() が pg_advisory_xact_lock を発行すること（SQLite テストではモック）
+  - ロック取得済みの場合（2回目のリクエスト）でも is_edited フラグによる分岐が正常に動くこと
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock, call
+from datetime import date
+
+from app.models.family import Family
+from app.models.user import User
+from app.models.baby import Baby
+from app.models.ai_summary import DailySummary
+from app.dependencies import get_current_user
+from sqlalchemy.orm import Session
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+def _setup_user_and_baby(db: Session):
+    user = User(username="lock_test_user", hashed_password="fake")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    family = Family(name="Lock Test Family", invite_code="LOCK-801")
+    db.add(family)
+    db.commit()
+    db.refresh(family)
+
+    baby = Baby(
+        family_id=family.id,
+        name="ロックちゃん",
+        gender="girl",
+        birthday=date.today(),
+    )
+    db.add(baby)
+    db.commit()
+    db.refresh(baby)
+
+    return user, baby
+
+
+# ---------------------------------------------------------------------------
+# テスト1: upsert 前に acquire_ai_summary_lock が呼ばれること（RED -> GREEN）
+# ---------------------------------------------------------------------------
+
+def test_advisory_lock_is_called_on_upsert(db: Session, client):
+    """
+    POST /api/babies/{baby_id}/daily-summary を呼んだ際に
+    acquire_ai_summary_lock(db, baby_id, summary_date) が必ず呼ばれることを確認する。
+    """
+    user, baby = _setup_user_and_baby(db)
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    try:
+        with patch("app.routers.ai_summary.verify_baby_access") as mock_verify, \
+             patch("app.routers.ai_summary.generate_daily_summary") as mock_generate, \
+             patch("app.routers.ai_summary.acquire_ai_summary_lock") as mock_lock:
+
+            mock_verify.return_value = baby
+            mock_generate.return_value = ("テスト日誌内容", "gemini-2.0-flash")
+
+            today_str = date.today().isoformat()
+            response = client.post(
+                f"/api/babies/{baby.id}/daily-summary",
+                json={"summary_date": today_str},
+            )
+
+            assert response.status_code == 201, response.text
+            # ロック関数が1回呼ばれていること
+            mock_lock.assert_called_once()
+            # baby_id と summary_date を引数に含むこと
+            call_args = mock_lock.call_args
+            assert baby.id in call_args.args or baby.id in call_args.kwargs.values()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# テスト2: acquire_ai_summary_lock が pg_advisory_xact_lock を実行すること
+# ---------------------------------------------------------------------------
+
+def test_acquire_ai_summary_lock_executes_pg_advisory_lock(db: Session):
+    """
+    acquire_ai_summary_lock() が db.execute() で pg_advisory_xact_lock を
+    呼び出していることを確認する。dialect を postgresql に偽装してテストする。
+    """
+    from app.routers.ai_summary import acquire_ai_summary_lock
+
+    mock_db = MagicMock()
+    # PostgreSQL dialect に見せかける
+    mock_db.bind.dialect.name = "postgresql"
+    target_date = date(2026, 3, 10)
+    baby_id = 42
+
+    acquire_ai_summary_lock(mock_db, baby_id, target_date)
+
+    # db.execute が呼ばれたことを確認
+    mock_db.execute.assert_called_once()
+    # 第1引数（TextClause）のテキストに pg_advisory_xact_lock が含まれること
+    first_arg = mock_db.execute.call_args.args[0]
+    assert "pg_advisory_xact_lock" in str(first_arg)
+
+
+# ---------------------------------------------------------------------------
+# テスト3: ロック後でも is_edited=True の場合は再生成しない
+# ---------------------------------------------------------------------------
+
+def test_advisory_lock_does_not_regenerate_when_edited(db: Session, client):
+    """
+    is_edited=True のレコードが存在する場合、ロック取得後も generate_daily_summary は
+    呼ばれずに既存レコードをそのまま返すこと。
+    """
+    user, baby = _setup_user_and_baby(db)
+
+    # 事前に is_edited=True のレコードを作成
+    existing = DailySummary(
+        baby_id=baby.id,
+        user_id=user.id,
+        summary_date=date.today(),
+        generated_content="既存の日誌",
+        edited_content="編集済み日誌",
+        is_edited=True,
+        model_name="gemini-2.0-flash",
+    )
+    db.add(existing)
+    db.commit()
+
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    try:
+        with patch("app.routers.ai_summary.verify_baby_access") as mock_verify, \
+             patch("app.routers.ai_summary.generate_daily_summary") as mock_generate, \
+             patch("app.routers.ai_summary.acquire_ai_summary_lock") as mock_lock:
+
+            mock_verify.return_value = baby
+
+            today_str = date.today().isoformat()
+            response = client.post(
+                f"/api/babies/{baby.id}/daily-summary",
+                json={"summary_date": today_str},
+            )
+
+            assert response.status_code == 201, response.text
+            data = response.json()
+            # 編集済みなので生成は呼ばれない
+            mock_generate.assert_not_called()
+            # 既存の generated_content が返る
+            assert data["generated_content"] == "既存の日誌"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# テスト4: ロック後の2重リクエストで UniqueViolation が発生しないこと
+#          （ロックで直列化されることを構造的に確認）
+# ---------------------------------------------------------------------------
+
+def test_second_request_after_first_insert_updates_not_duplicates(db: Session, client):
+    """
+    同一 (baby_id, summary_date) への2回目のリクエストが INSERT ではなく UPDATE に
+    なることを確認する（ロックによる直列化の結果）。
+    """
+    user, baby = _setup_user_and_baby(db)
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    try:
+        with patch("app.routers.ai_summary.verify_baby_access") as mock_verify, \
+             patch("app.routers.ai_summary.generate_daily_summary") as mock_generate, \
+             patch("app.routers.ai_summary.acquire_ai_summary_lock"), \
+             patch("app.routers.ai_summary.daily_summary_limiter") as mock_limiter:
+
+            mock_verify.return_value = baby
+            mock_generate.return_value = ("1回目の日誌", "gemini-2.0-flash")
+            mock_limiter.check.return_value = None  # レートリミットをスキップ
+
+            today_str = date.today().isoformat()
+
+            # 1回目: INSERT
+            r1 = client.post(
+                f"/api/babies/{baby.id}/daily-summary",
+                json={"summary_date": today_str},
+            )
+            assert r1.status_code == 201, r1.text
+            assert r1.json()["generated_content"] == "1回目の日誌"
+
+            # 2回目: UPDATE（ロックが直列化を保証するため既存レコードが見つかる）
+            mock_generate.return_value = ("2回目の日誌", "gemini-2.0-flash")
+            r2 = client.post(
+                f"/api/babies/{baby.id}/daily-summary",
+                json={"summary_date": today_str},
+            )
+            assert r2.status_code == 201, r2.text
+            assert r2.json()["generated_content"] == "2回目の日誌"
+
+            # DB上にレコードが1件だけ存在すること（重複 INSERT していない）
+            count = db.query(DailySummary).filter(
+                DailySummary.baby_id == baby.id,
+                DailySummary.summary_date == date.today(),
+            ).count()
+            assert count == 1, f"Expected 1 record, got {count}"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 概要

AI日誌生成エンドポイント（POST /api/babies/{baby_id}/daily-summary）で複数リクエストが並行した際に発生する UniqueViolation / SerializationFailure を、PostgreSQL の pg_advisory_xact_lock を使った排他ロックで防止する。

## 問題

existing レコード確認 → AI生成（数秒かかる）→ INSERT/UPDATE という3ステップの間に別リクエストが割り込むと、同一 (baby_id, summary_date) への二重 INSERT が発生し UniqueConstraint 違反エラーになる。

## 解決策

- acquire_ai_summary_lock(db, baby_id, summary_date) 関数を追加
- upsert の直前（AI生成前）にトランザクション内で pg_advisory_xact_lock(:baby_id, :date_int) を取得
- 同一キーへの並行リクエストはロック解放（= トランザクション完了）まで待機し、その後の SELECT で既存レコードを正しく検出できる
- SQLite（テスト環境）では dialect チェックでスキップ

## 変更ファイル

- app/routers/ai_summary.py: acquire_ai_summary_lock() 追加、create_or_get_daily_summary 内でロック取得

## テスト

tests/test_issue_801_advisory_lock.py を新規追加（TDD）:

1. test_advisory_lock_is_called_on_upsert: upsert前にロック関数が呼ばれること
2. test_acquire_ai_summary_lock_executes_pg_advisory_lock: pg_advisory_xact_lock SQL が発行されること
3. test_advisory_lock_does_not_regenerate_when_edited: is_edited=True 時はロック後も再生成しないこと
4. test_second_request_after_first_insert_updates_not_duplicates: 2回目リクエストが UPDATE になりレコードが1件のみであること

全208テスト通過・verify_all.sh 通過確認済み