### PR TITLE
feat: #800 SoftDeleteMixinでの不要な単一インデックス生成の抑止

### DIFF
--- a/alembic/versions/e7d5ce607567_softdeletemixin_is_deleted単独インデックスを削除.py
+++ b/alembic/versions/e7d5ce607567_softdeletemixin_is_deleted単独インデックスを削除.py
@@ -1,0 +1,52 @@
+"""SoftDeleteMixin is_deleted単独インデックスを削除
+
+SoftDeleteMixinの is_deleted=mapped_column(index=True) が生成していた
+不要な単独インデックスを削除する。各テーブルには複合インデックスが
+すでに定義されているため、単独インデックスは冗長。
+
+Revision ID: e7d5ce607567
+Revises: 288d335020a7
+Create Date: 2026-03-10 14:36:24.293013+09:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'e7d5ce607567'
+down_revision: Union[str, Sequence[str], None] = '288d335020a7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# SoftDeleteMixinを継承する全テーブルの単独 is_deleted インデックス
+_SINGLE_INDEXES = [
+    ("feedings",            "ix_feedings_is_deleted"),
+    ("diapers",             "ix_diapers_is_deleted"),
+    ("sleeps",              "ix_sleeps_is_deleted"),
+    ("growths",             "ix_growths_is_deleted"),
+    ("notes",               "ix_notes_is_deleted"),
+    ("babies",              "ix_babies_is_deleted"),
+    ("families",            "ix_families_is_deleted"),
+    ("contractions",        "ix_contractions_is_deleted"),
+    ("daily_summaries",     "ix_daily_summaries_is_deleted"),
+    ("schedules",           "ix_schedules_is_deleted"),
+    ("vaccinations",        "ix_vaccinations_is_deleted"),
+    ("temperature_records", "ix_temperature_records_is_deleted"),
+    ("record_comments",     "ix_record_comments_is_deleted"),
+    ("milestones",          "ix_milestones_is_deleted"),
+    ("app_notifications",   "ix_app_notifications_is_deleted"),
+    ("push_subscriptions",  "ix_push_subscriptions_is_deleted"),
+]
+
+
+def upgrade() -> None:
+    """不要な is_deleted 単独インデックスを削除する。"""
+    for table_name, index_name in _SINGLE_INDEXES:
+        op.drop_index(index_name, table_name=table_name, if_exists=True)
+
+
+def downgrade() -> None:
+    """is_deleted 単独インデックスを再作成する（ロールバック用）。"""
+    for table_name, index_name in reversed(_SINGLE_INDEXES):
+        op.create_index(index_name, table_name, ["is_deleted"])

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -11,4 +11,4 @@ class Base(DeclarativeBase):
     })
 
 class SoftDeleteMixin:
-    is_deleted: Mapped[bool] = mapped_column(default=False, nullable=False, index=True)
+    is_deleted: Mapped[bool] = mapped_column(default=False, nullable=False)

--- a/tests/test_soft_delete_mixin_index.py
+++ b/tests/test_soft_delete_mixin_index.py
@@ -1,0 +1,77 @@
+"""
+SoftDeleteMixin の is_deleted カラムに単独インデックスが存在しないことを確認するテスト。
+複合インデックス（baby_id + is_deleted 等）は各モデルで定義済みのため、
+単独インデックスは不要で排除すべき。
+"""
+import pytest
+from sqlalchemy import inspect
+from tests.conftest import engine
+from app.models.base import Base
+import app.models  # noqa: F401 - 全モデルをロード
+
+
+# SoftDeleteMixinを継承するモデルのテーブル名一覧
+SOFT_DELETE_TABLES = [
+    "feedings",
+    "diapers",
+    "sleeps",
+    "growths",
+    "notes",
+    "babies",
+    "families",
+    "contractions",
+    "daily_summaries",
+    "schedules",
+    "vaccinations",
+    "temperature_records",
+    "record_comments",
+    "milestones",
+    "app_notifications",
+    "push_subscriptions",
+]
+
+
+@pytest.fixture(scope="module")
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_no_single_column_is_deleted_index(setup_db):
+    """SoftDeleteMixinを継承する全テーブルで is_deleted の単独インデックスが存在しないこと"""
+    inspector = inspect(engine)
+    violations = []
+
+    for table_name in SOFT_DELETE_TABLES:
+        indexes = inspector.get_indexes(table_name)
+        for idx in indexes:
+            cols = idx["column_names"]
+            # is_deleted のみからなる単独インデックスは存在してはならない
+            if cols == ["is_deleted"]:
+                violations.append(f"{table_name}: single-column index on is_deleted found (name={idx['name']})")
+
+    assert not violations, (
+        "以下のテーブルに不要な is_deleted 単独インデックスが存在します:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_composite_is_deleted_index_exists(setup_db):
+    """各テーブルに is_deleted を含む複合インデックスが存在すること"""
+    inspector = inspect(engine)
+    missing = []
+
+    for table_name in SOFT_DELETE_TABLES:
+        indexes = inspector.get_indexes(table_name)
+        has_composite = any(
+            "is_deleted" in idx["column_names"] and len(idx["column_names"]) > 1
+            for idx in indexes
+        )
+        if not has_composite:
+            missing.append(table_name)
+
+    assert not missing, (
+        "以下のテーブルに is_deleted を含む複合インデックスがありません:\n"
+        + "\n".join(missing)
+    )


### PR DESCRIPTION
## 概要

Closes #800

## 変更内容

SoftDeleteMixinでの不要な単一インデックス生成の抑止

## 実装方法

- Claude Codeによる実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認