### PR TITLE
feat: #804 レコード削除時の画像データ(S3/R2)クリーンアップ処理の追加

### DIFF
--- a/app/routers/ai_summary.py
+++ b/app/routers/ai_summary.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy import func, text
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.postgresql import insert
@@ -16,7 +16,7 @@ from app.utils.notifications import notify_family_members
 from app.utils.rate_limit import RateLimiter
 from app.utils.timezone import get_jst_today
 from app.core import constants
-from app.utils.s3 import extract_object_key
+from app.utils.s3 import extract_object_key, delete_s3_objects
 
 
 def acquire_ai_summary_lock(db: Session, baby_id: int, summary_date: date) -> None:
@@ -227,6 +227,7 @@ def edit_daily_summary(
 def delete_daily_summary(
     baby_id: int,
     summary_date: date,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -242,5 +243,11 @@ def delete_daily_summary(
     )
     if not summary:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Daily summary not found")
+
+    image_urls = list(summary.image_urls or [])
+
     summary.is_deleted = True
     db.commit()
+
+    if image_urls:
+        background_tasks.add_task(delete_s3_objects, image_urls)

--- a/app/routers/milestones.py
+++ b/app/routers/milestones.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 from typing import List
@@ -8,7 +8,7 @@ from app.models.milestone import Milestone
 from app.models.baby import Baby
 from app.schemas.milestone import MilestoneCreate, MilestoneUpdate, MilestoneResponse, MilestoneTimelineGroup
 from datetime import date
-from app.utils.s3 import extract_object_key
+from app.utils.s3 import extract_object_key, delete_s3_objects
 
 router = APIRouter(prefix="/api/milestones", tags=["milestones"])
 
@@ -71,15 +71,18 @@ async def update_milestone(
 @router.delete("/{milestone_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_milestone(
     milestone_id: int,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
     db_milestone = db.query(Milestone).filter(Milestone.id == milestone_id).first()
     if not db_milestone:
         raise HTTPException(status_code=404, detail="Milestone not found")
-    
+
     verify_baby_access(db, db_milestone.baby_id, current_user.id, require_write=True)
-    
+
+    image_urls = list(db_milestone.image_urls or [])
+
     from app.models.comment import RecordComment
     db.query(RecordComment).filter(
         RecordComment.record_type == "milestone",
@@ -88,6 +91,9 @@ async def delete_milestone(
 
     db_milestone.is_deleted = True
     db.commit()
+
+    if image_urls:
+        background_tasks.add_task(delete_s3_objects, image_urls)
 
 @router.get("/timeline", response_model=List[MilestoneTimelineGroup])
 async def get_milestone_timeline(

--- a/app/utils/s3.py
+++ b/app/utils/s3.py
@@ -57,6 +57,26 @@ def extract_object_key(url_or_key: str) -> str:
         return path[len(bucket_name) + 1:]
     return path
 
+def delete_s3_objects(urls: List[str]) -> None:
+    """ストレージ上のオブジェクトを削除する。URLまたはキーのリストを受け取る。"""
+    if not urls:
+        return
+
+    client = _get_s3_client()
+    if not client:
+        logger.warning("S3 client not available; skipping object deletion.")
+        return
+
+    bucket_name = os.getenv("R2_BUCKET_NAME", "baby-app-images")
+    for url_or_key in urls:
+        key = extract_object_key(url_or_key)
+        try:
+            client.delete_object(Bucket=bucket_name, Key=key)
+            logger.info(f"Deleted S3 object: {key}")
+        except Exception as e:
+            logger.error(f"Failed to delete S3 object {key}: {e}")
+
+
 def sign_image_urls(image_urls: List[str]) -> List[str]:
     """画像URL（またはキー）のリストを署名付きURLのリストに変換する。"""
     if not image_urls:

--- a/tests/test_s3_cleanup.py
+++ b/tests/test_s3_cleanup.py
@@ -1,0 +1,140 @@
+"""レコード削除時のS3/R2画像クリーンアップ処理のテスト"""
+import pytest
+from datetime import date
+from unittest.mock import patch, MagicMock
+from app.models.baby import Baby
+from app.models.family import FamilyUser
+from app.models.milestone import Milestone
+from app.models.ai_summary import DailySummary
+from app.utils.s3 import delete_s3_objects
+
+
+# --- Unit tests for delete_s3_objects ---
+
+def test_delete_s3_objects_calls_delete_object():
+    """delete_s3_objects はキーごとに delete_object を呼び出す。"""
+    mock_client = MagicMock()
+    with patch("app.utils.s3._get_s3_client", return_value=mock_client):
+        with patch.dict("os.environ", {"R2_BUCKET_NAME": "test-bucket"}):
+            delete_s3_objects(["key1.jpg", "key2.jpg"])
+    assert mock_client.delete_object.call_count == 2
+    mock_client.delete_object.assert_any_call(Bucket="test-bucket", Key="key1.jpg")
+    mock_client.delete_object.assert_any_call(Bucket="test-bucket", Key="key2.jpg")
+
+
+def test_delete_s3_objects_empty_list():
+    """delete_s3_objects は空リストで S3 クライアントを呼ばない。"""
+    with patch("app.utils.s3._get_s3_client") as mock_get_client:
+        delete_s3_objects([])
+    mock_get_client.assert_not_called()
+
+
+def test_delete_s3_objects_no_client():
+    """delete_s3_objects は S3 クライアントが取得できない場合でもエラーにならない。"""
+    with patch("app.utils.s3._get_s3_client", return_value=None):
+        delete_s3_objects(["key1.jpg"])  # エラーにならないこと
+
+
+def test_delete_s3_objects_handles_client_error():
+    """delete_s3_objects は ClientError が発生しても処理を継続する。"""
+    from botocore.exceptions import ClientError
+    mock_client = MagicMock()
+    mock_client.delete_object.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchKey", "Message": "Not found"}}, "DeleteObject"
+    )
+    with patch("app.utils.s3._get_s3_client", return_value=mock_client):
+        with patch.dict("os.environ", {"R2_BUCKET_NAME": "test-bucket"}):
+            delete_s3_objects(["missing_key.jpg"])  # エラーにならないこと
+
+
+# --- Helper ---
+
+def _setup(auth_client, db, username):
+    client = auth_client(username=username, password="password123")
+    user_id = client.get("/api/auth/me").json()["id"]
+    fu = db.query(FamilyUser).filter(FamilyUser.user_id == user_id).first()
+    baby = Baby(family_id=fu.family_id, name="Cleanup Baby", birthday=date(2026, 1, 1))
+    db.add(baby)
+    db.commit()
+    db.refresh(baby)
+    return client, baby
+
+
+# --- Milestone deletion ---
+
+@patch("app.routers.milestones.delete_s3_objects")
+def test_delete_milestone_triggers_s3_cleanup(mock_delete, auth_client, db):
+    """マイルストーン削除時に画像の S3 クリーンアップが BackgroundTasks 経由で実行される。"""
+    client, baby = _setup(auth_client, db, "s3milestone1")
+    milestone = Milestone(
+        baby_id=baby.id,
+        milestone_type="rolling_over",
+        title="寝返り",
+        achieved_date=date(2026, 3, 1),
+        image_urls=["key1.jpg", "key2.jpg"],
+    )
+    db.add(milestone)
+    db.commit()
+
+    response = client.delete(f"/api/milestones/{milestone.id}")
+    assert response.status_code == 204
+    mock_delete.assert_called_once_with(["key1.jpg", "key2.jpg"])
+
+
+@patch("app.routers.milestones.delete_s3_objects")
+def test_delete_milestone_no_images_skips_cleanup(mock_delete, auth_client, db):
+    """画像なしのマイルストーン削除では S3 クリーンアップを実行しない。"""
+    client, baby = _setup(auth_client, db, "s3milestone2")
+    milestone = Milestone(
+        baby_id=baby.id,
+        milestone_type="sitting_up",
+        title="お座り",
+        achieved_date=date(2026, 3, 2),
+        image_urls=[],
+    )
+    db.add(milestone)
+    db.commit()
+
+    response = client.delete(f"/api/milestones/{milestone.id}")
+    assert response.status_code == 204
+    mock_delete.assert_not_called()
+
+
+# --- DailySummary deletion ---
+
+@patch("app.routers.ai_summary.delete_s3_objects")
+def test_delete_daily_summary_triggers_s3_cleanup(mock_delete, auth_client, db):
+    """AI 日誌削除時に画像の S3 クリーンアップが BackgroundTasks 経由で実行される。"""
+    client, baby = _setup(auth_client, db, "s3summary1")
+    summary = DailySummary(
+        baby_id=baby.id,
+        summary_date=date(2026, 3, 1),
+        generated_content="Test",
+        is_edited=False,
+        image_urls=["summary_key.jpg"],
+    )
+    db.add(summary)
+    db.commit()
+
+    response = client.delete(f"/api/babies/{baby.id}/daily-summary/2026-03-01")
+    assert response.status_code == 204
+    mock_delete.assert_called_once_with(["summary_key.jpg"])
+
+
+@patch("app.routers.ai_summary.delete_s3_objects")
+def test_delete_daily_summary_no_images_skips_cleanup(mock_delete, auth_client, db):
+    """画像なし（None）の AI 日誌削除では S3 クリーンアップを実行しない。"""
+    client, baby = _setup(auth_client, db, "s3summary2")
+    summary = DailySummary(
+        baby_id=baby.id,
+        summary_date=date(2026, 3, 2),
+        generated_content="Test",
+        is_edited=False,
+        image_urls=None,
+    )
+    db.add(summary)
+    db.commit()
+
+    response = client.delete(f"/api/babies/{baby.id}/daily-summary/2026-03-02")
+    assert response.status_code == 204
+    mock_delete.assert_not_called()


### PR DESCRIPTION
## 概要

Closes #804

## 変更内容

レコード削除時の画像データ(S3/R2)クリーンアップ処理の追加

## 実装方法

- Claude Codeによる実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認