### PR TITLE
feat: #825 DB漏洩時の被害を防ぐセッショントークンのハッシュ化保存

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -8,6 +8,7 @@ from app.models.baby import Baby, BabyPermission
 from app.models.family import FamilyUser, UserRole
 from app.models.user import User, UserSession
 from app.utils.timezone import ensure_aware
+from app.utils.session import hash_token
 from app.config import SESSION_EXPIRE_DAYS, COOKIE_SECURE
 
 
@@ -28,7 +29,7 @@ def get_current_user(request: Request, response: Response, db: db_dependency):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
     session = db.query(UserSession).filter(
-        UserSession.token == token,
+        UserSession.token == hash_token(token),
         UserSession.expires_at > func.now()
     ).first()
     if not session:

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,5 +1,6 @@
 import secrets
 from datetime import datetime, timedelta, timezone
+from app.utils.session import hash_token
 
 from fastapi import APIRouter, Depends, HTTPException, status, Response, Request
 from sqlalchemy import func
@@ -50,7 +51,7 @@ DUMMY_HASH = get_password_hash("dummy_password_for_timing_mitigation")
 def _create_session(db: Session, user_id: int) -> str:
     token = secrets.token_urlsafe(32)
     session = UserSession(
-        token=token,
+        token=hash_token(token),
         user_id=user_id,
         expires_at=datetime.now(timezone.utc) + timedelta(days=SESSION_EXPIRE_DAYS),
     )
@@ -70,9 +71,10 @@ async def change_password(
         raise HTTPException(status_code=400, detail="Current password is incorrect")
     current_user.hashed_password = await get_password_hash_async(req.new_password)
     current_token = request.cookies.get("access_token")
+    current_token_hash = hash_token(current_token) if current_token else None
     db.query(UserSession).filter(
         UserSession.user_id == current_user.id,
-        UserSession.token != current_token,
+        UserSession.token != current_token_hash,
     ).delete()
     
     log_event(
@@ -293,7 +295,7 @@ async def login(
 def logout(request: Request, response: Response, db: Session = Depends(get_db)):
     token = request.cookies.get("access_token")
     if token:
-        session = db.query(UserSession).filter(UserSession.token == token).first()
+        session = db.query(UserSession).filter(UserSession.token == hash_token(token)).first()
         if session:
             # Note: log_event with commit=False ensures this and the deletion 
             # are committed in the same transaction.

--- a/app/utils/session.py
+++ b/app/utils/session.py
@@ -1,0 +1,6 @@
+import hashlib
+
+
+def hash_token(token: str) -> str:
+    """セッショントークンを SHA-256 でハッシュ化して返す。"""
+    return hashlib.sha256(token.encode()).hexdigest()

--- a/tests/test_auth_persistence.py
+++ b/tests/test_auth_persistence.py
@@ -2,6 +2,7 @@ import pytest
 from sqlalchemy.orm import Session
 from app.models.user import User, UserSession
 from app.services.auth import get_password_hash
+from app.utils.session import hash_token
 from app.utils.timezone import ensure_aware
 from datetime import datetime, timedelta, timezone
 
@@ -39,7 +40,7 @@ def test_sliding_session_cookie_refresh(client, db: Session):
     
     # Replace the session with one that is about to expire
     token = client.cookies.get("access_token")
-    session = db.query(UserSession).filter(UserSession.token == token).first()
+    session = db.query(UserSession).filter(UserSession.token == hash_token(token)).first()
     session.expires_at = datetime.now(timezone.utc) + timedelta(days=1)
     db.commit()
 
@@ -68,8 +69,8 @@ def test_expired_session_fails(client, db: Session):
         }
     )
     token = client.cookies.get("access_token")
-    session = db.query(UserSession).filter(UserSession.token == token).first()
-    
+    session = db.query(UserSession).filter(UserSession.token == hash_token(token)).first()
+
     # Make session expired
     session.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
     db.commit()

--- a/tests/test_auth_session.py
+++ b/tests/test_auth_session.py
@@ -2,6 +2,7 @@ import pytest
 from datetime import datetime, timedelta, timezone
 from app.models.user import User, UserSession
 from app.services.auth import get_password_hash
+from app.utils.session import hash_token
 from app.utils.timezone import ensure_aware
 
 # Note: client and db fixtures are provided by conftest.py
@@ -40,8 +41,8 @@ def test_sliding_session(client, test_user, db):
     assert response.status_code == 200
     token = response.cookies["access_token"]
     
-    # Get session from DB
-    session = db.query(UserSession).filter(UserSession.token == token).first()
+    # Get session from DB (token is stored as SHA-256 hash)
+    session = db.query(UserSession).filter(UserSession.token == hash_token(token)).first()
     assert session is not None
     initial_expiry = ensure_aware(session.expires_at)
     

--- a/tests/test_session_token_hashing.py
+++ b/tests/test_session_token_hashing.py
@@ -1,0 +1,86 @@
+"""
+セッショントークンのハッシュ化保存に関するテスト (Issue #825)
+
+DB に保存されるトークンが SHA-256 ハッシュであり、
+平文トークンが DB に残らないことを検証する。
+"""
+import hashlib
+import pytest
+from app.models.user import User, UserSession
+from app.services.auth import get_password_hash
+from app.utils.session import hash_token
+
+
+@pytest.fixture
+def test_user(db):
+    user = User(username="hash_test_user", hashed_password=get_password_hash("password"))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_hash_token_is_sha256():
+    """hash_token は SHA-256 ハッシュを返す"""
+    raw = "test_token_value"
+    expected = hashlib.sha256(raw.encode()).hexdigest()
+    assert hash_token(raw) == expected
+
+
+def test_db_stores_hashed_token_not_plaintext(client, test_user, db):
+    """ログイン後、DB には平文トークンではなくハッシュ値が保存される"""
+    response = client.post(
+        "/api/auth/login",
+        json={"username": test_user.username, "password": "password"},
+    )
+    assert response.status_code == 200
+    raw_token = response.cookies["access_token"]
+
+    # DB上のセッションを全件取得して確認
+    sessions = db.query(UserSession).filter(UserSession.user_id == test_user.id).all()
+    assert len(sessions) == 1
+
+    stored = sessions[0].token
+    # 平文がそのまま保存されていないこと
+    assert stored != raw_token
+    # SHA-256 ハッシュが保存されていること
+    assert stored == hash_token(raw_token)
+
+
+def test_authenticated_with_raw_cookie_token(client, test_user):
+    """/api/auth/me がハッシュ化後も正常に動作する"""
+    response = client.post(
+        "/api/auth/login",
+        json={"username": test_user.username, "password": "password"},
+    )
+    assert response.status_code == 200
+
+    me_response = client.get("/api/auth/me")
+    assert me_response.status_code == 200
+    assert me_response.json()["username"] == test_user.username
+
+
+def test_logout_with_hashed_token(client, test_user, db):
+    """ログアウト後、DB のセッションが削除される"""
+    client.post(
+        "/api/auth/login",
+        json={"username": test_user.username, "password": "password"},
+    )
+    raw_token = client.cookies.get("access_token")
+
+    response = client.post("/api/auth/logout")
+    assert response.status_code == 200
+
+    hashed = hash_token(raw_token)
+    session = db.query(UserSession).filter(UserSession.token == hashed).first()
+    assert session is None
+
+
+def test_tampered_token_is_rejected(client):
+    """改ざんされたトークンで認証が通らない"""
+    # 有効なセッションなしで偽トークンだけ送信
+    response = client.get(
+        "/api/auth/me",
+        cookies={"access_token": "tampered_token_value"},
+    )
+    assert response.status_code == 401

--- a/tests/test_sliding_session_throttling.py
+++ b/tests/test_sliding_session_throttling.py
@@ -2,6 +2,7 @@ import pytest
 from datetime import datetime, timedelta, timezone
 from app.models.user import User, UserSession
 from app.services.auth import get_password_hash
+from app.utils.session import hash_token
 from app.config import SESSION_EXPIRE_DAYS
 from app.utils.timezone import ensure_aware
 
@@ -25,8 +26,8 @@ def test_sliding_session_throttling(client, test_user, db):
     assert response.status_code == 200
     token = response.cookies["access_token"]
     
-    # Get session from DB
-    session = db.query(UserSession).filter(UserSession.token == token).first()
+    # Get session from DB (token is stored as SHA-256 hash)
+    session = db.query(UserSession).filter(UserSession.token == hash_token(token)).first()
     assert session is not None
     initial_expiry = session.expires_at
     
@@ -49,8 +50,8 @@ def test_sliding_session_update_after_threshold(client, test_user, db):
     assert response.status_code == 200
     token = response.cookies["access_token"]
     
-    # Get session from DB
-    session = db.query(UserSession).filter(UserSession.token == token).first()
+    # Get session from DB (token is stored as SHA-256 hash)
+    session = db.query(UserSession).filter(UserSession.token == hash_token(token)).first()
     initial_expiry = session.expires_at
     
     # 2. Manually backdate the expires_at in DB to simulate "time passed"


### PR DESCRIPTION
## 概要

Closes #825

## 変更内容

DB漏洩時の被害を防ぐセッショントークンのハッシュ化保存

## 実装方法

- Claude Codeによる実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認