### PR TITLE
fix: #803後のユーザー入力日時9時間ずれ（JST→UTC誤解釈）を修正

### DIFF
--- a/alembic/versions/9952986ff200_fix_803_correct_user_datetime_tz_offset.py
+++ b/alembic/versions/9952986ff200_fix_803_correct_user_datetime_tz_offset.py
@@ -1,0 +1,67 @@
+"""fix_803_correct_user_datetime_tz_offset
+
+#803 のマイグレーションでユーザー入力の時刻カラムが TIMESTAMPTZ に変換された際、
+JST naive な値が UTC として解釈されてしまい 9 時間ずれが生じた。
+ユーザー入力フィールドのみ 9 時間引いて正しい UTC 値に補正する。
+
+対象: ユーザーが入力した時刻カラム（feeding_time, change_time 等）
+除外: サーバー生成の created_at, updated_at, expires_at 等
+
+Revision ID: 9952986ff200
+Revises: e7d5ce607567
+Create Date: 2026-03-10 18:57:15.609113+09:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '9952986ff200'
+down_revision: Union[str, Sequence[str], None] = 'e7d5ce607567'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# ユーザー入力の時刻カラム一覧（サーバー生成の created_at 等は含まない）
+_USER_DATETIME_COLUMNS = [
+    ("feedings", "feeding_time", False),
+    ("diapers", "change_time", False),
+    ("sleeps", "start_time", False),
+    ("sleeps", "end_time", True),           # nullable
+    ("temperature_records", "measured_at", False),
+    ("notes", "note_time", False),
+    ("schedules", "scheduled_time", False),
+    ("contractions", "start_time", False),
+    ("contractions", "end_time", True),      # nullable
+    ("contraction_timer_states", "start_time", True),  # nullable
+]
+
+
+def upgrade() -> None:
+    """JST naive → UTC として誤解釈された 9 時間分を引いて補正する。"""
+    for table, column, nullable in _USER_DATETIME_COLUMNS:
+        if nullable:
+            op.execute(
+                f"UPDATE {table} SET {column} = {column} - INTERVAL '9 hours'"
+                f" WHERE {column} IS NOT NULL"
+            )
+        else:
+            op.execute(
+                f"UPDATE {table} SET {column} = {column} - INTERVAL '9 hours'"
+            )
+
+
+def downgrade() -> None:
+    """補正を元に戻す（9 時間足す）。"""
+    for table, column, nullable in _USER_DATETIME_COLUMNS:
+        if nullable:
+            op.execute(
+                f"UPDATE {table} SET {column} = {column} + INTERVAL '9 hours'"
+                f" WHERE {column} IS NOT NULL"
+            )
+        else:
+            op.execute(
+                f"UPDATE {table} SET {column} = {column} + INTERVAL '9 hours'"
+            )

--- a/app/schemas/contraction.py
+++ b/app/schemas/contraction.py
@@ -1,7 +1,8 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import Optional
 from datetime import datetime
 from app.core.constants import NOTE_MAX_LENGTH
+from app.utils.timezone import localize_naive_as_jst
 
 
 class ContractionCreate(BaseModel):
@@ -12,12 +13,22 @@ class ContractionCreate(BaseModel):
     interval_seconds: Optional[int] = None
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
 
+    @field_validator('start_time', 'end_time', mode='before')
+    @classmethod
+    def localize_times(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
+
 
 class ContractionUpdate(BaseModel):
     start_time: Optional[datetime] = None
     end_time: Optional[datetime] = None
     duration_seconds: Optional[int] = None
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
+
+    @field_validator('start_time', 'end_time', mode='before')
+    @classmethod
+    def localize_times(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
 
 
 class ContractionResponse(ContractionCreate):

--- a/app/schemas/diaper.py
+++ b/app/schemas/diaper.py
@@ -1,8 +1,9 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import Optional
 from datetime import datetime
 from app.models.diaper import DiaperType
 from app.core.constants import NOTE_MAX_LENGTH
+from app.utils.timezone import localize_naive_as_jst
 
 
 class DiaperCreate(BaseModel):
@@ -11,12 +12,21 @@ class DiaperCreate(BaseModel):
     diaper_type: DiaperType
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
 
+    @field_validator('change_time', mode='before')
+    @classmethod
+    def localize_change_time(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
+
 
 class DiaperUpdate(BaseModel):
     change_time: Optional[datetime] = None
     diaper_type: Optional[DiaperType] = None
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
 
+    @field_validator('change_time', mode='before')
+    @classmethod
+    def localize_change_time(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
 
 
 class DiaperResponse(DiaperCreate):

--- a/app/schemas/feeding.py
+++ b/app/schemas/feeding.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, ConfigDict, model_validator, Field
+from pydantic import BaseModel, ConfigDict, model_validator, Field, field_validator
 from typing import Optional
 from datetime import datetime
+from app.utils.timezone import localize_naive_as_jst
 from app.models.feeding import FeedingType, BreastSide, BottleContentType, FeedingCompletion
 from app.core.constants import (
     NOTE_MAX_LENGTH,
@@ -13,6 +14,11 @@ from app.core.constants import (
 class FeedingCreate(BaseModel):
     baby_id: int
     feeding_time: datetime
+
+    @field_validator('feeding_time', mode='before')
+    @classmethod
+    def localize_feeding_time(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
     feeding_type: FeedingType
     amount_ml: Optional[float] = Field(None, ge=0, le=MAX_FEEDING_ML)
     duration_minutes: Optional[int] = Field(None, ge=0, le=MAX_FEEDING_DURATION_MINUTES)
@@ -46,6 +52,11 @@ class FeedingResponse(FeedingCreate):
 
 class FeedingUpdate(BaseModel):
     feeding_time: Optional[datetime] = None
+
+    @field_validator('feeding_time', mode='before')
+    @classmethod
+    def localize_feeding_time(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
     feeding_type: Optional[FeedingType] = None
     amount_ml: Optional[float] = Field(None, ge=0, le=MAX_FEEDING_ML)
     duration_minutes: Optional[int] = Field(None, ge=0, le=MAX_FEEDING_DURATION_MINUTES)

--- a/app/schemas/note.py
+++ b/app/schemas/note.py
@@ -1,18 +1,33 @@
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 from datetime import datetime
 from typing import Optional
 from app.core.constants import NOTE_MAX_LENGTH
+from app.utils.timezone import localize_naive_as_jst
+
 
 class NoteBase(BaseModel):
     content: str = Field(..., min_length=1, max_length=NOTE_MAX_LENGTH)
     note_time: datetime
 
+    @field_validator('note_time', mode='before')
+    @classmethod
+    def localize_note_time(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
+
+
 class NoteCreate(NoteBase):
     pass
+
 
 class NoteUpdate(BaseModel):
     content: Optional[str] = Field(None, min_length=1, max_length=NOTE_MAX_LENGTH)
     note_time: Optional[datetime] = None
+
+    @field_validator('note_time', mode='before')
+    @classmethod
+    def localize_note_time(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
+
 
 class NoteResponse(NoteBase):
     id: int

--- a/app/schemas/schedule.py
+++ b/app/schemas/schedule.py
@@ -1,7 +1,8 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import Optional
 from datetime import datetime
 from app.core.constants import NOTE_MAX_LENGTH
+from app.utils.timezone import localize_naive_as_jst
 
 
 class ScheduleCreate(BaseModel):
@@ -10,6 +11,11 @@ class ScheduleCreate(BaseModel):
     description: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
     scheduled_time: datetime
     is_completed: bool = False
+
+    @field_validator('scheduled_time', mode='before')
+    @classmethod
+    def localize_scheduled_time(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
 
 
 class ScheduleResponse(ScheduleCreate):

--- a/app/schemas/sleep.py
+++ b/app/schemas/sleep.py
@@ -1,7 +1,8 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import Optional
 from datetime import datetime
 from app.core.constants import NOTE_MAX_LENGTH
+from app.utils.timezone import localize_naive_as_jst
 
 
 class SleepCreate(BaseModel):
@@ -10,11 +11,21 @@ class SleepCreate(BaseModel):
     end_time: Optional[datetime] = None
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
 
+    @field_validator('start_time', 'end_time', mode='before')
+    @classmethod
+    def localize_times(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
+
 
 class SleepUpdate(BaseModel):
     start_time: Optional[datetime] = None
     end_time: Optional[datetime] = None
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
+
+    @field_validator('start_time', 'end_time', mode='before')
+    @classmethod
+    def localize_times(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
 
 
 class SleepResponse(SleepCreate):

--- a/app/schemas/temperature.py
+++ b/app/schemas/temperature.py
@@ -3,6 +3,7 @@ from typing import Optional
 from datetime import datetime
 from app.models.temperature import TemperatureMethod
 from app.core.constants import NOTE_MAX_LENGTH
+from app.utils.timezone import localize_naive_as_jst
 
 TEMPERATURE_MIN = 34.0
 TEMPERATURE_MAX = 42.0
@@ -15,12 +16,22 @@ class TemperatureCreate(BaseModel):
     method: TemperatureMethod = TemperatureMethod.AXILLARY
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
 
+    @field_validator('measured_at', mode='before')
+    @classmethod
+    def localize_measured_at(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
+
 
 class TemperatureUpdate(BaseModel):
     measured_at: Optional[datetime] = None
     temperature: Optional[float] = Field(None, ge=TEMPERATURE_MIN, le=TEMPERATURE_MAX)
     method: Optional[TemperatureMethod] = None
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
+
+    @field_validator('measured_at', mode='before')
+    @classmethod
+    def localize_measured_at(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
 
 
 class TemperatureResponse(TemperatureCreate):

--- a/app/schemas/timer.py
+++ b/app/schemas/timer.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 from typing import Optional, Literal
 from datetime import datetime
+from app.utils.timezone import localize_naive_as_jst
 
 
 # --- 陣痛タイマー ---
@@ -13,6 +14,11 @@ class ContractionTimerResponse(BaseModel):
 class ContractionTimerUpdate(BaseModel):
     status: Literal["idle", "timing"]
     start_time: Optional[datetime] = None
+
+    @field_validator('start_time', mode='before')
+    @classmethod
+    def localize_start_time(cls, v):
+        return localize_naive_as_jst(v) if isinstance(v, datetime) else v
 
 
 # --- 授乳タイマー ---

--- a/app/utils/timezone.py
+++ b/app/utils/timezone.py
@@ -22,6 +22,19 @@ def to_jst_naive(dt: datetime) -> datetime:
     # JSTに変換してからタイムゾーン情報を削除
     return dt.astimezone(JST).replace(tzinfo=None)
 
+def localize_naive_as_jst(v: datetime | None) -> datetime | None:
+    """
+    naive な datetime を JST として解釈し、timezone-aware にする。
+    フロントエンドの datetime-local 入力（JST naive）を DB 保存前に変換するために使用する。
+    already-aware な場合はそのまま返す。
+    """
+    if v is None:
+        return None
+    if v.tzinfo is None:
+        return v.replace(tzinfo=JST)
+    return v
+
+
 def ensure_aware(dt: datetime, default_tz=timezone.utc) -> datetime:
     """
     datetime が naive な場合に、指定されたタイムゾーン（デフォルトは UTC）を付与して aware にする。


### PR DESCRIPTION
## 原因

#803のTIMESTAMP→TIMESTAMPTZマイグレーション後、フロントエンドから送られていたJST naive値（例: `08:00`）がNeon（UTC）に `08:00 UTC` として解釈され、JST表示で17:00（+9時間）になっていた。

## 修正内容

### 1. Alembicマイグレーション（データ修正）
既存データのユーザー入力時刻カラムから9時間引いてUTC正規化。
- feedings.feeding_time / diapers.change_time / sleeps.start_time,end_time
- temperature_records.measured_at / notes.note_time / schedules.scheduled_time
- contractions.start_time,end_time / contraction_timer_states.start_time

除外: created_at, updated_at, expires_at, segment_start_time 等

### 2. Pydantic field_validator（新規レコード対策）
各スキーマのユーザー入力datetime fieldにnaive→JST-aware変換を追加。

### 3. localize_naive_as_jst() を timezone.py に追加

## Test plan
- [ ] デプロイ後、既存レコードの日時がJSTで正しく表示されること
- [ ] 新規レコード作成時も日時がずれないこと