### PR TITLE
fix: #822 複数家族所属時に特定の家族の赤ちゃんしか取得されないバグ

### DIFF
--- a/app/routers/baby.py
+++ b/app/routers/baby.py
@@ -50,18 +50,17 @@ def get_babies(db: Session = Depends(get_db), current_user: User = Depends(get_c
     if current_user.is_superadmin:
         return db.query(Baby).filter(Baby.is_deleted == False).all()
 
-    family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
-    if not family_user:
+    family_users = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).all()
+    if not family_users:
         return []
 
+    family_ids = [fu.family_id for fu in family_users]
     babies = db.query(Baby).filter(
-        Baby.family_id == family_user.family_id,
+        Baby.family_id.in_(family_ids),
         Baby.is_deleted == False
     ).all()
 
-    # admin / superadmin は全件返す
-    if family_user.role == UserRole.ADMIN or current_user.is_superadmin:
-        return babies
+    family_roles = {fu.family_id: fu.role for fu in family_users}
 
     # member/viewer: can_view=true の BabyPermission が存在する赤ちゃんのみ返す（デフォルト拒否）
     allowed_baby_ids = set(
@@ -71,7 +70,13 @@ def get_babies(db: Session = Depends(get_db), current_user: User = Depends(get_c
             BabyPermission.can_view == True,
         ).all()
     )
-    return [b for b in babies if b.id in allowed_baby_ids]
+    
+    result = []
+    for b in babies:
+        if family_roles.get(b.family_id) == UserRole.ADMIN or b.id in allowed_baby_ids:
+            result.append(b)
+            
+    return result
 
 
 @router.post("/", response_model=BabyResponse)

--- a/tests/test_issue_822_multi_family_babies.py
+++ b/tests/test_issue_822_multi_family_babies.py
@@ -1,0 +1,46 @@
+from sqlalchemy.orm import Session
+from app.models.user import User
+from app.models.family import Family, FamilyUser, UserRole
+from app.models.baby import Baby
+
+def test_get_babies_multi_family(auth_client, db: Session):
+    # Create the main user and family (Family 1)
+    client = auth_client(username="user1", password="password123", family_name="Family 1")
+    
+    # Create a baby in Family 1
+    res = client.post("/api/babies/", json={"name": "Baby 1", "birthday": "2024-01-01"})
+    assert res.status_code == 200
+    baby1_id = res.json()["id"]
+
+    # Now let's create a second family manually in DB
+    import uuid
+    new_family = Family(name="Family 2", invite_code=str(uuid.uuid4())[:8])
+    db.add(new_family)
+    db.commit()
+    db.refresh(new_family)
+
+    # Get the user
+    user1 = db.query(User).filter(User.username == "user1").first()
+
+    # Add user1 to Family 2 as well
+    new_family_user = FamilyUser(family_id=new_family.id, user_id=user1.id, role=UserRole.ADMIN)
+    db.add(new_family_user)
+    db.commit()
+
+    from datetime import date
+    # Create a baby in Family 2
+    baby2 = Baby(name="Baby 2", birthday=date(2024, 2, 1), family_id=new_family.id)
+    db.add(baby2)
+    db.commit()
+    db.refresh(baby2)
+
+    # Now call GET /api/babies/ with user1
+    res = client.get("/api/babies/")
+    assert res.status_code == 200
+    babies = res.json()
+    
+    # User 1 should see both Baby 1 and Baby 2
+    assert len(babies) == 2
+    baby_names = [b["name"] for b in babies]
+    assert "Baby 1" in baby_names
+    assert "Baby 2" in baby_names


### PR DESCRIPTION
## 概要

Closes #822

## 変更内容

複数家族所属時に特定の家族の赤ちゃんしか取得されないバグ

## 実装方法

- Gemini CLIによる自動実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認