### PR TITLE
fix: #824 JSONBカラムの変更検知漏れを防ぐMutableList導入

### DIFF
--- a/app/models/ai_summary.py
+++ b/app/models/ai_summary.py
@@ -1,5 +1,6 @@
 from sqlalchemy import Column, Integer, String, Text, Boolean, Date, DateTime, ForeignKey, UniqueConstraint, Index, JSON
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.sql import func
 from .base import Base, SoftDeleteMixin
 
@@ -15,7 +16,7 @@ class DailySummary(Base, SoftDeleteMixin):
     edited_content = Column(Text, nullable=True)
     is_edited = Column(Boolean, nullable=False, default=False)
     model_name = Column(String, nullable=True)
-    image_urls = Column(JSON().with_variant(JSONB, 'postgresql'), nullable=True, default=[])
+    image_urls = Column(MutableList.as_mutable(JSON().with_variant(JSONB, 'postgresql')), nullable=True, default=[])
     created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
 

--- a/app/models/milestone.py
+++ b/app/models/milestone.py
@@ -1,5 +1,6 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, Date, JSON, Index
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableList
 from .base import Base, SoftDeleteMixin
 
 class Milestone(Base, SoftDeleteMixin):
@@ -13,7 +14,7 @@ class Milestone(Base, SoftDeleteMixin):
     title = Column(String, nullable=False)
     achieved_date = Column(Date, nullable=False, index=True)
     
-    image_urls = Column(JSON().with_variant(JSONB, 'postgresql'), nullable=False, default=[])
+    image_urls = Column(MutableList.as_mutable(JSON().with_variant(JSONB, 'postgresql')), nullable=False, default=[])
     notes = Column(String, nullable=True)
 
     __table_args__ = (

--- a/tests/test_jsonb_columns.py
+++ b/tests/test_jsonb_columns.py
@@ -1,19 +1,43 @@
 import pytest
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableList
 
 from app.models.milestone import Milestone
 from app.models.ai_summary import DailySummary
 
 def test_milestone_image_urls_type():
     col_type = Milestone.image_urls.type
-    mapping = getattr(col_type, '_variant_mapping', None)
+    
+    # Extract the underlying type inside MutableList if it is one
+    if hasattr(col_type, 'impl'):
+        base_type = col_type.impl
+    else:
+        base_type = col_type
+        
+    mapping = getattr(base_type, '_variant_mapping', None)
+    assert mapping is not None, "Variant mapping is missing"
+    assert 'postgresql' in mapping
+    assert isinstance(mapping['postgresql'], JSONB)
+    
+def test_milestone_image_urls_is_mutable_list():
+    m = Milestone()
+    m.image_urls = []
+    assert isinstance(m.image_urls, MutableList), "Milestone.image_urls did not convert list to MutableList"
+
+def test_daily_summary_image_urls_type():
+    col_type = DailySummary.image_urls.type
+    
+    if hasattr(col_type, 'impl'):
+        base_type = col_type.impl
+    else:
+        base_type = col_type
+        
+    mapping = getattr(base_type, '_variant_mapping', None)
     assert mapping is not None, "Variant mapping is missing"
     assert 'postgresql' in mapping
     assert isinstance(mapping['postgresql'], JSONB)
 
-def test_daily_summary_image_urls_type():
-    col_type = DailySummary.image_urls.type
-    mapping = getattr(col_type, '_variant_mapping', None)
-    assert mapping is not None, "Variant mapping is missing"
-    assert 'postgresql' in mapping
-    assert isinstance(mapping['postgresql'], JSONB)
+def test_daily_summary_image_urls_is_mutable_list():
+    ds = DailySummary()
+    ds.image_urls = []
+    assert isinstance(ds.image_urls, MutableList), "DailySummary.image_urls did not convert list to MutableList"


### PR DESCRIPTION
## 概要

Closes #824

## 変更内容

JSONBカラムの変更検知漏れを防ぐMutableList導入

## 実装方法

- Gemini CLIによる自動実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認