### PR TITLE
fix: #823 SuperAdminのBaby一覧取得時のメモリ枯渇リスク

### DIFF
--- a/app/routers/baby.py
+++ b/app/routers/baby.py
@@ -46,9 +46,19 @@ class RecordCreate(BaseModel):
 
 
 @router.get("/", response_model=List[BabyResponse])
-def get_babies(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+def get_babies(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    limit: Optional[int] = Query(None, description="Maximum number of items to return (SuperAdmin only)", ge=1, le=1000),
+    offset: Optional[int] = Query(None, description="Number of items to skip (SuperAdmin only)", ge=0)
+):
     if current_user.is_superadmin:
-        return db.query(Baby).filter(Baby.is_deleted == False).all()
+        query = db.query(Baby).filter(Baby.is_deleted == False)
+        if limit is not None:
+            query = query.limit(limit)
+        if offset is not None:
+            query = query.offset(offset)
+        return query.all()
 
     family_users = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).all()
     if not family_users:

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4773,6 +4773,47 @@
     "/api/babies/": {
       "get": {
         "operationId": "get_babies_api_babies__get",
+        "parameters": [
+          {
+            "description": "Maximum number of items to return (SuperAdmin only)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 1000,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of items to return (SuperAdmin only)",
+              "title": "Limit"
+            }
+          },
+          {
+            "description": "Number of items to skip (SuperAdmin only)",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Number of items to skip (SuperAdmin only)",
+              "title": "Offset"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -4787,6 +4828,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Babies",

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -3049,7 +3049,12 @@ export interface operations {
     };
     get_babies_api_babies__get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return (SuperAdmin only) */
+                limit?: number | null;
+                /** @description Number of items to skip (SuperAdmin only) */
+                offset?: number | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -3063,6 +3068,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BabyResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/tests/test_issue_823_superadmin_babies_pagination.py
+++ b/tests/test_issue_823_superadmin_babies_pagination.py
@@ -1,0 +1,52 @@
+import pytest
+from fastapi import status
+from datetime import date
+from app.models.baby import Baby
+from app.models.family import Family
+from app.models.user import User
+
+def test_superadmin_babies_pagination(auth_client, db):
+    # 1. Register and login as a user
+    client = auth_client(username="adminuser_823", password="password123")
+    
+    # 2. Make the current user a SuperAdmin directly in the DB
+    admin_user = db.query(User).filter(User.username == "adminuser_823").first()
+    admin_user.is_superadmin = True
+    db.commit()
+
+    # Create a family
+    family = Family(name="Test Family for SuperAdmin Pagination", invite_code="SUPER123")
+    db.add(family)
+    db.commit()
+    db.refresh(family)
+    
+    # Create 5 babies
+    for i in range(5):
+        baby = Baby(
+            family_id=family.id,
+            name=f"Admin Baby {i}",
+            birthday=date(2023, 1, 1),
+            gender="unknown"
+        )
+        db.add(baby)
+    db.commit()
+
+    # Fetch without pagination
+    response = client.get("/api/babies/")
+    assert response.status_code == status.HTTP_200_OK
+    all_babies = response.json()
+    total_babies = len(all_babies)
+    assert total_babies >= 5
+    
+    # Fetch with limit=2
+    response = client.get("/api/babies/?limit=2")
+    assert response.status_code == status.HTTP_200_OK
+    paginated_babies = response.json()
+    assert len(paginated_babies) == 2
+    
+    # Fetch with limit=2, offset=2
+    response = client.get("/api/babies/?limit=2&offset=2")
+    assert response.status_code == status.HTTP_200_OK
+    offset_babies = response.json()
+    assert len(offset_babies) == 2
+    assert paginated_babies[0]["id"] != offset_babies[0]["id"]


### PR DESCRIPTION
## 概要

Closes #823

## 変更内容

SuperAdminのBaby一覧取得時のメモリ枯渇リスク

## 実装方法

- Gemini CLIによる自動実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認