### PR TITLE
✍️ Scribe: 通知センター仕様書への実績（achievement）通知の追加

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -274,3 +274,7 @@
 ## 2026-03-10 - [新しい記録タイプ 'temperature' の通知センター仕様への追加漏れ]
 **学び:** 体温記録機能（`app/routers/temperatures.py`）が追加され、API側で `notify_family_members_bg` などを利用して記録時に通知を送信する実装がされているにもかかわらず、通知仕様を取りまとめている `.specify/specs/ui/notification_center.md` の各リスト（通知の種類、トリガー、URLパターン等）への追記が漏れやすい。
 **アクション:** 新規の記録・トラッカー機能を追加する際は、APIや権限管理だけでなく、通知センターの仕様書（通知トリガーの対応表や遷移先URL設計など）にも新しい `record_type` が追加されているかを検証し、同期する。
+
+## 2026-03-10 - [新しい通知タイプ 'achievement' の通知センター仕様への追加漏れ]
+**学び:** 実績機能（Achievement）の追加に伴い、`app/utils/notifications.py` で `notify_achievements_bg` 関数が実装され、`category="achievement"` として通知が送信される機能が追加されたが、通知センターの仕様書 `.specify/specs/ui/notification_center.md` 内の複数のリスト（通知の種類、通知設定との連動、トリガー、APIレスポンス型、URL設計）への追記が完全に漏れていた。
+**アクション:** 新しい通知カテゴリ（type）をシステムに追加する際は、通知送信のユーティリティ関数（`app/utils/notifications.py`）だけでなく、仕様書（`.specify/specs/ui/notification_center.md`）内の複数のテーブル（種類、設定連動、DBコメント、API型、トリガー、URL設計）を網羅的に検索し、同期漏れがないように徹底する。

--- a/.specify/specs/ui/notification_center.md
+++ b/.specify/specs/ui/notification_center.md
@@ -77,6 +77,7 @@ notification_service.py の notify_*() を呼び出す
 | `feeding_reminder` | 前回の授乳から一定時間経過 | 「授乳の時間かもしれません」 | `Clock` |
 | `diaper_reminder` | 前回のおむつ替えから一定時間経過 | 「おむつ替えの時間かもしれません」 | `Clock` |
 | `system` | システムメッセージ（メンテナンス・アップデート情報等） | 「アプリが更新されました」 | `Bell` |
+| `achievement` | 記録等により実績（アチーブメント）を解除した | 「実績解除！🎖️ 初めての寝返り」 | `Trophy` |
 
 > **注意**: `comment` は PWA 仕様では `family_record` カテゴリに含まれているが、アプリ内通知センターでは視認性のため独立した `type` として扱う。
 
@@ -87,7 +88,7 @@ notification_service.py の notify_*() を呼び出す
 
 | `notification_settings` カラム | 対象 type |
 |-------------------------------|-----------|
-| `family_record_enabled` | `family_record`、`comment` |
+| `family_record_enabled` | `family_record`、`comment`、`achievement` |
 | `feeding_reminder_enabled` | `feeding_reminder` |
 | `diaper_reminder_enabled` | `diaper_reminder` |
 | `daily_summary_enabled` | `daily_summary` |
@@ -105,7 +106,7 @@ CREATE TABLE app_notifications (
     user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     type        VARCHAR(50)  NOT NULL,
     -- 'family_record' | 'comment' | 'daily_summary'
-    -- | 'feeding_reminder' | 'diaper_reminder' | 'system'
+    -- | 'feeding_reminder' | 'diaper_reminder' | 'system' | 'achievement'
     title       VARCHAR(255) NOT NULL,
     body        TEXT,
     url         VARCHAR(512),            -- タップ時の遷移先（null の場合は遷移なし）
@@ -147,7 +148,8 @@ type AppNotification = {
     | 'daily_summary'
     | 'feeding_reminder'
     | 'diaper_reminder'
-    | 'system';
+    | 'system'
+    | 'achievement';
   title: string;
   body: string | null;
   url: string | null;
@@ -290,6 +292,7 @@ async def notify_reminder(
 | 記録追加（授乳・おむつ・睡眠・成長・陣痛・メモ・体温） | `family_record` | 同ファミリーの**記録者以外**の全メンバー | 記録者自身は除外 |
 | コメント追加 | `comment` | **記録オーナー** | コメント投稿者と記録オーナーが同一の場合は除外 |
 | デイリーサマリー生成 | `daily_summary` | 同ファミリーの**全メンバー** | なし |
+| 実績解除（バックグラウンド処理） | `achievement` | 同ファミリーの**全メンバー** | なし |
 | 授乳リマインダー（バッチ処理） | `feeding_reminder` | 対象ユーザー | `feeding_reminder_enabled = False` の場合はスキップ |
 | オムツリマインダー（バッチ処理） | `diaper_reminder` | 対象ユーザー | `diaper_reminder_enabled = False` の場合はスキップ |
 | システムメッセージ | `system` | 指定ユーザー or 全ユーザー | なし |
@@ -309,6 +312,7 @@ async def notify_reminder(
 | `daily_summary` | `/diary` | AI 日誌ページへ遷移 |
 | `feeding_reminder` | `/feeding` | 授乳記録一覧ページへ遷移 |
 | `diaper_reminder` | `/diaper` | おむつ記録一覧ページへ遷移 |
+| `achievement` | `/dashboard?baby_id={id}` | ダッシュボード（実績確認）へ遷移 |
 | `system` | 任意（省略時は `null`） | URLが `null` の場合は遷移しない |
 
 **`{record_type}` の対応表**:


### PR DESCRIPTION
💡 何を:
`.specify/specs/ui/notification_center.md` に新しい通知タイプ `achievement`（実績解除）の仕様を追記しました。通知の種類、通知設定との連動、トリガー、APIレスポンス型、URL設計の各セクションに漏れなく追加しています。また、この仕様ドリフトに関する学びを `.jules/scribe.md` に記録しました。

🔍 発見:
実績機能（Achievement）の追加に伴い、バックエンド（`app/utils/notifications.py`）で `notify_achievements_bg` 関数が実装され、`category="achievement"` として通知が送信される機能が追加されていました。しかし、通知センターの仕様書において、この新しい通知タイプに関する記載が完全に漏れており、実装と仕様の間に乖離が生じていました。

🎯 影響:
ドキュメントが最新の実装に同期されたことで、フロントエンド開発者が実績通知のUI実装（アイコンの表示や適切なページへの遷移）を仕様書から正確に把握できるようになります。また、将来的なAPI型の不整合を防ぐことができます。

---
*PR created automatically by Jules for task [14860782821160961367](https://jules.google.com/task/14860782821160961367) started by @eburairu*