### PR TITLE
fix: NotificationType Enum に achievement を追加（通知センター空表示の修正）

### DIFF
--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -11,6 +11,7 @@ class NotificationType(str, Enum):
     feeding_reminder = "feeding_reminder"
     diaper_reminder = "diaper_reminder"
     system = "system"
+    achievement = "achievement"
 
 
 class AppNotificationResponse(BaseModel):

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2911,7 +2911,8 @@
           "daily_summary",
           "feeding_reminder",
           "diaper_reminder",
-          "system"
+          "system",
+          "achievement"
         ],
         "title": "NotificationType",
         "type": "string"


### PR DESCRIPTION
## 問題

achievement タイプの通知が DB に存在すると `/api/notifications` が Pydantic validation error で 422 を返し、通知センターが「通知はありません」と表示される。

`/api/notifications/unread-count` は Enum を使用しないため正常動作し、ベルマークの数字のみ表示される状態だった。

## 原因

`app/schemas/notification.py` の `NotificationType` Enum に `achievement` が含まれていなかった（実績システム追加時の漏れ）。

## 修正

`NotificationType` に `achievement = "achievement"` を追加。

## 影響範囲

- `/api/notifications` が achievement タイプの通知を正常にシリアライズできるようになる
- 本番 DB に存在する achievement 通知が通知センターに表示されるようになる