### PR TITLE
feat: #818 FamilyUserのroleカラムに対するEnum型制約の適用

### DIFF
--- a/alembic/versions/i1j2k3l4_add_userrole_enum_to_family_users.py
+++ b/alembic/versions/i1j2k3l4_add_userrole_enum_to_family_users.py
@@ -1,0 +1,41 @@
+"""add_userrole_enum_to_family_users
+
+Revision ID: i1j2k3l4
+Revises: h1i2j3k4
+Create Date: 2026-03-11
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'i1j2k3l4'
+down_revision: Union[str, Sequence[str], None] = 'h1i2j3k4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # userrole Enum 型を作成（既に存在する場合はスキップ）
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE userrole AS ENUM ('admin', 'member', 'viewer');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$
+    """)
+    # role カラムを String から userrole Enum 型に変更
+    op.execute("""
+        ALTER TABLE family_users
+        ALTER COLUMN role TYPE userrole USING role::userrole
+    """)
+
+
+def downgrade() -> None:
+    # role カラムを String に戻す
+    op.execute("""
+        ALTER TABLE family_users
+        ALTER COLUMN role TYPE VARCHAR USING role::VARCHAR
+    """)
+    op.execute("DROP TYPE IF EXISTS userrole")

--- a/app/models/family.py
+++ b/app/models/family.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, func, Index
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, func, Index, Enum
 from sqlalchemy.orm import relationship
 from .base import Base, SoftDeleteMixin
 from app.models.enums import UserRole
@@ -24,7 +24,7 @@ class FamilyUser(Base):
 
     family_id = Column(Integer, ForeignKey("families.id"), primary_key=True, nullable=False)
     user_id = Column(Integer, ForeignKey("users.id"), primary_key=True, nullable=False, index=True)
-    role = Column(String, nullable=False)
+    role = Column(Enum(UserRole, name="userrole", values_callable=lambda x: [e.value for e in x]), nullable=False)
     joined_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     family = relationship("Family", back_populates="family_users")

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -4,6 +4,23 @@
  */
 
 export interface paths {
+    "/api/achievements/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Achievements */
+        get: operations["get_achievements_api_achievements__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/audit-logs": {
         parameters: {
             query?: never;
@@ -1304,6 +1321,35 @@ export interface components {
             /** Username */
             username: string | null;
         };
+        /**
+         * BabyAchievementResponse
+         * @description 実績一覧APIのレスポンス
+         */
+        BabyAchievementResponse: {
+            /**
+             * Achieved At
+             * Format: date-time
+             */
+            achieved_at: string;
+            /** Achievement Id */
+            achievement_id: string;
+            /** Baby Id */
+            baby_id: number;
+            /** Category */
+            category: string;
+            /** Description */
+            description: string;
+            /** Icon */
+            icon: string;
+            /** Id */
+            id: number;
+            /** Name */
+            name: string;
+            /** Rarity */
+            rarity: string;
+            /** Triggered By Display Name */
+            triggered_by_display_name?: string | null;
+        };
         /** BabyAdminResponse */
         BabyAdminResponse: {
             /** Birthday */
@@ -1618,6 +1664,11 @@ export interface components {
             notes?: string | null;
             /** Recorded By Display Name */
             recorded_by_display_name?: string | null;
+            /**
+             * Unlocked Achievements
+             * @default []
+             */
+            unlocked_achievements: components["schemas"]["UnlockedAchievementInfo"][];
             /** User Id */
             user_id: number;
         };
@@ -1793,6 +1844,11 @@ export interface components {
             recorded_by_display_name?: string | null;
             /** Right Breast Minutes */
             right_breast_minutes?: number | null;
+            /**
+             * Unlocked Achievements
+             * @default []
+             */
+            unlocked_achievements: components["schemas"]["UnlockedAchievementInfo"][];
             /** User Id */
             user_id: number;
         };
@@ -1891,6 +1947,11 @@ export interface components {
             notes?: string | null;
             /** Recorded By Display Name */
             recorded_by_display_name?: string | null;
+            /**
+             * Unlocked Achievements
+             * @default []
+             */
+            unlocked_achievements: components["schemas"]["UnlockedAchievementInfo"][];
             /** User Id */
             user_id: number;
             /** Weight */
@@ -1966,6 +2027,11 @@ export interface components {
             notes?: string | null;
             /** Title */
             title: string;
+            /**
+             * Unlocked Achievements
+             * @default []
+             */
+            unlocked_achievements: components["schemas"]["UnlockedAchievementInfo"][];
             /** User Id */
             user_id: number | null;
         };
@@ -2077,7 +2143,7 @@ export interface components {
          * NotificationType
          * @enum {string}
          */
-        NotificationType: "family_record" | "comment" | "daily_summary" | "feeding_reminder" | "diaper_reminder" | "system";
+        NotificationType: "family_record" | "comment" | "daily_summary" | "feeding_reminder" | "diaper_reminder" | "system" | "achievement";
         /** PasswordChangeRequest */
         PasswordChangeRequest: {
             /** Current Password */
@@ -2234,6 +2300,11 @@ export interface components {
              * Format: date-time
              */
             start_time: string;
+            /**
+             * Unlocked Achievements
+             * @default []
+             */
+            unlocked_achievements: components["schemas"]["UnlockedAchievementInfo"][];
             /** User Id */
             user_id: number;
         };
@@ -2296,6 +2367,11 @@ export interface components {
             recorded_by_display_name?: string | null;
             /** Temperature */
             temperature: number;
+            /**
+             * Unlocked Achievements
+             * @default []
+             */
+            unlocked_achievements: components["schemas"]["UnlockedAchievementInfo"][];
             /** User Id */
             user_id: number;
         };
@@ -2331,6 +2407,24 @@ export interface components {
             timestamp: string;
             /** Type */
             type: string;
+        };
+        /**
+         * UnlockedAchievementInfo
+         * @description 記録APIレスポンスに含める実績解除情報
+         */
+        UnlockedAchievementInfo: {
+            /** Achievement Id */
+            achievement_id: string;
+            /** Category */
+            category: string;
+            /** Description */
+            description: string;
+            /** Icon */
+            icon: string;
+            /** Name */
+            name: string;
+            /** Rarity */
+            rarity: string;
         };
         /** UnreadCountResponse */
         UnreadCountResponse: {
@@ -2520,6 +2614,37 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    get_achievements_api_achievements__get: {
+        parameters: {
+            query: {
+                baby_id: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BabyAchievementResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_audit_logs_api_admin_audit_logs_get: {
         parameters: {
             query?: {

--- a/tests/test_issue_818_role_enum.py
+++ b/tests/test_issue_818_role_enum.py
@@ -1,0 +1,54 @@
+"""
+Issue #818: FamilyUserのroleカラムに対するEnum型制約の適用
+
+FamilyUser.role が SQLAlchemy Enum 型として定義されていることを確認するテスト。
+"""
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import Enum as SAEnum
+
+
+def test_family_user_role_column_is_enum_type():
+    """role カラムが SQLAlchemy Enum 型であることを確認する"""
+    from app.models.family import FamilyUser
+    from app.models.enums import UserRole
+
+    role_col = FamilyUser.__table__.c.role
+    assert isinstance(role_col.type, SAEnum), (
+        f"role カラムの型が Enum ではなく {type(role_col.type)} です。"
+        "Column(Enum(UserRole), ...) に変更してください。"
+    )
+
+
+def test_family_user_role_enum_values_match_user_role():
+    """Enum 型の値が UserRole の値と一致することを確認する"""
+    from app.models.family import FamilyUser
+    from app.models.enums import UserRole
+
+    role_col = FamilyUser.__table__.c.role
+    assert isinstance(role_col.type, SAEnum)
+
+    expected_values = {r.value for r in UserRole}
+    actual_values = set(role_col.type.enums)
+    assert actual_values == expected_values, (
+        f"Enum 値が一致しません。期待値: {expected_values}, 実際: {actual_values}"
+    )
+
+
+def test_family_user_role_enum_name():
+    """Enum 型の名前が 'userrole' であることを確認する"""
+    from app.models.family import FamilyUser
+
+    role_col = FamilyUser.__table__.c.role
+    assert isinstance(role_col.type, SAEnum)
+    assert role_col.type.name == "userrole", (
+        f"Enum 型名が 'userrole' ではなく '{role_col.type.name}' です。"
+    )
+
+
+def test_family_user_role_column_not_nullable():
+    """role カラムが nullable=False であることを確認する"""
+    from app.models.family import FamilyUser
+
+    role_col = FamilyUser.__table__.c.role
+    assert not role_col.nullable, "role カラムは nullable=False でなければなりません。"


### PR DESCRIPTION
## 概要

Closes #818

## 変更内容

FamilyUserのroleカラムに対するEnum型制約の適用

## 実装方法

- Claude Codeによる実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認