### PR TITLE
fix: 最新の記録と授乳履歴・AIフィードバックに月日を追加表示

### DIFF
--- a/frontend/components/dashboard/ActivityItem.tsx
+++ b/frontend/components/dashboard/ActivityItem.tsx
@@ -2,6 +2,7 @@
 import React from "react"
 import { BabyRecord } from "@/types/record"
 import { formatElapsed } from "@/lib/ageUtils"
+import { formatDateTime } from "@/lib/dateUtils"
 import { MessageCircle, User, StickyNote } from "lucide-react"
 import { RECORD_TYPE_LABELS, RECORD_TYPE_LUCIDE_ICONS, RECORD_TYPE_COLORS, RECORD_TYPE_BG_COLORS } from "@/constants/ui"
 import { AppIcons } from "@/constants/icons"
@@ -72,9 +73,14 @@ export const ActivityItem = React.memo(function ActivityItem({ record, onClick }
                         ) : null}
                     </div>
                 </div>
-                <span className="text-xs text-gray-400 dark:text-zinc-500 whitespace-nowrap">
-                    {formatElapsed(record.timestamp)}
-                </span>
+                <div className="flex flex-col items-end shrink-0">
+                    <span className="text-xs text-gray-400 dark:text-zinc-500 whitespace-nowrap">
+                        {formatDateTime(record.timestamp)}
+                    </span>
+                    <span className="text-[10px] text-gray-300 dark:text-zinc-600 whitespace-nowrap">
+                        {formatElapsed(record.timestamp)}
+                    </span>
+                </div>
             </button>
         </li>
     )

--- a/frontend/components/feeding/feeding-history.tsx
+++ b/frontend/components/feeding/feeding-history.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { Feeding, FeedingUpdate } from "@/types/feeding"
 import { RECORD_TYPES } from "@/types/enums"
-import { formatTime } from "@/lib/dateUtils"
+import { formatDateTime } from "@/lib/dateUtils"
 import { GenericRecordHistory } from "@/components/records/GenericRecordHistory"
 import { FeedingEditDialog } from "./FeedingEditDialog"
 import { COMPLETION_STYLE, FEEDING_TYPE_LABELS } from "@/constants/feeding"
@@ -39,11 +39,11 @@ export function FeedingHistory({
             initialCommentRecordId={initialCommentRecordId}
             onRefresh={onRefresh || (() => {})}
             onDelete={onDelete}
-            getCommentTitle={(record) => `授乳 ${formatTime(record.feeding_time)}`}
+            getCommentTitle={(record) => `授乳 ${formatDateTime(record.feeding_time)}`}
             renderIcon={(record) => <FeedingIcon type={record.feeding_type} />}
             renderTitle={(record) => (
                 <div className="font-medium">
-                    {formatTime(record.feeding_time)}
+                    {formatDateTime(record.feeding_time)}
                     <span className="ml-2 text-sm text-muted-foreground">
                         {FEEDING_TYPE_LABELS[record.feeding_type] || record.feeding_type}
                     </span>


### PR DESCRIPTION
## 変更内容

### ActivityItem（ダッシュボード最新記録）
- 右側の時刻表示を `formatElapsed`（相対時間のみ）から `formatDateTime`（M/d HH:mm）に変更
- 相対時間（「3分前」など）はサブテキストとして残す

### FeedingHistory（授乳記録ページ）
- 各レコードのタイトル: `formatTime`（HH:mm のみ）→ `formatDateTime`（M/d HH:mm）
- AIフィードバックダイアログのタイトル（getCommentTitle）も同様に修正

## 背景
授乳履歴は日付をまたいで表示されるケースがあるが、これまで時刻（HH:mm）しか表示されず、どの日の記録か判別できなかった。また、AIフィードバックダイアログのタイトルも同じ問題があった。