### PR TITLE
✍️ Scribe: [体温記録機能のページネーション仕様と実装の同期]

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -278,3 +278,6 @@
 ## 2026-03-10 - [新しい通知タイプ 'achievement' の通知センター仕様への追加漏れ]
 **学び:** 実績機能（Achievement）の追加に伴い、`app/utils/notifications.py` で `notify_achievements_bg` 関数が実装され、`category="achievement"` として通知が送信される機能が追加されたが、通知センターの仕様書 `.specify/specs/ui/notification_center.md` 内の複数のリスト（通知の種類、通知設定との連動、トリガー、APIレスポンス型、URL設計）への追記が完全に漏れていた。
 **アクション:** 新しい通知カテゴリ（type）をシステムに追加する際は、通知送信のユーティリティ関数（`app/utils/notifications.py`）だけでなく、仕様書（`.specify/specs/ui/notification_center.md`）内の複数のテーブル（種類、設定連動、DBコメント、API型、トリガー、URL設計）を網羅的に検索し、同期漏れがないように徹底する。
+## 2026-03-10 - [体温記録仕様書のページネーションデフォルト値と実装の同期]
+**学び:** 体温記録エンドポイント（`app/routers/temperatures.py`）の実装では、デフォルトの `limit` パラメータが `MAX_PAGINATION_LIMIT`（100）に設定されているにもかかわらず、仕様書（`temperature_tracker.md`）には誤って `limit=20` と記載されていました。
+**アクション:** 仕様書内のハードコードされた `limit` パラメータのデフォルト値を、バックエンドの実装に合わせ `100` へ修正しました。今後は API ルーターの `Query(...)` のデフォルト値と仕様書の記載が一致しているかを常に確認します。

--- a/.specify/specs/tracking/temperature_tracker.md
+++ b/.specify/specs/tracking/temperature_tracker.md
@@ -119,7 +119,7 @@
 
 - `GET /api/temperatures/?baby_id={id}&skip={skip}&limit={limit}`
     - 指定した赤ちゃんの記録を測定日時順（降順）で取得。
-    - デフォルト: skip=0, limit=20 (最大100)
+    - デフォルト: skip=0, limit=100 (最大100)
 - `POST /api/temperatures/`
     - 新規作成。
 - `PUT /api/temperatures/{id}`


### PR DESCRIPTION
💡 何を
`temperature_tracker.md` の GET `/api/temperatures/` エンドポイント仕様において、`limit` パラメータのデフォルト値を 20 から 100 に修正しました。

🔍 発見
体温記録エンドポイント（`app/routers/temperatures.py`）の実装を確認したところ、`limit: int = Query(MAX_PAGINATION_LIMIT, ge=1, le=MAX_PAGINATION_LIMIT)` と定義されており、プロジェクトで定義されている `MAX_PAGINATION_LIMIT` は `100` であるため、実際のデフォルト値は `100` となっています。
しかし、仕様書（`.specify/specs/tracking/temperature_tracker.md`）には誤って「デフォルト: limit=20」と記載されており、仕様が実装と乖離（仕様ドリフト）していました。

🎯 影響
APIを利用する開発者（フロントエンド側など）が、1回のリクエストで取得できるデフォルトの件数を正しく把握できるようになり、ページネーションの実装時に予期せぬデータの取りこぼしを防ぐことができます。また、プロジェクト全体の「デフォルト件数」の一貫性を保つ手助けになります。

---
*PR created automatically by Jules for task [2560053834146564133](https://jules.google.com/task/2560053834146564133) started by @eburairu*