### PR TITLE
feat: #873 招待コードに48時間の有効期限を追加

### DIFF
--- a/alembic/versions/k1l2m3n4_add_invite_code_expires_at.py
+++ b/alembic/versions/k1l2m3n4_add_invite_code_expires_at.py
@@ -1,0 +1,24 @@
+"""add_invite_code_expires_at
+
+Revision ID: k1l2m3n4
+Revises: 0c6faa11a8a9
+Create Date: 2026-03-11
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'k1l2m3n4'
+down_revision: Union[str, Sequence[str], None] = '0c6faa11a8a9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('families', sa.Column('invite_code_expires_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('families', 'invite_code_expires_at')

--- a/app/models/family.py
+++ b/app/models/family.py
@@ -10,6 +10,7 @@ class Family(Base, SoftDeleteMixin):
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
     name = Column(String, nullable=False)
     invite_code = Column(String, unique=True, index=True, nullable=False)
+    invite_code_expires_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     family_users = relationship("FamilyUser", back_populates="family")

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -127,7 +127,8 @@ async def register_family(
     while db.query(Family).filter(Family.invite_code == invite_code).first():
         invite_code = secrets.token_hex(8).upper()
 
-    new_family = Family(name=family_in.name, invite_code=invite_code)
+    invite_code_expires_at = datetime.now(timezone.utc) + timedelta(hours=48)
+    new_family = Family(name=family_in.name, invite_code=invite_code, invite_code_expires_at=invite_code_expires_at)
     db.add(new_family)
     db.flush()
 
@@ -192,6 +193,8 @@ async def join_family(
     family = db.query(Family).filter(Family.invite_code == invite_code).first()
     if not family:
         raise HTTPException(status_code=404, detail="Invalid invite code")
+    if family.invite_code_expires_at and family.invite_code_expires_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
+        raise HTTPException(status_code=410, detail="Invite code has expired")
 
     new_user = User(
         username=user_in.username.lower(),

--- a/app/routers/family.py
+++ b/app/routers/family.py
@@ -1,5 +1,6 @@
 import logging
 import secrets
+from datetime import datetime, timedelta, timezone
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -81,6 +82,7 @@ def regenerate_invite_code(
     while db.query(Family).filter(Family.invite_code == new_code).first():
         new_code = secrets.token_hex(8).upper()
     family.invite_code = new_code
+    family.invite_code_expires_at = datetime.now(timezone.utc) + timedelta(hours=48)
     logger.info("Invite code regenerated: family_id=%s, by user_id=%s", family.id, current_user.id)
     db.commit()
     db.refresh(family)

--- a/app/schemas/family.py
+++ b/app/schemas/family.py
@@ -24,6 +24,7 @@ class FamilyResponse(BaseModel):
     id: int
     name: str
     invite_code: str
+    invite_code_expires_at: Optional[datetime] = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1579,6 +1579,18 @@
             "title": "Invite Code",
             "type": "string"
           },
+          "invite_code_expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Invite Code Expires At"
+          },
           "name": {
             "title": "Name",
             "type": "string"

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -1771,6 +1771,8 @@ export interface components {
             id: number;
             /** Invite Code */
             invite_code: string;
+            /** Invite Code Expires At */
+            invite_code_expires_at?: string | null;
             /** Name */
             name: string;
         };

--- a/tests/test_invite_code_expiry.py
+++ b/tests/test_invite_code_expiry.py
@@ -1,0 +1,88 @@
+"""招待コード有効期限機能のテスト (issue #873)"""
+import pytest
+from datetime import datetime, timedelta, timezone
+from tests.conftest import client
+
+
+def test_family_creation_sets_invite_code_expiry(client):
+    """ファミリー作成時に招待コードの有効期限が設定される"""
+    res = client.post(
+        "/api/auth/register/family",
+        json={"name": "Test Family", "username": "admin1", "password": "password123"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert "invite_code_expires_at" in data
+    expires_at = datetime.fromisoformat(data["invite_code_expires_at"]).replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    # 有効期限は現在から約48時間後（±5分の誤差を許容）
+    assert expires_at > now + timedelta(hours=47, minutes=55)
+    assert expires_at < now + timedelta(hours=48, minutes=5)
+
+
+def test_regenerate_invite_code_resets_expiry(client):
+    """招待コード再生成時に有効期限がリセットされる"""
+    res = client.post(
+        "/api/auth/register/family",
+        json={"name": "Regen Family", "username": "admin2", "password": "password123"},
+    )
+    assert res.status_code == 200
+    original_expires = res.json()["invite_code_expires_at"]
+
+    res = client.post("/api/family/invite_code/regenerate")
+    assert res.status_code == 200
+    data = res.json()
+    assert "invite_code_expires_at" in data
+    new_expires = datetime.fromisoformat(data["invite_code_expires_at"]).replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    # 再生成後の有効期限は約48時間後
+    assert new_expires > now + timedelta(hours=47, minutes=55)
+    assert new_expires < now + timedelta(hours=48, minutes=5)
+
+
+def test_join_with_valid_invite_code_succeeds(client):
+    """有効な招待コードでファミリーに参加できる"""
+    res = client.post(
+        "/api/auth/register/family",
+        json={"name": "Join Family", "username": "admin3", "password": "password123"},
+    )
+    assert res.status_code == 200
+    invite_code = res.json()["invite_code"]
+    client.cookies.clear()
+
+    res = client.post(
+        f"/api/auth/register/join?invite_code={invite_code}",
+        json={"username": "newmember", "password": "password123"},
+    )
+    assert res.status_code == 200
+
+
+def test_join_with_expired_invite_code_fails(client):
+    """期限切れの招待コードではファミリーに参加できない"""
+    from app.models.family import Family
+    from app.database import SessionLocal
+
+    res = client.post(
+        "/api/auth/register/family",
+        json={"name": "Expired Family", "username": "admin4", "password": "password123"},
+    )
+    assert res.status_code == 200
+    invite_code = res.json()["invite_code"]
+    family_id = res.json()["id"]
+    client.cookies.clear()
+
+    # DBで有効期限を過去に設定して期限切れにする
+    db = SessionLocal()
+    try:
+        family = db.query(Family).filter(Family.id == family_id).first()
+        family.invite_code_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        db.commit()
+    finally:
+        db.close()
+
+    res = client.post(
+        f"/api/auth/register/join?invite_code={invite_code}",
+        json={"username": "latemember", "password": "password123"},
+    )
+    assert res.status_code == 410
+    assert "expired" in res.json()["detail"].lower()


### PR DESCRIPTION
## 変更内容

- `Family` モデルに `invite_code_expires_at` (DateTime) カラムを追加
- ファミリー作成・招待コード再生成時に **48時間後** の有効期限を設定
- `POST /api/auth/register/join` で期限チェックを追加（期限切れは HTTP 410 を返す）
- Alembic マイグレーション追加 (`k1l2m3n4`)

## テスト

- `tests/test_invite_code_expiry.py` を新規追加（4テスト）
  - ファミリー作成時に有効期限が設定される
  - 再生成時に有効期限がリセットされる
  - 有効な招待コードでの参加が成功する
  - 期限切れ招待コードでの参加が HTTP 410 で失敗する

Closes #873