### PR TITLE
feat: #887 PWAでのService Workerを活用したオフライン書き込みと楽観的UI更新

### DIFF
--- a/frontend/__tests__/hooks/useOfflineSync.test.ts
+++ b/frontend/__tests__/hooks/useOfflineSync.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useOfflineSyncStore } from '../../stores/offlineSyncStore'
+
+vi.mock('../../lib/api', () => ({
+    api: {
+        post: vi.fn(),
+        patch: vi.fn(),
+        delete: vi.fn(),
+    },
+}))
+
+vi.mock('swr', async () => {
+    const mockMutate = vi.fn()
+    return {
+        default: vi.fn(),
+        useSWRConfig: vi.fn(() => ({ mutate: mockMutate })),
+    }
+})
+
+describe('useOfflineSync', () => {
+    beforeEach(async () => {
+        useOfflineSyncStore.getState().clearAll()
+        vi.stubGlobal('crypto', {
+            randomUUID: vi.fn()
+                .mockReturnValueOnce('uuid-1')
+                .mockReturnValueOnce('uuid-2')
+                .mockReturnValueOnce('uuid-3'),
+        })
+        Object.defineProperty(navigator, 'onLine', { value: true, writable: true, configurable: true })
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it('初期状態でonlineであることを検出する', async () => {
+        const { useOfflineSync } = await import('../../hooks/useOfflineSync')
+        const { result } = renderHook(() => useOfflineSync())
+        expect(result.current.isOnline).toBe(true)
+    })
+
+    it('pendingCountがキューのサイズと一致する', async () => {
+        useOfflineSyncStore.getState().addOp({ endpoint: '/diapers/', method: 'POST', body: {} })
+        const { useOfflineSync } = await import('../../hooks/useOfflineSync')
+        const { result } = renderHook(() => useOfflineSync())
+        expect(result.current.pendingCount).toBe(1)
+    })
+
+    it('offlineイベントでisOnlineがfalseになる', async () => {
+        const { useOfflineSync } = await import('../../hooks/useOfflineSync')
+        const { result } = renderHook(() => useOfflineSync())
+        act(() => {
+            window.dispatchEvent(new Event('offline'))
+        })
+        expect(result.current.isOnline).toBe(false)
+    })
+
+    it('onlineイベントでisOnlineがtrueになる', async () => {
+        Object.defineProperty(navigator, 'onLine', { value: false, writable: true, configurable: true })
+        const { useOfflineSync } = await import('../../hooks/useOfflineSync')
+        const { result } = renderHook(() => useOfflineSync())
+        await act(async () => {
+            window.dispatchEvent(new Event('online'))
+        })
+        expect(result.current.isOnline).toBe(true)
+    })
+
+    it('onlineイベントでPOSTキューがフラッシュされる', async () => {
+        const { api } = await import('../../lib/api')
+        vi.mocked(api.post).mockResolvedValue({ id: 1 })
+
+        useOfflineSyncStore.getState().addOp({
+            endpoint: '/diapers/',
+            method: 'POST',
+            body: { baby_id: 1 },
+        })
+
+        const { useOfflineSync } = await import('../../hooks/useOfflineSync')
+        renderHook(() => useOfflineSync())
+
+        await act(async () => {
+            window.dispatchEvent(new Event('online'))
+        })
+
+        expect(api.post).toHaveBeenCalledWith('/diapers/', { baby_id: 1 })
+        expect(useOfflineSyncStore.getState().pendingOps).toHaveLength(0)
+    })
+
+    it('APIエラー時は操作がキューに残る', async () => {
+        const { api } = await import('../../lib/api')
+        vi.mocked(api.post).mockRejectedValue(new Error('Network error'))
+
+        useOfflineSyncStore.getState().addOp({ endpoint: '/diapers/', method: 'POST', body: {} })
+
+        const { useOfflineSync } = await import('../../hooks/useOfflineSync')
+        renderHook(() => useOfflineSync())
+
+        await act(async () => {
+            window.dispatchEvent(new Event('online'))
+        })
+
+        expect(useOfflineSyncStore.getState().pendingOps).toHaveLength(1)
+    })
+})

--- a/frontend/__tests__/stores/offlineSyncStore.test.ts
+++ b/frontend/__tests__/stores/offlineSyncStore.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useOfflineSyncStore } from '../../stores/offlineSyncStore'
+
+describe('useOfflineSyncStore', () => {
+    beforeEach(() => {
+        useOfflineSyncStore.getState().clearAll()
+        vi.stubGlobal('crypto', {
+            randomUUID: vi.fn()
+                .mockReturnValueOnce('uuid-1')
+                .mockReturnValueOnce('uuid-2')
+                .mockReturnValueOnce('uuid-3'),
+        })
+    })
+
+    it('初期状態ではpendingOpsが空である', () => {
+        expect(useOfflineSyncStore.getState().pendingOps).toHaveLength(0)
+    })
+
+    it('addOpで操作をキューに追加してIDを返す', () => {
+        const id = useOfflineSyncStore.getState().addOp({
+            endpoint: '/diapers/',
+            method: 'POST',
+            body: { baby_id: 1, diaper_type: 'WET' },
+        })
+        expect(id).toBe('uuid-1')
+        const ops = useOfflineSyncStore.getState().pendingOps
+        expect(ops).toHaveLength(1)
+        expect(ops[0].id).toBe('uuid-1')
+        expect(ops[0].endpoint).toBe('/diapers/')
+        expect(ops[0].method).toBe('POST')
+        expect(ops[0].body).toEqual({ baby_id: 1, diaper_type: 'WET' })
+        expect(ops[0].timestamp).toBeGreaterThan(0)
+    })
+
+    it('removeOpでIDを指定して操作を削除できる', () => {
+        useOfflineSyncStore.getState().addOp({ endpoint: '/diapers/', method: 'POST', body: {} })
+        expect(useOfflineSyncStore.getState().pendingOps).toHaveLength(1)
+        useOfflineSyncStore.getState().removeOp('uuid-1')
+        expect(useOfflineSyncStore.getState().pendingOps).toHaveLength(0)
+    })
+
+    it('存在しないIDでremoveOpしても他の操作は残る', () => {
+        useOfflineSyncStore.getState().addOp({ endpoint: '/diapers/', method: 'POST', body: {} })
+        useOfflineSyncStore.getState().removeOp('nonexistent-id')
+        expect(useOfflineSyncStore.getState().pendingOps).toHaveLength(1)
+    })
+
+    it('clearAllでキューを空にできる', () => {
+        useOfflineSyncStore.getState().addOp({ endpoint: '/diapers/', method: 'POST', body: {} })
+        useOfflineSyncStore.getState().addOp({ endpoint: '/feeding/', method: 'POST', body: {} })
+        useOfflineSyncStore.getState().clearAll()
+        expect(useOfflineSyncStore.getState().pendingOps).toHaveLength(0)
+    })
+
+    it('複数の操作を追加順に保持する', () => {
+        useOfflineSyncStore.getState().addOp({ endpoint: '/diapers/', method: 'POST', body: { type: 'WET' } })
+        useOfflineSyncStore.getState().addOp({ endpoint: '/feeding/', method: 'POST', body: { ml: 100 } })
+        const ops = useOfflineSyncStore.getState().pendingOps
+        expect(ops).toHaveLength(2)
+        expect(ops[0].endpoint).toBe('/diapers/')
+        expect(ops[1].endpoint).toBe('/feeding/')
+    })
+
+    it('DELETEメソッドの操作も登録できる', () => {
+        useOfflineSyncStore.getState().addOp({ endpoint: '/diapers/1', method: 'DELETE' })
+        const ops = useOfflineSyncStore.getState().pendingOps
+        expect(ops[0].method).toBe('DELETE')
+        expect(ops[0].body).toBeUndefined()
+    })
+})

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { SplashScreen } from "@/components/ui/splash-screen";
 import Script from "next/script";
 import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
+import { OfflineSyncIndicator } from "@/components/OfflineSyncIndicator";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -84,6 +85,7 @@ export default function RootLayout({
             />
           )}
           <ServiceWorkerRegister />
+          <OfflineSyncIndicator />
           <SplashScreen />
           {children}
           <Toaster />

--- a/frontend/components/OfflineSyncIndicator.tsx
+++ b/frontend/components/OfflineSyncIndicator.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useOfflineSync } from "@/hooks/useOfflineSync";
+
+/**
+ * オフライン状態と同期待ちキューをグローバルに管理するコンポーネント。
+ * layout.tsx にマウントしてアプリ全体で useOfflineSync を動作させる。
+ * pendingCount が 0 より大きい場合、画面下部に同期待ちバナーを表示する。
+ */
+export function OfflineSyncIndicator() {
+  const { isOnline, pendingCount } = useOfflineSync();
+
+  if (isOnline && pendingCount === 0) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-20 left-1/2 z-50 -translate-x-1/2 rounded-full px-4 py-2 text-sm font-medium shadow-lg transition-all"
+      style={{
+        backgroundColor: isOnline ? "hsl(var(--primary))" : "#6b7280",
+        color: "#fff",
+      }}
+    >
+      {isOnline
+        ? `同期中... (${pendingCount}件)`
+        : pendingCount > 0
+          ? `オフライン — ${pendingCount}件の記録を同期待ち`
+          : "オフライン"}
+    </div>
+  );
+}

--- a/frontend/components/ServiceWorkerRegister.tsx
+++ b/frontend/components/ServiceWorkerRegister.tsx
@@ -4,11 +4,30 @@ import { useEffect } from "react";
 
 export function ServiceWorkerRegister() {
   useEffect(() => {
-    if ("serviceWorker" in navigator) {
-      navigator.serviceWorker.register("/sw.js").catch((err) => {
-        console.error("Service Worker registration failed:", err);
+    if (!("serviceWorker" in navigator)) return;
+
+    navigator.serviceWorker.register("/sw.js").catch((err) => {
+      console.error("Service Worker registration failed:", err);
+    });
+
+    // オフライン移行時に Background Sync タグを登録する。
+    // SW が起動したタイミングでオンライン復帰を検知し SYNC_REQUESTED をクライアントに送信する。
+    const registerBackgroundSync = () => {
+      navigator.serviceWorker.ready.then((registration) => {
+        if ("sync" in registration) {
+          (registration.sync as { register: (tag: string) => Promise<void> })
+            .register("botoro-offline-sync")
+            .catch(() => {
+              // Background Sync 非対応ブラウザでは無視する（online イベントでフォールバック）
+            });
+        }
       });
-    }
+    };
+
+    window.addEventListener("offline", registerBackgroundSync);
+    return () => {
+      window.removeEventListener("offline", registerBackgroundSync);
+    };
   }, []);
 
   return null;

--- a/frontend/hooks/useBaseRecord.ts
+++ b/frontend/hooks/useBaseRecord.ts
@@ -1,6 +1,7 @@
 import useSWR from 'swr';
 import { api, fetcher } from '@/lib/api';
 import { achievementEvents } from '@/lib/achievementEvents';
+import { useOfflineSyncStore } from '@/stores/offlineSyncStore';
 
 /**
  * 記録リソース（授乳、おむつ、睡眠など）の CRUD を行う基底フック
@@ -21,6 +22,26 @@ export function useBaseRecord<T, TCreate, TUpdate>(
   // レコード追加
   const add = async (record: TCreate): Promise<T | undefined> => {
     if (!numericBabyId) return undefined;
+
+    // オフライン時: 楽観的UIとオフラインキューで対応
+    const isOnline = typeof navigator !== 'undefined' ? navigator.onLine : true;
+    if (!isOnline) {
+      const tempId = -Date.now();
+      const optimisticItem = { ...record, id: tempId } as unknown as T;
+      // SWRキャッシュに楽観的に追加（再検証なし）
+      await mutate(
+        (current: T[] | undefined) => [...(current ?? []), optimisticItem],
+        { revalidate: false }
+      );
+      // オフラインキューに登録してオンライン復帰時に同期
+      useOfflineSyncStore.getState().addOp({
+        endpoint: `/${endpoint}/`,
+        method: 'POST',
+        body: record,
+      });
+      return optimisticItem;
+    }
+
     const newRecord = await api.post<T, TCreate>(`/${endpoint}/`, record);
     mutate();
     // 実績解除があれば通知

--- a/frontend/hooks/useOfflineSync.ts
+++ b/frontend/hooks/useOfflineSync.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useSWRConfig } from 'swr'
+import { api } from '@/lib/api'
+import { useOfflineSyncStore } from '@/stores/offlineSyncStore'
+
+/**
+ * オフライン状態を検出し、復帰時にキューをフラッシュするフック。
+ * アプリのルートに一度だけマウントすることを想定。
+ */
+export function useOfflineSync() {
+    const [isOnline, setIsOnline] = useState(
+        typeof navigator !== 'undefined' ? navigator.onLine : true
+    )
+    const { pendingOps, removeOp } = useOfflineSyncStore()
+    const { mutate } = useSWRConfig()
+
+    const flush = useCallback(async () => {
+        const ops = useOfflineSyncStore.getState().pendingOps
+        if (ops.length === 0) return
+
+        for (const op of ops) {
+            try {
+                if (op.method === 'POST') {
+                    await api.post(op.endpoint, op.body)
+                } else if (op.method === 'PATCH') {
+                    await api.patch(op.endpoint, op.body)
+                } else if (op.method === 'DELETE') {
+                    await api.delete(op.endpoint)
+                }
+                useOfflineSyncStore.getState().removeOp(op.id)
+            } catch {
+                // 失敗した操作はキューに残し、次回オンライン復帰時に再試行する
+            }
+        }
+
+        // キューをフラッシュ後、全SWRキャッシュを再検証して最新データを取得する
+        mutate(() => true, undefined, { revalidate: true })
+    }, [mutate])
+
+    useEffect(() => {
+        const handleOnline = () => {
+            setIsOnline(true)
+            void flush()
+        }
+        const handleOffline = () => setIsOnline(false)
+
+        window.addEventListener('online', handleOnline)
+        window.addEventListener('offline', handleOffline)
+
+        return () => {
+            window.removeEventListener('online', handleOnline)
+            window.removeEventListener('offline', handleOffline)
+        }
+    }, [flush])
+
+    // Service WorkerからのSYNC_REQUESTEDメッセージを受信してフラッシュする
+    useEffect(() => {
+        if (!('serviceWorker' in navigator)) return
+
+        const handleMessage = (event: MessageEvent) => {
+            if (event.data?.type === 'SYNC_REQUESTED') {
+                void flush()
+            }
+        }
+
+        navigator.serviceWorker.addEventListener('message', handleMessage)
+        return () => {
+            navigator.serviceWorker.removeEventListener('message', handleMessage)
+        }
+    }, [flush])
+
+    return {
+        isOnline,
+        pendingCount: pendingOps.length,
+        flush,
+        removeOp,
+    }
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -11,3 +11,16 @@ self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim(
 
 // Push notification handler (handles push events and notification clicks)
 importScripts('/worker-1e999a0f776a11db.js');
+
+// Background Sync: オフライン中にキューされた書き込みをオンライン復帰後に同期する。
+// クライアント側の localStorage ベースのキューをフラッシュするため、
+// 全ウィンドウに SYNC_REQUESTED メッセージを送信して useOfflineSync フックを起動する。
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'botoro-offline-sync') {
+    event.waitUntil(
+      self.clients.matchAll({ includeUncontrolled: true, type: 'window' }).then((clients) => {
+        clients.forEach((client) => client.postMessage({ type: 'SYNC_REQUESTED' }));
+      })
+    );
+  }
+});

--- a/frontend/stores/offlineSyncStore.ts
+++ b/frontend/stores/offlineSyncStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export interface PendingOperation {
+    id: string
+    endpoint: string
+    method: 'POST' | 'PATCH' | 'DELETE'
+    body?: unknown
+    timestamp: number
+}
+
+interface OfflineSyncStore {
+    pendingOps: PendingOperation[]
+    addOp: (op: Omit<PendingOperation, 'id' | 'timestamp'>) => string
+    removeOp: (id: string) => void
+    clearAll: () => void
+}
+
+export const useOfflineSyncStore = create<OfflineSyncStore>()(
+    persist(
+        (set) => ({
+            pendingOps: [],
+            addOp: (op) => {
+                const id = crypto.randomUUID()
+                const pending: PendingOperation = { ...op, id, timestamp: Date.now() }
+                set((state) => ({ pendingOps: [...state.pendingOps, pending] }))
+                return id
+            },
+            removeOp: (id) =>
+                set((state) => ({
+                    pendingOps: state.pendingOps.filter((op) => op.id !== id),
+                })),
+            clearAll: () => set({ pendingOps: [] }),
+        }),
+        { name: 'offline-sync-store' }
+    )
+)


### PR DESCRIPTION
## 概要

Closes #887

## 変更内容

PWAでのService Workerを活用したオフライン書き込みと楽観的UI更新

## 実装方法

- Claude Codeによる実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認