### PR TITLE
✍️ Scribe: ダッシュボード仕様書への統合レコード作成API（POST）の追加

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -281,3 +281,10 @@
 ## 2026-03-10 - [体温記録仕様書のページネーションデフォルト値と実装の同期]
 **学び:** 体温記録エンドポイント（`app/routers/temperatures.py`）の実装では、デフォルトの `limit` パラメータが `MAX_PAGINATION_LIMIT`（100）に設定されているにもかかわらず、仕様書（`temperature_tracker.md`）には誤って `limit=20` と記載されていました。
 **アクション:** 仕様書内のハードコードされた `limit` パラメータのデフォルト値を、バックエンドの実装に合わせ `100` へ修正しました。今後は API ルーターの `Query(...)` のデフォルト値と仕様書の記載が一致しているかを常に確認します。
+
+## 2026-03-11 - [統合タイムラインAPIのPOSTエンドポイントの仕様書欠落]
+**学び:**
+- 統合タイムライン（`app/routers/baby.py`）において、一覧取得エンドポイント（`GET /api/babies/{id}/records`）とレスポンススキーマ（`UnifiedRecord`）は仕様書（`.specify/specs/ui/dashboard.md`）に記載されていたが、同ファイル内で定義されているクイック記録作成用のエンドポイント（`POST /api/babies/{id}/records`）およびリクエストスキーマ（`RecordCreate`）が完全に欠落していた。
+- トラッカーのメインエンドポイントとは別に、ダッシュボード等で横断的に利用される統合APIの場合、取得（GET）は記載されても更新・作成（POST/PATCH）の仕様が漏れるパターンがある。
+**アクション:**
+- `dashboard.md` のAPI仕様セクションに、`POST /api/babies/{id}/records` と `RecordCreate` スキーマのTypeScriptインターフェースを追記した。横断APIや統合APIの仕様書を確認する際は、必ずCRUD全体（特にPOST/PUT）が実装に沿って網羅されているかを確認する。

--- a/.specify/specs/ui/dashboard.md
+++ b/.specify/specs/ui/dashboard.md
@@ -163,6 +163,20 @@ Botoro のメイン画面（ホーム）となるダッシュボードの仕様�
         - `limit`: 取得件数 (default: 20, min: 1, max: 100)
     - **Response**: `List[UnifiedRecord]`
 
+- **POST /api/babies/{baby_id}/records**
+    - **Request Body**: `RecordCreate`
+    - **Response**: `UnifiedRecord` (作成された記録の初期状態)
+    - **備考**: クイックアクション等から「最低限の情報」で即時記録を作成する際に利用します。
+
+**リクエストスキーマ (`RecordCreate`)**
+
+```typescript
+interface RecordCreate {
+  type: string;
+  timestamp: string; // ISO 8601 (JST)
+}
+```
+
 **レスポンススキーマ (`UnifiedRecord`)**
 
 ```typescript

--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+import re
+with open('.specify/specs/ui/dashboard.md', 'r') as f:
+    text = f.read()
+if re.search(r'POST /api/babies/{baby_id}/records', text):
+    print("Found")
+else:
+    print("Not Found")


### PR DESCRIPTION
💡 何を (What)
- `.specify/specs/ui/dashboard.md` のAPI仕様セクションに、`POST /api/babies/{baby_id}/records` エンドポイントおよび `RecordCreate` のTypeScriptインターフェース定義を追記しました。
- `.jules/scribe.md` に今回の発見と学びをジャーナルとして記録しました。

🔍 発見 (Discovery)
- バックエンドの `app/routers/baby.py` にはクイック記録作成用の `POST /api/babies/{id}/records` エンドポイントが実装され使用されているにもかかわらず、ダッシュボードの仕様書には一覧取得エンドポイント（GET）しか記載されておらず、更新側のインターフェース定義が完全に欠落していました。

🎯 影響 (Impact)
- 統合APIを利用するフロントエンド開発において、記録の作成時に必要なペイロードの型やエンドポイントが明確になり、実装時の誤解や不整合を防ぐことができます。

---
*PR created automatically by Jules for task [6276454747254751578](https://jules.google.com/task/6276454747254751578) started by @eburairu*