### PR TITLE
fix: 実績通知タップで実績タブが開かないバグを修正

### DIFF
--- a/frontend/components/dashboard/BabyWidget.tsx
+++ b/frontend/components/dashboard/BabyWidget.tsx
@@ -27,25 +27,28 @@ export function BabyWidget({ baby, size }: BabyWidgetProps) {
   const searchParams = useSearchParams()
   const router = useRouter()
 
-  const isAchievementsDeepLink =
-    searchParams.get("baby_id") === String(baby.id) &&
-    searchParams.get("tab") === "achievements"
+  const [open, setOpen] = useState<boolean>(false)
+  const [activeTab, setActiveTab] = useState<TabId>("info")
 
-  const [open, setOpen] = useState<boolean>(() => isAchievementsDeepLink)
-  const [activeTab, setActiveTab] = useState<TabId>(() =>
-    isAchievementsDeepLink ? "achievements" : "info"
-  )
-
-  // URLパラメータのクリーンアップのみ（setStateを呼ばない）
+  // URLパラメータ経由のディープリンク（通知タップ時）を処理する。
+  // searchParams が変化したとき（client-side navigation 後も含む）に実行する。
+  // URL パラメータ（外部システム）の変化に応答する正当な useEffect。
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (!isAchievementsDeepLink) return
+    const babyId = searchParams.get("baby_id")
+    const tab = searchParams.get("tab")
+    if (babyId !== String(baby.id) || tab !== "achievements") return
+
+    setOpen(true)
+    setActiveTab("achievements")
+
     const params = new URLSearchParams(searchParams.toString())
     params.delete("baby_id")
     params.delete("tab")
     const newUrl = params.size > 0 ? `?${params}` : window.location.pathname
     router.replace(newUrl)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) // マウント時のみ実行
+  }, [searchParams, baby.id, router])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const handleManualOpen = () => {
     setActiveTab("info")


### PR DESCRIPTION
## 問題

実績解除の通知をタップしてもダッシュボードの実績タブが開かなかった。

## 原因

`BabyWidget` が `useState` の lazy initializer で `?tab=achievements` URL パラメータを読んでいたが、lazy initializer はコンポーネントの**初回マウント時にしか実行されない**。

通知タップは `router.push('/dashboard?baby_id=X&tab=achievements')` による client-side navigation のため、ダッシュボードに既にマウントされている `BabyWidget` は unmount/remount しない。結果として lazy initializer が再実行されず、ポップアップが開かなかった。

## 修正

`useState` lazy initializer を `useEffect` に変更し、`searchParams` の変化を監視してポップアップを開く。これにより client-side navigation 後も URL パラメータを正しく処理できる。

`react-hooks/set-state-in-effect` は URL（外部システム）への応答として意図的に抑制。

## テスト

1. 実績が解除されると通知が届く
2. 通知をタップするとダッシュボードに遷移し、実績タブが自動で開く