### PR TITLE
fix: 比較ビューの7日平均破線の視認性を修正

### DIFF
--- a/frontend/components/charts/DayComparisonChart.tsx
+++ b/frontend/components/charts/DayComparisonChart.tsx
@@ -97,9 +97,9 @@ export function DayComparisonChart({ data, colorToday, currentHour, unit = "回"
                     <Line
                         dataKey="avg7"
                         name="7日平均"
-                        stroke={gridColor}
-                        strokeDasharray="4 2"
-                        strokeWidth={1.5}
+                        stroke={isDark ? "#a1a1aa" : "#9ca3af"}
+                        strokeDasharray="6 3"
+                        strokeWidth={2}
                         dot={false}
                     />
                 </LineChart>


### PR DESCRIPTION
## 問題

`DayComparisonChart` で7日平均ラインの `stroke={gridColor}` がグリッド線と同色になっており、グラフ上で破線がほぼ見えない状態だった。

## 修正内容

- `stroke`: `gridColor`（グリッドと同色）→ `#a1a1aa`/`#9ca3af`（識別可能なグレー）
- `strokeWidth`: 1.5 → 2
- `strokeDasharray`: `4 2` → `6 3`（ダッシュを長くして視認性向上）

## 影響範囲

授乳チャート・おむつチャートの「今日 vs 7日平均」比較ビュー