### PR TITLE
fix: テーマトグルのアイコン表示を修正

### DIFF
--- a/frontend/components/theme-toggle.tsx
+++ b/frontend/components/theme-toggle.tsx
@@ -23,8 +23,8 @@ export function ThemeToggle() {
           className="cursor-pointer"
           icon={
             <>
-              <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-              <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+              <Moon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+              <Sun className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
               <span className="sr-only">テーマを切り替える</span>
             </>
           }


### PR DESCRIPTION
## 変更内容

設定ページのテーマ切り替えボタンのアイコンが逆になっていたバグを修正。

**修正前（誤り）:**
- ライトモード → Sunアイコン表示
- ダークモード → Moonアイコン表示

**修正後（正しい）:**
- ライトモード → Moonアイコン表示（「ダークモードに切り替え可能」を示す）
- ダークモード → Sunアイコン表示（「ライトモードに切り替え可能」を示す）

## 変更ファイル

- `frontend/components/theme-toggle.tsx`: SunとMoonの表示ロジックを入れ替え