### PR TITLE
fix: 設定ページのアイコン背景色がライト/ダークで反転するバグを修正

### DIFF
--- a/frontend/components/settings/SettingItem.tsx
+++ b/frontend/components/settings/SettingItem.tsx
@@ -27,18 +27,14 @@ export function SettingItem({
     isDestructive = false,
     rightElement,
 }: SettingItemProps) {
-    const hexagonColorClass = bgClass.replace(/bg-/g, 'text-');
-    
     const content = (
         <SettingsCard className={`flex items-center gap-4 ${
             onClick || href ? "cursor-pointer hover:bg-gray-50 dark:hover:bg-zinc-800" : ""
         } ${
             isDestructive ? "hover:bg-red-50 dark:hover:bg-red-950/20 group" : ""
         }`}>
-            <div className={`relative flex items-center justify-center ${
-                isDestructive ? "group-hover:text-red-100 dark:group-hover:text-red-900/30 transition-colors" : ""
-            }`}>
-                <Hexagon size={40} className={hexagonColorClass}>
+            <div className="relative flex items-center justify-center">
+                <Hexagon size={40} className={`${bgClass} transition-colors ${isDestructive ? "group-hover:bg-red-100 dark:group-hover:bg-red-900/30" : ""}`} color="transparent">
                     <Icon className={`relative z-10 h-5 w-5 ${colorClass} ${
                         isDestructive ? "group-hover:text-red-600 dark:group-hover:text-red-400" : ""
                     }`} />


### PR DESCRIPTION
## 原因

`SettingItem` 内で `bgClass.replace(/bg-/g, 'text-')` により動的生成された CSS クラス（例: `text-blue-50`）は Tailwind のビルド時スキャンで検出されず、CSS が生成されない。

その結果、Hexagon SVG の `fill="currentColor"` がページのデフォルトテキスト色を参照してしまい、ライトモードで黒、ダークモードで白のアイコン背景が表示されていた。

## 修正内容

- `bgClass.replace()` による動的クラス生成を廃止
- `bgClass`（例: `bg-blue-50 dark:bg-blue-950/30`）をそのまま Hexagon の `className` に渡す
- `color="transparent"` で SVG フィルを無効化し、Hexagon 外側 DIV の `background-color`（clipPath 済み）で背景色を正しく適用
- `isDestructive` ホバー状態を `group-hover:text-*` から `group-hover:bg-*` に変更

## 変更ファイル

- `frontend/components/settings/SettingItem.tsx`