### PR TITLE
feat: #868 主要な記録モデルへの created_at / updated_at カラムの追加

### DIFF
--- a/alembic/versions/m1n2o3p4_add_created_at_updated_at_to_record_models.py
+++ b/alembic/versions/m1n2o3p4_add_created_at_updated_at_to_record_models.py
@@ -1,0 +1,75 @@
+"""Add created_at and updated_at to record models
+
+Revision ID: m1n2o3p4
+Revises: l1m2n3o4
+Create Date: 2026-03-12 14:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'm1n2o3p4'
+down_revision = 'l1m2n3o4'
+branch_labels = None
+depends_on = None
+
+# 対象テーブル（両方のカラムを追加）
+TABLES_BOTH = [
+    'feedings',
+    'sleeps',
+    'diapers',
+    'growths',
+    'contractions',
+    'vaccinations',
+    'milestones',
+    'temperature_records',
+]
+
+# updated_at のみ追加（created_at は既存）
+TABLES_UPDATED_AT_ONLY = [
+    'schedules',
+]
+
+
+def upgrade() -> None:
+    for table in TABLES_BOTH:
+        op.add_column(
+            table,
+            sa.Column(
+                'created_at',
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+        op.add_column(
+            table,
+            sa.Column(
+                'updated_at',
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+    for table in TABLES_UPDATED_AT_ONLY:
+        op.add_column(
+            table,
+            sa.Column(
+                'updated_at',
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    for table in TABLES_UPDATED_AT_ONLY:
+        op.drop_column(table, 'updated_at')
+
+    for table in TABLES_BOTH:
+        op.drop_column(table, 'updated_at')
+        op.drop_column(table, 'created_at')

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,5 +1,7 @@
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, DateTime
+from sqlalchemy.sql import func
+from datetime import datetime
 
 class Base(DeclarativeBase):
     metadata = MetaData(naming_convention={
@@ -12,3 +14,11 @@ class Base(DeclarativeBase):
 
 class SoftDeleteMixin:
     is_deleted: Mapped[bool] = mapped_column(default=False, nullable=False)
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )

--- a/app/models/contraction.py
+++ b/app/models/contraction.py
@@ -1,8 +1,8 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Index
-from .base import Base, SoftDeleteMixin
+from .base import Base, SoftDeleteMixin, TimestampMixin
 
 
-class Contraction(Base, SoftDeleteMixin):
+class Contraction(Base, SoftDeleteMixin, TimestampMixin):
     __tablename__ = "contractions"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)

--- a/app/models/diaper.py
+++ b/app/models/diaper.py
@@ -1,9 +1,9 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Enum, Index
-from .base import Base, SoftDeleteMixin
+from .base import Base, SoftDeleteMixin, TimestampMixin
 from app.models.enums import DiaperType
 
 
-class Diaper(Base, SoftDeleteMixin):
+class Diaper(Base, SoftDeleteMixin, TimestampMixin):
     __tablename__ = "diapers"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)

--- a/app/models/feeding.py
+++ b/app/models/feeding.py
@@ -1,9 +1,9 @@
 from sqlalchemy import Boolean, Column, Integer, String, ForeignKey, DateTime, Float, Enum, Index
-from .base import Base, SoftDeleteMixin
+from .base import Base, SoftDeleteMixin, TimestampMixin
 from app.models.enums import FeedingType, BreastSide, BottleContentType, FeedingCompletion
 
 
-class Feeding(Base, SoftDeleteMixin):
+class Feeding(Base, SoftDeleteMixin, TimestampMixin):
     __tablename__ = "feedings"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)

--- a/app/models/growth.py
+++ b/app/models/growth.py
@@ -1,8 +1,8 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, Date, Float, Index
-from .base import Base, SoftDeleteMixin
+from .base import Base, SoftDeleteMixin, TimestampMixin
 
 
-class Growth(Base, SoftDeleteMixin):
+class Growth(Base, SoftDeleteMixin, TimestampMixin):
     __tablename__ = "growths"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)

--- a/app/models/milestone.py
+++ b/app/models/milestone.py
@@ -1,9 +1,9 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, Date, JSON, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableList
-from .base import Base, SoftDeleteMixin
+from .base import Base, SoftDeleteMixin, TimestampMixin
 
-class Milestone(Base, SoftDeleteMixin):
+class Milestone(Base, SoftDeleteMixin, TimestampMixin):
     __tablename__ = "milestones"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)

--- a/app/models/schedule.py
+++ b/app/models/schedule.py
@@ -12,6 +12,7 @@ class Schedule(Base, SoftDeleteMixin):
     scheduled_time = Column(DateTime(timezone=True), nullable=False, index=True)
     is_completed = Column(Boolean, nullable=False, default=False)
     created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
     baby_id = Column(Integer, ForeignKey("babies.id"), nullable=False)
 
     __table_args__ = (

--- a/app/models/sleep.py
+++ b/app/models/sleep.py
@@ -1,8 +1,8 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Index
-from .base import Base, SoftDeleteMixin
+from .base import Base, SoftDeleteMixin, TimestampMixin
 
 
-class Sleep(Base, SoftDeleteMixin):
+class Sleep(Base, SoftDeleteMixin, TimestampMixin):
     __tablename__ = "sleeps"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)

--- a/app/models/temperature.py
+++ b/app/models/temperature.py
@@ -1,9 +1,9 @@
 from sqlalchemy import Column, Integer, String, Float, ForeignKey, DateTime, Enum, Index
-from .base import Base, SoftDeleteMixin
+from .base import Base, SoftDeleteMixin, TimestampMixin
 from app.models.enums import TemperatureMethod
 
 
-class TemperatureRecord(Base, SoftDeleteMixin):
+class TemperatureRecord(Base, SoftDeleteMixin, TimestampMixin):
     __tablename__ = "temperature_records"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)

--- a/app/models/vaccination.py
+++ b/app/models/vaccination.py
@@ -1,8 +1,8 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, Date, Boolean, Enum as SQLEnum, Index
-from .base import Base, SoftDeleteMixin
+from .base import Base, SoftDeleteMixin, TimestampMixin
 from app.models.enums import VaccinationStatus
 
-class Vaccination(Base, SoftDeleteMixin):
+class Vaccination(Base, SoftDeleteMixin, TimestampMixin):
     __tablename__ = "vaccinations"
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)

--- a/tests/test_issue_868_timestamps.py
+++ b/tests/test_issue_868_timestamps.py
@@ -1,0 +1,126 @@
+"""
+Issue #868: 主要な記録モデルへの created_at / updated_at カラムの追加
+TDDテスト: 実装前は全てRedになることを確認する
+"""
+import pytest
+from datetime import datetime, timezone
+from sqlalchemy import inspect
+
+from app.models.feeding import Feeding
+from app.models.sleep import Sleep
+from app.models.diaper import Diaper
+from app.models.growth import Growth
+from app.models.contraction import Contraction
+from app.models.vaccination import Vaccination
+from app.models.milestone import Milestone
+from app.models.temperature import TemperatureRecord
+from app.models.schedule import Schedule
+from app.models.note import Note
+
+
+RECORD_MODELS = [
+    Feeding,
+    Sleep,
+    Diaper,
+    Growth,
+    Contraction,
+    Vaccination,
+    Milestone,
+    TemperatureRecord,
+    Schedule,
+    Note,
+]
+
+
+@pytest.mark.parametrize("model_cls", RECORD_MODELS)
+def test_model_has_created_at(model_cls):
+    """全記録モデルに created_at カラムが存在すること"""
+    mapper = inspect(model_cls)
+    column_names = [c.key for c in mapper.columns]
+    assert "created_at" in column_names, (
+        f"{model_cls.__name__} に created_at カラムがありません"
+    )
+
+
+@pytest.mark.parametrize("model_cls", RECORD_MODELS)
+def test_model_has_updated_at(model_cls):
+    """全記録モデルに updated_at カラムが存在すること"""
+    mapper = inspect(model_cls)
+    column_names = [c.key for c in mapper.columns]
+    assert "updated_at" in column_names, (
+        f"{model_cls.__name__} に updated_at カラムがありません"
+    )
+
+
+def test_feeding_created_at_set_on_insert(db):
+    """Feeding作成時に created_at が自動セットされること"""
+    from app.models.feeding import FeedingType
+    from app.models.baby import Baby
+    from app.models.family import Family, FamilyUser
+    from app.models.user import User
+    from app.models.enums import UserRole
+
+    import uuid
+    family = Family(name="Test", invite_code=str(uuid.uuid4()))
+    db.add(family)
+    db.flush()
+
+    user = User(username="u1", hashed_password="x")
+    db.add(user)
+    db.flush()
+
+    db.add(FamilyUser(family_id=family.id, user_id=user.id, role=UserRole.ADMIN))
+    db.flush()
+
+    baby = Baby(family_id=family.id, name="Baby", birthday=datetime.now(timezone.utc).date())
+    db.add(baby)
+    db.flush()
+
+    feeding = Feeding(
+        user_id=user.id,
+        baby_id=baby.id,
+        feeding_time=datetime.now(timezone.utc),
+        feeding_type=FeedingType.BOTTLE,
+    )
+    db.add(feeding)
+    db.commit()
+    db.refresh(feeding)
+
+    assert feeding.created_at is not None
+    assert feeding.updated_at is not None
+
+
+def test_sleep_created_at_set_on_insert(db):
+    """Sleep作成時に created_at が自動セットされること"""
+    import uuid
+    from app.models.baby import Baby
+    from app.models.family import Family, FamilyUser
+    from app.models.user import User
+    from app.models.enums import UserRole
+
+    family = Family(name="Test2", invite_code=str(uuid.uuid4()))
+    db.add(family)
+    db.flush()
+
+    user = User(username="u2", hashed_password="x")
+    db.add(user)
+    db.flush()
+
+    db.add(FamilyUser(family_id=family.id, user_id=user.id, role=UserRole.ADMIN))
+    db.flush()
+
+    baby = Baby(family_id=family.id, name="Baby2", birthday=datetime.now(timezone.utc).date())
+    db.add(baby)
+    db.flush()
+
+    sleep = Sleep(
+        user_id=user.id,
+        baby_id=baby.id,
+        start_time=datetime.now(timezone.utc),
+    )
+    db.add(sleep)
+    db.commit()
+    db.refresh(sleep)
+
+    assert sleep.created_at is not None
+    assert sleep.updated_at is not None


### PR DESCRIPTION
## 概要

Issue #868 の実装。記録系モデルに `created_at` / `updated_at` タイムスタンプカラムを追加する。

## 変更内容

- `app/models/base.py` に `TimestampMixin` を追加
- 以下モデルに `TimestampMixin` を適用:
  - `Feeding`, `Sleep`, `Diaper`, `Growth`, `Contraction`, `Vaccination`, `Milestone`, `TemperatureRecord`
- `Schedule` は既存の `created_at` を維持しつつ `updated_at` を追加
- `Note` は既に両カラムを持つため変更なし
- Alembicマイグレーション `m1n2o3p4` を追加（8テーブルに両カラム、`schedules` に `updated_at` のみ）
- `frontend/openapi.json` を更新

## テスト

- 全記録モデル（10モデル）の `created_at` / `updated_at` カラム存在チェック（22テスト）
- `Feeding` / `Sleep` の実際の挿入時自動セットテスト

Closes #868