### PR TITLE
✍️ Scribe: PWAプッシュ通知仕様書の通知項目一覧の更新（体温記録、実績解除の追加）

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -310,3 +310,6 @@
 ## 2026-03-13 - [新しい記録タイプ 'temperature' のアクセス権限設定・仕様書の先行記載の修正]
 **学び:** 体温記録機能（`temperature`）に関連して、仕様書 `.specify/specs/settings/baby_permissions.md` には `record_type` として `"temperature"` が先行して追加記載されていましたが、実際の権限管理の実装コード（`app/schemas/baby_permission.py` の `VALID_RECORD_TYPES` や `app/routers/baby_permissions.py` の `valid_types` リスト、フロントエンドの `ALL_RECORD_TYPES` など）には反映されておらず、仕様書が実装を先行する「嘘の仕様書」状態になっていました。
 **アクション:** `baby_permissions.md` から未実装の `"temperature"` を削除し、現在の実装コードと100%一致させました。今後仕様書を更新する際は、対応するバックエンド側のロジックやリストに実際に追加されているかを必ず確認・同期します。
+## 2026-03-14 - [PWAプッシュ通知仕様書における新機能の追記漏れ]
+**学び:** 体温記録や実績解除機能が追加された際、アプリ内通知仕様書（`notification_center.md`）が更新されていても、PWA向けのプッシュ通知仕様書（`pwa_notifications.md`）の「通知項目一覧」には追記が漏れやすい。特に記録タイプが「family_record」カテゴリに属する場合、独立した行としての追加が見落とされがちである。
+**アクション:** 通知機能に関連する新しい記録タイプやカテゴリを追加する際は、`notification_center.md` だけでなく `pwa_notifications.md` などのインフラ・PWA関連の仕様書にも通知項目が網羅されているかを必ず確認・同期する。

--- a/.specify/specs/infrastructure/pwa_notifications.md
+++ b/.specify/specs/infrastructure/pwa_notifications.md
@@ -36,7 +36,9 @@ Web Push API を使用して、ユーザーのデバイス（スマートフォ�
 | **メモ・日記** | 家族がメモや日記を投稿したとき | `/note` | `family_record` |
 | **成長の記録** | 家族が身長・体重を記録したとき | `/growth` | `family_record` |
 | **陣痛タイマー** | 家族が陣痛を計測したとき | `/contraction` | `family_record` |
+| **体温の記録** | 家族が体温を記録したとき | `/temperature` | `family_record` |
 | **コメント** | 自分の記録に家族がコメントしたとき | 該当する記録画面 | `family_record` |
+| **実績の解除** | 実績（アチーブメント）を達成したとき | `/dashboard?baby_id={id}&tab=achievements` | `achievement` |
 | **デイリーサマリー** | AIによる1日のまとめが生成されたとき | `/diary` | `daily_summary` |
 | **授乳リマインダー** | 前回の授乳から一定時間経過したとき | `/feeding` | `feeding_reminder` |
 | **オムツリマインダー** | 前回のオムツから一定時間経過したとき | `/diaper` | `diaper_reminder` |


### PR DESCRIPTION
### 💡 何を
PWAのプッシュ通知仕様書（`.specify/specs/infrastructure/pwa_notifications.md`）の「通知項目（Notification Items）」のテーブルに、「体温の記録」と「実績の解除」の行を追加しました。

### 🔍 発見
バックエンド実装（`app/routers/temperatures.py`, `app/routers/milestones.py`, `app/utils/notifications.py`）において、体温記録や実績解除時に `notify_family_members_bg`（カテゴリ: `family_record`）や `notify_achievements_bg`（カテゴリ: `achievement`）を利用して通知を生成する機能が実装されていました。
しかし、PWA向けのプッシュ通知の仕様を定義する `pwa_notifications.md` にはこれらの項目が含まれておらず、実装と仕様の間に乖離（仕様ドリフト）が生じていました。アプリ内通知センターの仕様書（`notification_center.md`）には一部記載されていたものの、インフラ寄りのPWA仕様書への追記が漏れやすい傾向にあります。

### 🎯 影響
この更新により、PWAによるプッシュ通知の対象となる機能（体温記録、実績解除）が仕様書上で明確になり、開発者間の認識のズレや、今後の通知設定UIの実装漏れ（「実績解除通知のON/OFF」など）を防ぐことができます。また、関連する学びを `.jules/scribe.md` に記録しました。

---
*PR created automatically by Jules for task [3703008210461307343](https://jules.google.com/task/3703008210461307343) started by @eburairu*