### PR TITLE
🧹 Tidy: ButtonとAlertDialogActionのloadingプロップを活用したローディング表示のリファクタリング

### DIFF
--- a/.jules/tidy.md
+++ b/.jules/tidy.md
@@ -30,3 +30,6 @@
 ## 2024-05-19 - useAsyncAction フックの活用とコードの共通化
 **学び:** `isSaving` や `error` といった非同期処理のローカルステート、および `try/catch/finally` によるエラーハンドリングが複数のコンポーネント（特に設定・フォーム画面）で重複して記述されている。これらは `useAsyncAction` フックによって共通化でき、コンポーネントの責務を削減できる。また、APIエラー時の詳細メッセージ取得も各所で `e.info.detail` を手動パースしていたが、`lib/api.ts` の `getErrorMessage` に切り出すことで DRY 原則を満たし、可読性が向上する。
 **アクション:** フォーム送信やAPI通信など、非同期アクションのローディング・エラー状態を管理する際は、常に `useAsyncAction` を利用する。また、UIコンポーネント固有の API エラーメッセージ取得は必ず `getErrorMessage` ユーティリティを用いるようにする。
+## 2024-03-14 - ButtonおよびAlertDialogActionへのloadingプロップの適用漏れと冗長なスピナー表示
+**学び:** `components/ui/button.tsx` や `components/ui/alert-dialog.tsx` には既に非同期処理中であることを示す `loading` プロップが実装されていますが、`disabled={isSubmitting}` を渡しつつ自前で `<Loader2 />` をレンダリングしている箇所（Fat Component化の一因）、または単に `disabled` のみを渡していてローディングインジケーターが表示されない箇所（UXの低下）が散見されました。
+**アクション:** フォームやダイアログのサブミットボタンでは、手動でスピナーを記述するのではなく、常に共有の `loading` プロップを利用することで、DRY原則を保ちつつ一貫したUXを提供するよう今後も共通化を推進します。

--- a/frontend/app/(dashboard)/settings/profile/page.tsx
+++ b/frontend/app/(dashboard)/settings/profile/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { User, Loader2, Lock } from "lucide-react"
+import { User, Lock } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -142,9 +142,8 @@ export default function ProfileSettingsPage() {
                                         <Button
                                             className="flex-1 bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white"
                                             onClick={handleSave}
-                                            disabled={isSaving}
+                                            loading={isSaving}
                                         >
-                                            {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                                             保存
                                         </Button>
                                         <Button
@@ -218,9 +217,8 @@ export default function ProfileSettingsPage() {
                                     <Button
                                         className="flex-1 bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white"
                                         onClick={handlePasswordSave}
-                                        disabled={isSavingPassword}
+                                        loading={isSavingPassword}
                                     >
-                                        {isSavingPassword && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                                         変更する
                                     </Button>
                                     <Button

--- a/frontend/components/settings/BabyDeleteDialog.tsx
+++ b/frontend/components/settings/BabyDeleteDialog.tsx
@@ -83,7 +83,8 @@ export function BabyDeleteDialog({ baby, open, onClose, onDeleted }: Props) {
                     </Button>
                     <Button
                         onClick={handleDelete}
-                        disabled={!canDelete || deleting}
+                        loading={deleting}
+                        disabled={!canDelete}
                         className="bg-red-500 hover:bg-red-600 text-white"
                     >
                         削除

--- a/frontend/components/settings/MemberPasswordResetDialog.tsx
+++ b/frontend/components/settings/MemberPasswordResetDialog.tsx
@@ -123,7 +123,7 @@ export function MemberPasswordResetDialog({ member, open, onClose }: Props) {
                     <AlertDialogCancel onClick={handleClose}>キャンセル</AlertDialogCancel>
                     <AlertDialogAction
                         onClick={handleReset}
-                        disabled={resetting}
+                        loading={resetting}
                         className="bg-indigo-600 hover:bg-indigo-700"
                     >
                         再発行する

--- a/frontend/components/settings/MemberRoleDialog.tsx
+++ b/frontend/components/settings/MemberRoleDialog.tsx
@@ -79,7 +79,8 @@ export function MemberRoleDialog({ member, open, onClose, onUpdated }: Props) {
                     <Button variant="outline" onClick={onClose} disabled={saving}>キャンセル</Button>
                     <Button
                         onClick={handleSave}
-                        disabled={saving || selectedRole === member?.role}
+                        loading={saving}
+                        disabled={selectedRole === member?.role}
                         className="bg-indigo-600 hover:bg-indigo-700 text-white"
                     >
                         変更する


### PR DESCRIPTION
## 💡 何を
設定画面や各種ダイアログの保存・削除・再発行ボタンにおいて、以下のようなコードの重複や不完全なローディング表示が存在していました。
1. `disabled={isSaving}` を指定しつつ、自前で `<Loader2 className="animate-spin" />` を子要素としてレンダリングしている（冗長なFat Componentの一因）。
2. 非同期処理中（`saving` や `deleting`）に `disabled` のみを指定し、ローディングスピナーが表示されないため、ユーザーに処理中であることが伝わりにくい（UXの低下）。

これらを解決するため、対象の `<Button>` および `<AlertDialogAction>` コンポーネントにおいて、組み込みの `loading` プロップを使用するようにリファクタリングしました。

## 🎯 なぜ
- **DRY原則（重複の排除）**: ローディングスピナーの表示ロジックは、すでに `Button` や `AlertDialogAction` コンポーネント内にカプセル化されています。これを活用することで、呼び出し側のコード（ボイラープレート）を大幅に削減できます。
- **可読性の向上**: 不要なインポート（`Loader2` など）や条件分岐のレンダリングを削除でき、コンポーネントがより宣言的で読みやすくなります。
- **UXの統一**: 非同期処理中のボタンの振る舞い（スピナーの表示と無効化）をシステム全体で一貫させることができます。

## 🛡️ 安全性
- 機能の変更はありません。UIの見た目やユーザーの操作体験（振る舞い）は変更前と同等、あるいは改善（スピナーが追加される）されています。
- 各ボタンの独自の `disabled` 条件（例: `disabled={!canDelete}` や `disabled={selectedRole === member?.role}`）は意図的に残しており、ビジネスロジックによるバリデーションや保護は引き続き機能します。
- `pnpm lint`、`pnpm test --run`、および `pnpm build` がすべて正常に通過することを確認済みです。

---
*PR created automatically by Jules for task [7167461124122418316](https://jules.google.com/task/7167461124122418316) started by @eburairu*