### PR TITLE
fix: #959 ログアウト時のPushSubscriptionクリーンアップ漏れを修正

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,19 +1,21 @@
 import secrets
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 from app.utils.session import hash_token
 
-from fastapi import APIRouter, Depends, HTTPException, status, Response, Request, BackgroundTasks
+from fastapi import APIRouter, Body, Depends, HTTPException, status, Response, Request, BackgroundTasks
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.database import SessionLocal
 from app.dependencies import get_db, get_current_user
-from app.schemas.auth import LoginRequest
+from app.schemas.auth import LoginRequest, LogoutRequest
 from app.schemas.family import FamilyCreate, FamilyResponse
 from app.schemas.user import UserCreate, UserResponse, UserProfileUpdate, PasswordChangeRequest
 from app.models.user import User, UserSession
 from app.models.family import Family, FamilyUser
+from app.models.notification import PushSubscription
 from app.models.enums import UserRole
 from app.services.auth import verify_password, get_password_hash, verify_password_async, get_password_hash_async
 from app.config import SESSION_EXPIRE_DAYS, COOKIE_SECURE
@@ -298,16 +300,24 @@ async def login(
 
 
 @router.post("/logout")
-def logout(request: Request, response: Response, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
+def logout(request: Request, response: Response, background_tasks: BackgroundTasks, db: Session = Depends(get_db), logout_req: Optional[LogoutRequest] = Body(default=None)):
     token = request.cookies.get("access_token")
     if token:
         session = db.query(UserSession).filter(UserSession.token == hash_token(token)).first()
         if session:
+            if logout_req and logout_req.endpoint:
+                sub = db.query(PushSubscription).filter(
+                    PushSubscription.endpoint == logout_req.endpoint,
+                    PushSubscription.user_id == session.user_id,
+                    PushSubscription.is_deleted == False,  # noqa: E712
+                ).first()
+                if sub:
+                    sub.is_deleted = True
             # Note: log_event in background task decoupled from main transaction
             background_tasks.add_task(
                 log_event,
-                action="LOGOUT", 
-                user_id=session.user_id, 
+                action="LOGOUT",
+                user_id=session.user_id,
                 ip_address=get_client_ip(request)
             )
             db.delete(session)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,6 +1,11 @@
+from typing import Optional
 from pydantic import BaseModel, Field
 
 
 class LoginRequest(BaseModel):
     username: str = Field(..., max_length=50)
     password: str = Field(..., max_length=128)
+
+
+class LogoutRequest(BaseModel):
+    endpoint: Optional[str] = None

--- a/frontend/app/(dashboard)/settings/page.tsx
+++ b/frontend/app/(dashboard)/settings/page.tsx
@@ -79,7 +79,18 @@ export default function SettingsPage() {
 
     const handleLogout = async () => {
         try {
-            await api.post("/auth/logout", {})
+            let endpoint: string | undefined
+            if ("serviceWorker" in navigator) {
+                const registration = await navigator.serviceWorker.ready.catch(() => null)
+                if (registration) {
+                    const subscription = await registration.pushManager.getSubscription().catch(() => null)
+                    if (subscription) {
+                        endpoint = subscription.endpoint
+                        await subscription.unsubscribe().catch(() => null)
+                    }
+                }
+            }
+            await api.post("/auth/logout", { endpoint: endpoint ?? null })
             await mutate() // clear user state
             router.push("/login")
         } catch (e) {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2437,6 +2437,23 @@
         "title": "LoginRequest",
         "type": "object"
       },
+      "LogoutRequest": {
+        "properties": {
+          "endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endpoint"
+          }
+        },
+        "title": "LogoutRequest",
+        "type": "object"
+      },
       "MemberRoleUpdate": {
         "properties": {
           "role": {
@@ -4842,6 +4859,23 @@
     "/api/auth/logout": {
       "post": {
         "operationId": "logout_api_auth_logout_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/LogoutRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Logout Req"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "content": {
@@ -4850,6 +4884,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Logout",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -68,6 +68,52 @@ def test_logout(auth_client):
     assert response.status_code == 200
     assert "access_token" not in client.cookies
 
+def test_logout_with_endpoint_deletes_push_subscription(client, db):
+    """ログアウト時に endpoint を渡すと対応する PushSubscription が論理削除される"""
+    from app.models.notification import PushSubscription
+
+    # ユーザー登録
+    res = client.post(
+        "/api/auth/register/family",
+        json={"name": "Push Family", "username": "pushuser", "password": "password123"},
+    )
+    assert res.status_code == 200
+
+    # PushSubscription を登録
+    endpoint = "https://push.example.com/test-endpoint"
+    sub_res = client.post(
+        "/api/notifications/subscribe",
+        json={
+            "endpoint": endpoint,
+            "p256dh": "dummyp256dh",
+            "auth": "dummyauth",
+        },
+    )
+    assert sub_res.status_code == 200
+
+    # ログアウト時に endpoint を渡す
+    logout_res = client.post("/api/auth/logout", json={"endpoint": endpoint})
+    assert logout_res.status_code == 200
+
+    # PushSubscription が論理削除されていること
+    sub = db.query(PushSubscription).filter(PushSubscription.endpoint == endpoint).first()
+    assert sub is not None
+    assert sub.is_deleted is True
+
+
+def test_logout_without_endpoint_works_as_before(client):
+    """endpoint なしのログアウトは従来通り動作する"""
+    client.post(
+        "/api/auth/register/family",
+        json={"name": "Nopush Family", "username": "nopushuser", "password": "password123"},
+    )
+    assert "access_token" in client.cookies
+
+    response = client.post("/api/auth/logout", json={})
+    assert response.status_code == 200
+    assert "access_token" not in client.cookies
+
+
 def test_join_family(client):
     # 家族作成
     res = client.post(


### PR DESCRIPTION
## 変更内容

- ログアウト API に任意の `endpoint` フィールドを受け取る `LogoutRequest` スキーマを追加
- ログアウト時に `endpoint` が渡された場合、対応する `PushSubscription` を論理削除する
- フロントエンドのログアウト処理で `serviceWorker.pushManager.getSubscription()` を呼び出し、endpoint をリクエストに含めてブラウザ側の購読も解除する

## 問題

共用端末などでログアウトした後も、同じブラウザに対して以前のユーザー宛のプッシュ通知が届き続けるリスクがあった。

## テスト

- `test_logout_with_endpoint_deletes_push_subscription`: endpoint を渡すとPushSubscriptionが論理削除される
- `test_logout_without_endpoint_works_as_before`: endpoint なしの従来通りのログアウトが動作する

Closes #959