### PR TITLE
✍️ Scribe: baby_permissions.md から未実装の temperature 権限を削除

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -298,3 +298,7 @@
 ## 2024-03-12 - [BabyPermissions Spec Drift]
 **学び:** 新しい記録タイプ（今回は体温）が追加された際に、BabyPermissionsの仕様書（.specify/specs/settings/baby_permissions.md）内の ValidRecordType や有効値一覧表への追加が漏れやすいパターンの発見。
 **アクション:** 仕様書側のテーブル定義や型定義にも新しい記録タイプを追加し、バックエンドのバリデーション定義との同期を保つ。
+
+## 2024-05-15 - baby_permissions.md の「存在しない仕様 (ghost feature)」を削除
+**学び:** `temperature` (体温) はフロント/バックエンドには記録機能として実装されているが、権限管理の `BabyPermission` の `VALID_RECORD_TYPES` や `usePermissionsPage.ts` の `ALL_RECORD_TYPES` 等のバリデーションには追加されていない。にもかかわらず、`.specify/specs/settings/baby_permissions.md` には `temperature` が「有効値」として記載されている「ghost feature」の仕様ドリフトが発生していた。
+**アクション:** 実装に先行してドキュメントにのみ記載されている「ghost feature」は実際の実装と乖離するため、現在のコードに合わせてドキュメントから削除した。

--- a/.specify/specs/settings/baby_permissions.md
+++ b/.specify/specs/settings/baby_permissions.md
@@ -51,8 +51,7 @@ Baby（赤ちゃん全体の可視性）
        ├── schedule（スケジュール）
        ├── vaccination（予防接種）
        ├── note（汎用メモ）
-       ├── milestone（マイルストーン）
-       └── temperature（体温）
+       └── milestone（マイルストーン）
 ```
 
 ### `record_type` の有効値一覧
@@ -69,7 +68,6 @@ Baby（赤ちゃん全体の可視性）
 | `"vaccination"` | 予防接種記録 | `vaccinations` |
 | `"note"` | 汎用メモ | `notes` |
 | `"milestone"` | 発育発達マイルストーン記録 | `milestones` |
-| `"temperature"` | 体温記録 | `temperature_records` |
 
 ### 権限判定ロジック
 
@@ -238,8 +236,7 @@ for record_type in VALID_RECORD_TYPES:
         { "record_type": "schedule",    "can_view": true  },
         { "record_type": "vaccination", "can_view": true  },
         { "record_type": "note",        "can_view": true  },
-        { "record_type": "milestone",   "can_view": true  },
-        { "record_type": "temperature", "can_view": true  }
+        { "record_type": "milestone",   "can_view": true  }
       ]
     }
   ]
@@ -255,7 +252,7 @@ for record_type in VALID_RECORD_TYPES:
 ### リクエスト/レスポンススキーマ
 
 ```typescript
-type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone" | "temperature";
+type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone";
 
 // 単一の権限レコード（1ユーザー × 1record_type）
 interface BabyPermissionItem {


### PR DESCRIPTION
💡 何を: 
`.specify/specs/settings/baby_permissions.md` から、権限モデルとして実際には実装されていない `temperature` の記述（有効値一覧、型定義、レスポンス例など）を削除しました。

🔍 発見: 
`temperature` (体温) はフロント/バックエンドに記録機能として実装されていますが、権限管理の `BabyPermission` の `VALID_RECORD_TYPES` や `usePermissionsPage.ts` の `ALL_RECORD_TYPES` 等のバリデーションには追加されていませんでした。にもかかわらず、仕様書には将来の対応を見越したかのように「有効値」として記載されている「存在しない仕様 (ghost feature)」のドリフトが発生していました。

🎯 影響: 
実装に先行してドキュメントにのみ記載されている「ghost feature」を削除することで、開発者が仕様書を読んで「体温の権限制御もすでに実装済みである」と誤解することを防ぎます。古い・間違った仕様書が開発者を迷わせるリスクを排除しました。

---
*PR created automatically by Jules for task [7967354780600473972](https://jules.google.com/task/7967354780600473972) started by @eburairu*