### PR TITLE
🧹 Tidy: 陣痛タイマーの非同期処理を useAsyncAction にリファクタリング

### DIFF
--- a/.jules/tidy.md
+++ b/.jules/tidy.md
@@ -37,3 +37,5 @@
 ## 2024-03-14 - ButtonおよびAlertDialogActionへのloadingプロップの適用漏れと冗長なスピナー表示
 **学び:** `components/ui/button.tsx` や `components/ui/alert-dialog.tsx` には既に非同期処理中であることを示す `loading` プロップが実装されていますが、`disabled={isSubmitting}` を渡しつつ自前で `<Loader2 />` をレンダリングしている箇所（Fat Component化の一因）、または単に `disabled` のみを渡していてローディングインジケーターが表示されない箇所（UXの低下）が散見されました。
 **アクション:** フォームやダイアログのサブミットボタンでは、手動でスピナーを記述するのではなく、常に共有の `loading` プロップを利用することで、DRY原則を保ちつつ一貫したUXを提供するよう今後も共通化を推進します。
+
+2025-03-15 - [Tidy: 陣痛タイマーの非同期処理を useAsyncAction にリファクタリング] 学び: `ContractionTimer.tsx` 内の非同期処理の状態管理(`isSubmitting`, `setIsSubmitting`)と手動の `try-catch-finally` ブロック、およびトースト通知ロジックを共通の `useAsyncAction` フックに抽出することで、コンポーネントの責務が明確になり可読性が向上した。 アクション: 今後もローカルで独自に `try-catch-finally` と `isSubmitting` のような状態を管理しているフォームやタイマーコンポーネントを見つけたら、同様に `useAsyncAction` フックを活用して共通化・DRY化を推進する。

--- a/frontend/components/contraction/ContractionTimer.tsx
+++ b/frontend/components/contraction/ContractionTimer.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useCallback, useState } from "react"
+import { useCallback } from "react"
+import { useAsyncAction } from "@/hooks/useAsyncAction"
 import { useContractionTimer } from "@/stores/contractionStore"
 import { api } from "@/lib/api"
 import { Button } from "@/components/ui/button"
@@ -20,7 +21,7 @@ interface ContractionTimerProps {
 export default function ContractionTimer({ babyId, onRecorded }: ContractionTimerProps) {
     const { status, elapsedSeconds, start, stop, tick, sync } = useContractionTimer()
     const { mutate } = useContractionTimerSync(babyId)
-    const [isSubmitting, setIsSubmitting] = useState(false)
+    const { loading: isSubmitting, execute } = useAsyncAction()
 
     const isTiming = status === "timing"
 
@@ -46,35 +47,38 @@ export default function ContractionTimer({ babyId, onRecorded }: ContractionTime
         } else {
             const result = stop()
             if (result) {
-                setIsSubmitting(true)
-                try {
-                    // PUT (状態更新) と POST (記録作成) を並行して実行
-                    await Promise.all([
-                        api.put(`/babies/${babyId}/timer/contraction`, {
-                            status: "idle",
-                            start_time: null
-                        }),
-                        api.post("/contractions/", {
-                            baby_id: babyId,
-                            start_time: result.startTime.toISOString(),
-                            end_time: result.endTime.toISOString(),
-                            duration_seconds: result.durationSeconds,
-                        })
-                    ])
-                    toast.success("記録しました")
-                    onRecorded()
-                    mutate()
-                } catch (err) {
-                    console.error("Failed to save contraction", err)
-                    toast.error("保存に失敗しました")
-                    // サーバーの状態と同期し直す
-                    mutate()
-                } finally {
-                    setIsSubmitting(false)
-                }
+                await execute(
+                    async () => {
+                        // PUT (状態更新) と POST (記録作成) を並行して実行
+                        await Promise.all([
+                            api.put(`/babies/${babyId}/timer/contraction`, {
+                                status: "idle",
+                                start_time: null
+                            }),
+                            api.post("/contractions/", {
+                                baby_id: babyId,
+                                start_time: result.startTime.toISOString(),
+                                end_time: result.endTime.toISOString(),
+                                duration_seconds: result.durationSeconds,
+                            })
+                        ])
+                    },
+                    {
+                        successMessage: "記録しました",
+                        errorMessage: "保存に失敗しました",
+                        onSuccess: () => {
+                            onRecorded()
+                            mutate()
+                        },
+                        onError: () => {
+                            // サーバーの状態と同期し直す
+                            mutate()
+                        }
+                    }
+                )
             }
         }
-    }, [status, babyId, start, stop, sync, onRecorded, mutate])
+    }, [status, babyId, start, stop, sync, onRecorded, mutate, execute])
 
     return (
         <Card className={`transition-all duration-300 ${isTiming ? "border-red-400 bg-red-50 dark:bg-red-950/30 shadow-lg shadow-red-100 dark:shadow-red-900/20" : ""}`}>


### PR DESCRIPTION
## 💡 何を
`frontend/components/contraction/ContractionTimer.tsx` 内で手動で管理されていたローディング状態（`isSubmitting`）と非同期処理（`try-catch-finally`ブロックおよびトースト通知）を、プロジェクト共通の `useAsyncAction` フックを使用するようにリファクタリングしました。

## 🎯 なぜ
*   **DRY原則の適用:** APIリクエスト時のローディング状態の管理やエラーハンドリングはアプリケーション全体で共通の処理です。これを各コンポーネントで独自実装するのではなく、共通フック（`useAsyncAction`）を利用することでコードの重複を排除します。
*   **可読性の向上:** `try-catch-finally` ブロックが削減され、状態の宣言と更新がシンプルになるため、コンポーネントが本来のUIロジックに集中できるようになります。

## 🛡️ 安全性
*   `pnpm lint` を実行し、構文エラーがないことを確認しました。
*   `pnpm test --run` を実行し、すべてのテストがパスすることを確認しました。
*   `pnpm build` を実行し、プロダクションビルドが正常に完了することを確認しました。
*   機能的な変更は一切行わず、状態管理と非同期処理の呼び出し方のみを変更しています。並列実行されるAPIリクエスト（PUTとPOST）のロジックはそのまま維持されています。

---
*PR created automatically by Jules for task [15610481736926385178](https://jules.google.com/task/15610481736926385178) started by @eburairu*