### PR TITLE
⚡ Bolt: GzipMiddleware追加によるAPIレスポンスの圧縮

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2026-03-09 - [Fetch, Sort, Truncate, THEN Enrich pattern]
 **Learning:** When aggregating lists from multiple tables in memory (like a timeline), fetching auxiliary data (like comment counts and related users) for *all* retrieved items before truncating the list to the pagination `limit` causes explosive DB load. If each table returns up to 1000 items, you might query auxiliary data for 7000 items, only to discard 6950 of them after sorting.
 **Action:** Always follow the "Fetch -> Sort -> Truncate -> THEN Enrich" pattern. Sort the unified in-memory list and apply the `limit` slice *before* executing the `IN()` queries for related entities like comments and user mappings.
+
+## 2024-03-24 - Gzip Middlewareの導入によるペイロード圧縮
+**学び:** FastAPI はデフォルトでレスポンス圧縮を提供していないため、タイムライン（`/api/babies/{id}/records`）のような大量のJSONデータを返すエンドポイントで巨大なペイロードが発生し、転送遅延の原因になっていた。
+**アクション:** 今後、FastAPI プロジェクトの初期段階で `GZipMiddleware`（適切な `minimum_size` 設定付き）が組み込まれているかをチェックリストに加える。

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi.responses import JSONResponse
 from app.middleware.security import SecurityHeadersMiddleware
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 import os
@@ -49,6 +50,9 @@ app.add_middleware(
 )
 
 app.add_middleware(SecurityHeadersMiddleware)
+
+# ⚡ Bolt: レスポンスサイズが1000バイトを超える場合にGzip圧縮を行い、ネットワーク転送時間を大幅に短縮する
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 # Trusted Host Middleware (Security Enhancement)
 allowed_hosts = os.getenv("ALLOWED_HOSTS", "*").split(",")


### PR DESCRIPTION
💡 何を:
FastAPI の初期化設定 (`app/main.py`) に `GZipMiddleware` を導入しました。レスポンスサイズが1000バイトを超える場合にGzip圧縮を行うように設定しています。

🎯 なぜ:
FastAPI はデフォルトではレスポンスの圧縮を行いません。`/api/babies/{id}/records` のようなタイムラインエンドポイントでは、日々の記録データが蓄積するにつれて巨大なJSONペイロードが返されるようになり、ネットワーク帯域の消費および転送遅延のボトルネックになっていました。圧縮を導入することで、特にモバイル環境等の低速ネットワークでのロード時間を大幅に改善できます。

📊 影響:
1000バイト以上のJSONレスポンスペイロードが圧縮され、ネットワーク転送量が大幅に（典型的にはJSONデータの場合 50%〜80% 程度）削減されます。

🔬 測定:
ブラウザの開発者ツール（Networkタブ）を開き、APIリクエスト（例: `/api/babies/{id}/records`）のレスポンスヘッダに `Content-Encoding: gzip` が含まれていること、および転送サイズ（Transferred Size）がリソースサイズ（Resource Size）よりも大幅に小さくなっていることを確認できます。

---
*PR created automatically by Jules for task [9300484734871863285](https://jules.google.com/task/9300484734871863285) started by @eburairu*