### PR TITLE
feat: #927 AIフィードバックのルーター/サービス層責務分離とソフトデリートバグ修正

### DIFF
--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -1,3 +1,23 @@
 class AIGenerationError(Exception):
     """Exception raised when an AI service fails to generate content or is disabled."""
     pass
+
+
+class AIRateLimitError(AIGenerationError):
+    """Exception raised when an AI service rate limit is exceeded."""
+    pass
+
+
+class AIServiceError(AIGenerationError):
+    """Exception raised when an AI service encounters an internal error or is unavailable."""
+    pass
+
+
+class RecordNotFoundError(Exception):
+    """Exception raised when a record is not found."""
+    pass
+
+
+class InvalidRecordTypeError(Exception):
+    """Exception raised when a record type is invalid."""
+    pass

--- a/app/routers/ai_feedback.py
+++ b/app/routers/ai_feedback.py
@@ -1,17 +1,16 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from datetime import datetime
-import openai
 
 from app.dependencies import get_db, get_current_user, verify_baby_access
 from app.models.user import User
-from app.core.exceptions import AIGenerationError
+from app.core.exceptions import AIGenerationError, AIRateLimitError, AIServiceError, InvalidRecordTypeError, RecordNotFoundError
 from app.schemas.ai_feedback import RecordFeedbackRequest, RecordFeedbackResponse
 from app.services.ai_feedback import (
-    _verify_record_ownership,
     generate_record_feedback,
     save_ai_comment,
 )
+from app.services.record import verify_record_ownership
 from app.utils.rate_limit import RateLimiter
 from app.utils.timezone import get_jst_now
 from app.core import constants
@@ -39,26 +38,31 @@ async def create_record_feedback(
     baby = verify_baby_access(db, baby_id, current_user.id, require_write=False)
 
     # record_id が baby_id に属するか確認
-    _verify_record_ownership(db, body.record_type, body.record_id, baby_id)
+    try:
+        verify_record_ownership(db, body.record_type, body.record_id, baby_id)
+    except InvalidRecordTypeError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except RecordNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
     try:
         feedback_text, has_concern, model_name = await generate_record_feedback(
             db, baby_id, baby, body.record_type, body.record_id
         )
-    except AIGenerationError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
-        )
-    except openai.RateLimitError:
+    except AIRateLimitError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="AIサービスの利用上限に達しました。しばらく時間をおいてから再試行してください。",
         )
-    except openai.OpenAIError:
+    except AIServiceError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="AIサービスでエラーが発生しました。時間をおいて再試行してください。",
+        )
+    except AIGenerationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
         )
 
     comment = save_ai_comment(

--- a/app/routers/contraction.py
+++ b/app/routers/contraction.py
@@ -28,13 +28,14 @@ def _build_contraction_response(record: Contraction, user_map: dict, comment_cou
 @router.get("/", response_model=List[ContractionResponse])
 def get_contractions(baby_id: int, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
     verify_baby_access(db, baby_id, current_user.id, record_type="contraction")
-    records = db.query(Contraction).filter(Contraction.baby_id == baby_id).order_by(Contraction.start_time.desc()).all()
+    records = db.query(Contraction).filter(Contraction.baby_id == baby_id, Contraction.is_deleted == False).order_by(Contraction.start_time.desc()).all()
     record_ids = [r.id for r in records]
     comment_count_map: dict = {}
     if record_ids:
         rows = db.query(RecordComment.record_id, func.count(RecordComment.id).label("cnt")).filter(
             RecordComment.record_type == "contraction",
-            RecordComment.record_id.in_(record_ids)
+            RecordComment.record_id.in_(record_ids),
+            RecordComment.is_deleted == False
         ).group_by(RecordComment.record_id).all()
         comment_count_map = {row.record_id: row.cnt for row in rows}
     user_ids = {r.user_id for r in records if r.user_id is not None}

--- a/app/routers/diaper.py
+++ b/app/routers/diaper.py
@@ -33,13 +33,14 @@ def get_diapers(
     current_user: User = Depends(get_current_user)
 ):
     verify_baby_access(db, baby_id, current_user.id, record_type="diaper")
-    records = db.query(Diaper).filter(Diaper.baby_id == baby_id).order_by(Diaper.change_time.desc()).offset(skip).limit(limit).all()
+    records = db.query(Diaper).filter(Diaper.baby_id == baby_id, Diaper.is_deleted == False).order_by(Diaper.change_time.desc()).offset(skip).limit(limit).all()
     record_ids = [r.id for r in records]
     comment_count_map: dict = {}
     if record_ids:
         rows = db.query(RecordComment.record_id, func.count(RecordComment.id).label("cnt")).filter(
             RecordComment.record_type == "diaper",
-            RecordComment.record_id.in_(record_ids)
+            RecordComment.record_id.in_(record_ids),
+            RecordComment.is_deleted == False
         ).group_by(RecordComment.record_id).all()
         comment_count_map = {row.record_id: row.cnt for row in rows}
     user_ids = {r.user_id for r in records if r.user_id is not None}

--- a/app/routers/feeding.py
+++ b/app/routers/feeding.py
@@ -28,13 +28,14 @@ def _build_feeding_response(record: Feeding, user_map: dict, comment_count_map: 
 @router.get("/", response_model=List[FeedingResponse])
 def get_feedings(baby_id: int, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
     verify_baby_access(db, baby_id, current_user.id, record_type="feeding")
-    records = db.query(Feeding).filter(Feeding.baby_id == baby_id).order_by(Feeding.feeding_time.desc()).all()
+    records = db.query(Feeding).filter(Feeding.baby_id == baby_id, Feeding.is_deleted == False).order_by(Feeding.feeding_time.desc()).all()
     record_ids = [r.id for r in records]
     comment_count_map: dict = {}
     if record_ids:
         rows = db.query(RecordComment.record_id, func.count(RecordComment.id).label("cnt")).filter(
             RecordComment.record_type == "feeding",
-            RecordComment.record_id.in_(record_ids)
+            RecordComment.record_id.in_(record_ids),
+            RecordComment.is_deleted == False
         ).group_by(RecordComment.record_id).all()
         comment_count_map = {row.record_id: row.cnt for row in rows}
     user_ids = {r.user_id for r in records if r.user_id is not None}

--- a/app/routers/growth.py
+++ b/app/routers/growth.py
@@ -26,13 +26,14 @@ def _build_growth_response(record: Growth, user_map: dict, comment_count_map: di
 @router.get("/", response_model=List[GrowthResponse])
 def get_growths(baby_id: int, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
     verify_baby_access(db, baby_id, current_user.id, record_type="growth")
-    records = db.query(Growth).filter(Growth.baby_id == baby_id).order_by(Growth.date.desc()).all()
+    records = db.query(Growth).filter(Growth.baby_id == baby_id, Growth.is_deleted == False).order_by(Growth.date.desc()).all()
     record_ids = [r.id for r in records]
     comment_count_map: dict = {}
     if record_ids:
         rows = db.query(RecordComment.record_id, func.count(RecordComment.id).label("cnt")).filter(
             RecordComment.record_type == "growth",
-            RecordComment.record_id.in_(record_ids)
+            RecordComment.record_id.in_(record_ids),
+            RecordComment.is_deleted == False
         ).group_by(RecordComment.record_id).all()
         comment_count_map = {row.record_id: row.cnt for row in rows}
     user_ids = {r.user_id for r in records if r.user_id is not None}

--- a/app/routers/note.py
+++ b/app/routers/note.py
@@ -28,13 +28,14 @@ def get_notes(
 ):
     """メモ一覧取得（履歴）"""
     verify_baby_access(db, baby_id, current_user.id, record_type="note")
-    records = db.query(Note).filter(Note.baby_id == baby_id).order_by(Note.note_time.desc()).all()
+    records = db.query(Note).filter(Note.baby_id == baby_id, Note.is_deleted == False).order_by(Note.note_time.desc()).all()
     record_ids = [r.id for r in records]
     comment_count_map: dict = {}
     if record_ids:
         rows = db.query(RecordComment.record_id, func.count(RecordComment.id).label("cnt")).filter(
             RecordComment.record_type == "note",
-            RecordComment.record_id.in_(record_ids)
+            RecordComment.record_id.in_(record_ids),
+            RecordComment.is_deleted == False
         ).group_by(RecordComment.record_id).all()
         comment_count_map = {row.record_id: row.cnt for row in rows}
     user_ids = {r.user_id for r in records if r.user_id is not None}

--- a/app/routers/sleep.py
+++ b/app/routers/sleep.py
@@ -26,13 +26,14 @@ def _build_sleep_response(record: Sleep, user_map: dict, comment_count_map: dict
 @router.get("/", response_model=List[SleepResponse])
 def get_sleeps(baby_id: int, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
     verify_baby_access(db, baby_id, current_user.id, record_type="sleep")
-    records = db.query(Sleep).filter(Sleep.baby_id == baby_id).order_by(Sleep.start_time.desc()).all()
+    records = db.query(Sleep).filter(Sleep.baby_id == baby_id, Sleep.is_deleted == False).order_by(Sleep.start_time.desc()).all()
     record_ids = [r.id for r in records]
     comment_count_map: dict = {}
     if record_ids:
         rows = db.query(RecordComment.record_id, func.count(RecordComment.id).label("cnt")).filter(
             RecordComment.record_type == "sleep",
-            RecordComment.record_id.in_(record_ids)
+            RecordComment.record_id.in_(record_ids),
+            RecordComment.is_deleted == False
         ).group_by(RecordComment.record_id).all()
         comment_count_map = {row.record_id: row.cnt for row in rows}
     user_ids = {r.user_id for r in records if r.user_id is not None}

--- a/app/routers/temperatures.py
+++ b/app/routers/temperatures.py
@@ -37,7 +37,7 @@ def get_temperatures(
     verify_baby_access(db, baby_id, current_user.id, record_type="temperature")
     records = (
         db.query(TemperatureRecord)
-        .filter(TemperatureRecord.baby_id == baby_id)
+        .filter(TemperatureRecord.baby_id == baby_id, TemperatureRecord.is_deleted == False)
         .order_by(TemperatureRecord.measured_at.desc())
         .offset(skip)
         .limit(limit)
@@ -51,6 +51,7 @@ def get_temperatures(
             .filter(
                 RecordComment.record_type == "temperature",
                 RecordComment.record_id.in_(record_ids),
+                RecordComment.is_deleted == False,
             )
             .group_by(RecordComment.record_id)
             .all()

--- a/app/services/ai_feedback.py
+++ b/app/services/ai_feedback.py
@@ -5,11 +5,10 @@ import time
 from datetime import datetime, timedelta
 from typing import Tuple
 from app.core.constants import AI_MAX_TOKENS
-from app.core.exceptions import AIGenerationError
+from app.core.exceptions import AIGenerationError, AIRateLimitError, AIServiceError
 
 import openai
 from sqlalchemy.orm import Session
-from fastapi import HTTPException, status
 
 from app.models.comment import RecordComment
 from app.models.feeding import Feeding
@@ -85,31 +84,6 @@ def _extract_json(text: str) -> str:
 
     return text
 
-
-def _verify_record_ownership(
-    db: Session, record_type: str, record_id: int, baby_id: int
-) -> None:
-    """record_id と baby_id の対応を確認（なりすまし防止）"""
-    model_map = {
-        "feeding": Feeding,
-        "diaper": Diaper,
-        "growth": Growth,
-        "note": Note,
-    }
-    model = model_map.get(record_type)
-    if model is None:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid record_type")
-
-    record = db.query(model).filter(
-        model.id == record_id,
-        model.baby_id == baby_id,
-    ).first()
-
-    if not record:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"{record_type} record {record_id} not found for baby {baby_id}",
-        )
 
 
 def _build_records_text(db: Session, baby_id: int, now: datetime) -> str:
@@ -337,9 +311,15 @@ async def generate_record_feedback(
                 return "記録を分析しましたが、現在適切なアドバイスを生成できませんでした。赤ちゃんの様子に気になる点がある場合は、直接医師にご相談ください。", True, model_name
             last_error = e
             break # リトライしない
-        except (openai.RateLimitError, openai.APIConnectionError) as e:
-            logger.warning("Retryable error on attempt %d: %s", attempt + 1, e)
-            last_error = e
+        except openai.RateLimitError as e:
+            logger.warning("Rate limit on attempt %d: %s", attempt + 1, e)
+            last_error = AIRateLimitError(str(e))
+        except openai.APIConnectionError as e:
+            logger.warning("Connection error on attempt %d: %s", attempt + 1, e)
+            last_error = AIServiceError(str(e))
+        except openai.OpenAIError as e:
+            logger.warning("OpenAI error on attempt %d: %s", attempt + 1, e)
+            raise AIServiceError(str(e))
     else:
         raise last_error
 

--- a/app/services/record.py
+++ b/app/services/record.py
@@ -1,0 +1,38 @@
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import InvalidRecordTypeError, RecordNotFoundError
+from app.models.feeding import Feeding
+from app.models.diaper import Diaper
+from app.models.growth import Growth
+from app.models.note import Note
+
+_RECORD_MODEL_MAP = {
+    "feeding": Feeding,
+    "diaper": Diaper,
+    "growth": Growth,
+    "note": Note,
+}
+
+
+def verify_record_ownership(
+    db: Session, record_type: str, record_id: int, baby_id: int
+) -> None:
+    """record_id と baby_id の対応を確認する（なりすまし防止）。
+
+    Raises:
+        InvalidRecordTypeError: record_type が不正な場合
+        RecordNotFoundError: 対応するレコードが見つからない場合
+    """
+    model = _RECORD_MODEL_MAP.get(record_type)
+    if model is None:
+        raise InvalidRecordTypeError(f"Invalid record_type: {record_type}")
+
+    record = db.query(model).filter(
+        model.id == record_id,
+        model.baby_id == baby_id,
+    ).first()
+
+    if not record:
+        raise RecordNotFoundError(
+            f"{record_type} record {record_id} not found for baby {baby_id}"
+        )

--- a/tests/test_ai_feedback.py
+++ b/tests/test_ai_feedback.py
@@ -113,3 +113,62 @@ async def test_generate_record_feedback_disabled(mock_config, db):
     with pytest.raises(AIGenerationError, match="AI 記録フィードバック機能は現在無効化されています。"):
         await generate_record_feedback(db, baby.id, baby, "feeding", feeding.id)
 
+import openai
+from app.core.exceptions import AIRateLimitError, AIServiceError
+
+@pytest.mark.anyio
+@patch("app.services.ai_feedback.get_async_llm_client")
+@patch("app.services.ai_feedback.get_ai_config")
+async def test_generate_record_feedback_rate_limit(mock_config, mock_get_client, db):
+    mock_config.return_value = {"ai_enabled_feedback": True}
+    mock_client = MagicMock()
+    mock_get_client.return_value = (mock_client, "gpt-test-model")
+    
+    mock_client.chat.completions.create = AsyncMock(
+        side_effect=openai.RateLimitError(
+            message="Rate limit exceeded",
+            response=MagicMock(),
+            body={}
+        )
+    )
+
+    user = User(username="test_user_ai_rate", hashed_password="fake")
+    db.add(user)
+    db.commit()
+    family = Family(name="Test Family Rate", invite_code="TEST-AI-RT")
+    db.add(family)
+    db.commit()
+    baby = Baby(family_id=family.id, name="テストベビー", gender="boy", birthday=datetime.now(timezone.utc).date())
+    db.add(baby)
+    db.commit()
+
+    with pytest.raises(AIRateLimitError):
+        await generate_record_feedback(db, baby.id, baby, "feeding", 1)
+
+@pytest.mark.anyio
+@patch("app.services.ai_feedback.get_async_llm_client")
+@patch("app.services.ai_feedback.get_ai_config")
+async def test_generate_record_feedback_openai_error(mock_config, mock_get_client, db):
+    mock_config.return_value = {"ai_enabled_feedback": True}
+    mock_client = MagicMock()
+    mock_get_client.return_value = (mock_client, "gpt-test-model")
+    
+    mock_client.chat.completions.create = AsyncMock(
+        side_effect=openai.APIConnectionError(
+            request=MagicMock()
+        )
+    )
+
+    user = User(username="test_user_ai_api", hashed_password="fake")
+    db.add(user)
+    db.commit()
+    family = Family(name="Test Family API", invite_code="TEST-AI-AP")
+    db.add(family)
+    db.commit()
+    baby = Baby(family_id=family.id, name="テストベビー", gender="boy", birthday=datetime.now(timezone.utc).date())
+    db.add(baby)
+    db.commit()
+
+    with pytest.raises(AIServiceError):
+        await generate_record_feedback(db, baby.id, baby, "feeding", 1)
+

--- a/tests/test_record_service.py
+++ b/tests/test_record_service.py
@@ -1,0 +1,38 @@
+import pytest
+from app.services.record import verify_record_ownership
+from app.core.exceptions import InvalidRecordTypeError, RecordNotFoundError
+from app.models.feeding import Feeding
+from app.models.user import User
+from app.models.family import Family
+from app.models.baby import Baby
+from datetime import datetime, timezone
+
+def test_verify_record_ownership_invalid_type(db):
+    with pytest.raises(InvalidRecordTypeError, match="Invalid record_type"):
+        verify_record_ownership(db, "invalid_type", 1, 1)
+
+def test_verify_record_ownership_not_found(db):
+    with pytest.raises(RecordNotFoundError, match="feeding record 999 not found for baby 1"):
+        verify_record_ownership(db, "feeding", 999, 1)
+
+def test_verify_record_ownership_success(db):
+    user = User(username="test_user_rec", hashed_password="fake")
+    db.add(user)
+    db.commit()
+    family = Family(name="Test Family", invite_code="TEST-REC")
+    db.add(family)
+    db.commit()
+    baby = Baby(family_id=family.id, name="テストベビー", gender="boy", birthday=datetime.now(timezone.utc).date())
+    db.add(baby)
+    db.commit()
+    feeding = Feeding(
+        baby_id=baby.id,
+        user_id=user.id,
+        feeding_time=datetime.now(timezone.utc),
+        feeding_type="BREAST"
+    )
+    db.add(feeding)
+    db.commit()
+
+    # Should not raise
+    verify_record_ownership(db, "feeding", feeding.id, baby.id)


### PR DESCRIPTION
## 変更内容

### #927 AIフィードバック責務分離

- app/services/record.py 新設: verify_record_ownership() を InvalidRecordTypeError / RecordNotFoundError で実装（HTTPException 非依存）
- app/services/ai_feedback.py: _verify_record_ownership を削除し services/record に移動。OpenAI 例外を AIRateLimitError / AIServiceError にラップ
- app/routers/ai_feedback.py: openai 直接依存を除去、アプリ固有例外のみキャッチする薄いコントローラーに変更

### ソフトデリートバグ修正

- feeding/diaper/note/growth/sleep/contraction/temperatures の GET エンドポイントに is_deleted == False フィルター追加（削除後リフレッシュで記録が再表示されるバグを修正）
- コメント数クエリに RecordComment.is_deleted == False フィルター追加

## テスト

- tests/test_record_service.py 新規追加
- tests/test_ai_feedback.py に AIRateLimitError / AIServiceError テスト追加
- 全 31 テスト通過

Closes #927