### PR TITLE
✍️ Scribe: baby_permissions.md の record_type に temperature を追加

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -321,3 +321,7 @@
 ## 2026-03-14 - [PWAプッシュ通知仕様書における新機能の追記漏れ]
 **学び:** 体温記録や実績解除機能が追加された際、アプリ内通知仕様書（`notification_center.md`）が更新されていても、PWA向けのプッシュ通知仕様書（`pwa_notifications.md`）の「通知項目一覧」には追記が漏れやすい。特に記録タイプが「family_record」カテゴリに属する場合、独立した行としての追加が見落とされがちである。
 **アクション:** 通知機能に関連する新しい記録タイプやカテゴリを追加する際は、`notification_center.md` だけでなく `pwa_notifications.md` などのインフラ・PWA関連の仕様書にも通知項目が網羅されているかを必ず確認・同期する。
+
+## 2024-03-16 - [設定] baby_permissions.md と実装の乖離修正
+**学び:** 新しい記録タイプ（例: `temperature`）が追加された場合、各機能（この場合は `app/routers/temperatures.py` や `app/models/temperature.py`）は実装されるが、`baby_permissions.md` のような権限管理の仕様書への追記が漏れやすい。特に `record_type` の有効値一覧は、APIの連携にも関わるため、実装が先行しドキュメントと不整合が起きる。ただし、仕様書への追記は実装と対応させる必要があり、コード自体の更新（`app/schemas/baby_permission.py` など）は Scribe の責務外である。
+**アクション:** 仕様書 `.specify/specs/settings/baby_permissions.md` の `record_type` 一覧に `temperature` を追記し、コード（`app/routers/temperatures.py` 内の `record_type="temperature"` の使用）と整合させた。今後も新しい記録タイプが実装された際には、`baby_permissions.md` にも対応する値が含まれているか確認する。

--- a/.specify/specs/settings/baby_permissions.md
+++ b/.specify/specs/settings/baby_permissions.md
@@ -51,7 +51,8 @@ Baby（赤ちゃん全体の可視性）
        ├── schedule（スケジュール）
        ├── vaccination（予防接種）
        ├── note（汎用メモ）
-       └── milestone（マイルストーン）
+       ├── milestone（マイルストーン）
+       └── temperature（体温）
 ```
 
 ### `record_type` の有効値一覧
@@ -68,6 +69,7 @@ Baby（赤ちゃん全体の可視性）
 | `"vaccination"` | 予防接種記録 | `vaccinations` |
 | `"note"` | 汎用メモ | `notes` |
 | `"milestone"` | 発育発達マイルストーン記録 | `milestones` |
+| `"temperature"` | 体温記録 | `temperature_records` |
 
 ### 権限判定ロジック
 
@@ -236,7 +238,8 @@ for record_type in VALID_RECORD_TYPES:
         { "record_type": "schedule",    "can_view": true  },
         { "record_type": "vaccination", "can_view": true  },
         { "record_type": "note",        "can_view": true  },
-        { "record_type": "milestone",   "can_view": true  }
+        { "record_type": "milestone",   "can_view": true  },
+        { "record_type": "temperature", "can_view": true  }
       ]
     }
   ]
@@ -252,7 +255,7 @@ for record_type in VALID_RECORD_TYPES:
 ### リクエスト/レスポンススキーマ
 
 ```typescript
-type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone";
+type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone" | "temperature";
 
 // 単一の権限レコード（1ユーザー × 1record_type）
 interface BabyPermissionItem {


### PR DESCRIPTION
💡 何を
- `.specify/specs/settings/baby_permissions.md` の `record_type` 有効値一覧に `temperature` を追加しました。

🔍 発見
- `app/routers/temperatures.py` や `app/models/temperature.py` に体温記録機能が実装され、`verify_baby_access` でも `record_type="temperature"` が使用されていますが、権限管理の仕様書 (`baby_permissions.md`) からこの情報が漏れていました。

🎯 影響
- 仕様書の記述が実際のコードベースと一致し、新しく参加した開発者や将来のメンテナンス時に `temperature` の権限がどのように扱われるか迷うことがなくなります。APIの仕様（`ValidRecordType` など）も実装と整合性が取れました。

---
*PR created automatically by Jules for task [2936241686817079599](https://jules.google.com/task/2936241686817079599) started by @eburairu*