### PR TITLE
fix: おむつ記録の「両方」ボタン押下でApplication errorになるバグを修正

### DIFF
--- a/frontend/components/diaper/PoopDetailsFields.tsx
+++ b/frontend/components/diaper/PoopDetailsFields.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { UseFormReturn, useWatch } from "react-hook-form"
 import { DiaperFormValues } from "@/schemas/diaper"
-import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form"
+import { FormField, FormItem, FormControl, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Label } from "@/components/ui/label"
@@ -24,9 +24,7 @@ export function PoopDetailsFields({ form }: PoopDetailsFieldsProps) {
                 render={({ field }) => (
                     <FormItem className="space-y-2">
                         <fieldset>
-                        <FormLabel asChild>
-                            <legend className="text-xs text-muted-foreground">うんちの色</legend>
-                        </FormLabel>
+                        <legend className="text-xs text-muted-foreground">うんちの色</legend>
                         <FormControl>
                             <RadioGroup
                                 onValueChange={field.onChange}
@@ -77,9 +75,7 @@ export function PoopDetailsFields({ form }: PoopDetailsFieldsProps) {
                 render={({ field }) => (
                     <FormItem className="space-y-2">
                         <fieldset>
-                        <FormLabel asChild>
-                            <legend className="text-xs text-muted-foreground">うんちの量</legend>
-                        </FormLabel>
+                        <legend className="text-xs text-muted-foreground">うんちの量</legend>
                         <FormControl>
                             <RadioGroup
                                 onValueChange={field.onChange}


### PR DESCRIPTION
## 問題

おむつ記録画面で「両方」ボタンを押すと Application error が発生する。

## 原因

`PoopDetailsFields.tsx` で `<FormLabel asChild><legend>...</legend></FormLabel>` を使用していたことが原因。

- `FormLabel` 内部で `{required && <span>*</span>}` が `undefined` として children 配列に含まれる
- `React.Children.count([<legend>, undefined])` が `2` を返す
- Radix UI Slot の `SlotClone` が `React.Children.only(null)` を呼び、例外をスローする

## 修正

`<FormLabel asChild>` を削除し、`<legend>` を直接使用するよう変更。  
`fieldset` + `legend` によるアクセシビリティ構造（PR #970 で導入）は維持。

## 影響範囲

- うんち（DIRTY）選択時も同様のエラーが発生していたが、同じ修正で解消される

## チェックリスト

- [x] `sh scripts/verify_all.sh` 全チェック通過