### PR TITLE
✍️ Scribe: 権限仕様への体温記録(temperature)の追加

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -321,3 +321,6 @@
 ## 2026-03-14 - [PWAプッシュ通知仕様書における新機能の追記漏れ]
 **学び:** 体温記録や実績解除機能が追加された際、アプリ内通知仕様書（`notification_center.md`）が更新されていても、PWA向けのプッシュ通知仕様書（`pwa_notifications.md`）の「通知項目一覧」には追記が漏れやすい。特に記録タイプが「family_record」カテゴリに属する場合、独立した行としての追加が見落とされがちである。
 **アクション:** 通知機能に関連する新しい記録タイプやカテゴリを追加する際は、`notification_center.md` だけでなく `pwa_notifications.md` などのインフラ・PWA関連の仕様書にも通知項目が網羅されているかを必ず確認・同期する。
+## 2024-03-16 - [権限仕様の同期]
+**学び:** `app/models/temperature.py` と `app/routers/temperatures.py` に体温記録 (`temperature`) が実装され、権限検証 (`verify_baby_access(..., record_type="temperature")`) が行われているにもかかわらず、`.specify/specs/settings/baby_permissions.md` の `record_type` の有効値一覧やレスポンス例、TypeScriptの型定義に記述が漏れていた。新しく追加された記録タイプが権限仕様に反映されない「specification drift」のパターンを確認した。
+**アクション:** 今後、バックエンドに新しい記録タイプ（モデルおよびルーター）が追加された際は、対応する権限仕様書（`baby_permissions.md` など）の `record_type` リストや関連定義も漏れなく更新する必要がある。

--- a/.specify/specs/settings/baby_permissions.md
+++ b/.specify/specs/settings/baby_permissions.md
@@ -51,6 +51,7 @@ Baby（赤ちゃん全体の可視性）
        ├── schedule（スケジュール）
        ├── vaccination（予防接種）
        ├── note（汎用メモ）
+       ├── temperature（体温）
        └── milestone（マイルストーン）
 ```
 
@@ -67,6 +68,7 @@ Baby（赤ちゃん全体の可視性）
 | `"schedule"` | スケジュール | `schedules` |
 | `"vaccination"` | 予防接種記録 | `vaccinations` |
 | `"note"` | 汎用メモ | `notes` |
+| `"temperature"` | 体温記録 | `temperature_records` |
 | `"milestone"` | 発育発達マイルストーン記録 | `milestones` |
 
 ### 権限判定ロジック
@@ -236,6 +238,7 @@ for record_type in VALID_RECORD_TYPES:
         { "record_type": "schedule",    "can_view": true  },
         { "record_type": "vaccination", "can_view": true  },
         { "record_type": "note",        "can_view": true  },
+        { "record_type": "temperature", "can_view": true  },
         { "record_type": "milestone",   "can_view": true  }
       ]
     }
@@ -252,7 +255,7 @@ for record_type in VALID_RECORD_TYPES:
 ### リクエスト/レスポンススキーマ
 
 ```typescript
-type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone";
+type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "temperature" | "milestone";
 
 // 単一の権限レコード（1ユーザー × 1record_type）
 interface BabyPermissionItem {


### PR DESCRIPTION
💡 何を
- `.specify/specs/settings/baby_permissions.md` の階層制御図、有効値一覧、レスポンス例、TypeScript型定義（`ValidRecordType`）に `"temperature"` を追加しました。

🔍 発見
- `app/routers/temperatures.py` に体温記録のエンドポイントが実装されており、`verify_baby_access(..., record_type="temperature")` を使用してアクセス制御が行われています。しかし、設計仕様書である `baby_permissions.md` の `record_type` リストに `"temperature"` が含まれておらず、仕様と実装の間に乖離（specification drift）が生じていました。

🎯 影響
- フロントエンド開発者が仕様書を基に権限管理UI（`/settings/permissions`）や型定義を実装・修正する際、「体温記録の権限」が存在しないと誤解するのを防ぎます。
- 仕様書が最新の実装（真実）を正確に反映するようになりました。

---
*PR created automatically by Jules for task [9285985925044083773](https://jules.google.com/task/9285985925044083773) started by @eburairu*