### PR TITLE
🧹 Tidy: 睡眠追加ダイアログをEditDialogBaseに統一

### DIFF
--- a/frontend/components/sleep/SleepCreateDialog.tsx
+++ b/frontend/components/sleep/SleepCreateDialog.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { useSleeps } from "@/hooks/useSleep"
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { Plus } from "lucide-react"
 import { SleepForm } from "./SleepForm"
+import { EditDialogBase } from "@/components/records/EditDialogBase"
 
 interface Props {
     babyId: string
@@ -16,17 +16,22 @@ export function SleepCreateDialog({ babyId }: Props) {
     const [isOpen, setIsOpen] = useState(false)
 
     return (
-        <Dialog open={isOpen} onOpenChange={setIsOpen}>
-            <DialogTrigger asChild>
-                <Button variant="outline" className="w-full bg-white dark:bg-zinc-900 text-indigo-600 dark:text-indigo-400 border-indigo-100 dark:border-zinc-800 hover:bg-indigo-50 dark:hover:bg-zinc-800 hover:text-indigo-700 dark:hover:text-indigo-300 h-12 rounded-xl shadow-sm transition-colors" data-sentry-unmask>
-                    <Plus className="mr-2 h-4 w-4" />
-                    手動で記録を追加
-                </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
-                <DialogHeader>
-                    <DialogTitle>睡眠記録の手動追加</DialogTitle>
-                </DialogHeader>
+        <>
+            <Button
+                variant="outline"
+                className="w-full bg-white dark:bg-zinc-900 text-indigo-600 dark:text-indigo-400 border-indigo-100 dark:border-zinc-800 hover:bg-indigo-50 dark:hover:bg-zinc-800 hover:text-indigo-700 dark:hover:text-indigo-300 h-12 rounded-xl shadow-sm transition-colors"
+                onClick={() => setIsOpen(true)}
+                data-sentry-unmask
+            >
+                <Plus className="mr-2 h-4 w-4" />
+                手動で記録を追加
+            </Button>
+            <EditDialogBase
+                open={isOpen}
+                onOpenChange={setIsOpen}
+                title="睡眠記録の手動追加"
+                dialogClassName="sm:max-w-md"
+            >
                 <SleepForm
                     babyId={babyId}
                     onSuccess={() => {
@@ -34,7 +39,7 @@ export function SleepCreateDialog({ babyId }: Props) {
                         setIsOpen(false)
                     }}
                 />
-            </DialogContent>
-        </Dialog>
+            </EditDialogBase>
+        </>
     )
 }


### PR DESCRIPTION
💡 何を
`frontend/components/sleep/SleepCreateDialog.tsx` のダイアログ実装を、生の `Dialog` 関連コンポーネントの組み合わせから、プロジェクトの標準コンポーネントである `EditDialogBase` を使用する形にリファクタリングしました。さらに、`sm:max-w-md` のレイアウト指定を引き継ぐため、`dialogClassName` プロパティを追加しました。

🎯 なぜ
ダイアログのヘッダーやレイアウト構造といったボイラープレートのコード重複を減らし（DRY）、全体的なUIの一貫性とコンポーネントの保守性を向上させるためです。

🛡️ 安全性
- `pnpm lint` と `pnpm build` が通ることを確認しました。
- `pnpm test` の既存テストケースをすべてパスすることを確認しました。
- `EditDialogBase` の呼び出しにおいて、元々のコンポーネント幅の指定（`sm:max-w-md`）を引き継いでいるため、見た目の副作用はありません。
- トリガーを外出しし、`onClick` を用いて手動でステートを更新する形をとることで、他のレコード編集ダイアログの実装パターンと統一しました。

---
*PR created automatically by Jules for task [14080151197395722951](https://jules.google.com/task/14080151197395722951) started by @eburairu*