### PR TITLE
fix: #936 タイマー完了処理と記録作成の同一トランザクション化

### DIFF
--- a/.specify/specs/tracking/breastfeeding_tracker.md
+++ b/.specify/specs/tracking/breastfeeding_tracker.md
@@ -168,6 +168,7 @@ interface FeedingCreate {
   feeding_completion?: "FULL" | "PARTIAL"
   burped?: boolean
   notes?: string                      // 最大2000文字 (NOTE_MAX_LENGTH)
+  reset_timer?: boolean               // trueの場合、作成と同時にタイマーをリセットする
 }
 
 // Update

--- a/.specify/specs/tracking/contraction_timer.md
+++ b/.specify/specs/tracking/contraction_timer.md
@@ -142,6 +142,7 @@ interface ContractionCreate {
   duration_seconds?: number
   interval_seconds?: number
   notes?: string
+  reset_timer?: boolean   // trueの場合、作成と同時にタイマーをリセットする
 }
 
 // PATCH リクエスト (New)

--- a/app/routers/contraction.py
+++ b/app/routers/contraction.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from app.dependencies import get_db, get_current_user, verify_baby_access
 from app.models.user import User
 from app.models.contraction import Contraction
+from app.models.timer import ContractionTimerState
 from app.models.comment import RecordComment
 from app.schemas.contraction import ContractionCreate, ContractionResponse, ContractionUpdate
 from app.utils.timezone import JST, ensure_aware
@@ -78,6 +79,16 @@ def create_contraction(contraction_in: ContractionCreate, db: Session = Depends(
         notes=contraction_in.notes,
     )
     db.add(new_contraction)
+
+    # タイマーリセット要求があれば処理
+    if contraction_in.reset_timer:
+        db.query(ContractionTimerState).filter(
+            ContractionTimerState.baby_id == contraction_in.baby_id
+        ).update({
+            "status": "idle",
+            "start_time": None
+        }, synchronize_session=False)
+
     db.commit()
     db.refresh(new_contraction)
 

--- a/app/routers/feeding.py
+++ b/app/routers/feeding.py
@@ -6,6 +6,7 @@ from typing import List
 from app.dependencies import get_db, get_current_user, verify_baby_access
 from app.models.user import User
 from app.models.feeding import Feeding
+from app.models.timer import FeedingTimerState
 from app.models.enums import FeedingType
 from app.models.comment import RecordComment
 from app.schemas.feeding import FeedingCreate, FeedingResponse, FeedingUpdate
@@ -69,6 +70,17 @@ def create_feeding(
     )
     db.add(new_feeding)
     db.flush()
+
+    # タイマーリセット要求があれば処理
+    if feeding_in.reset_timer:
+        db.query(FeedingTimerState).filter(
+            FeedingTimerState.baby_id == feeding_in.baby_id
+        ).update({
+            "active_side": None,
+            "left_elapsed_seconds": 0,
+            "right_elapsed_seconds": 0,
+            "segment_start_time": None
+        }, synchronize_session=False)
 
     unlocked = check_and_award_achievements(
         baby_id=new_feeding.baby_id,

--- a/app/schemas/contraction.py
+++ b/app/schemas/contraction.py
@@ -12,6 +12,7 @@ class ContractionCreate(BaseModel):
     duration_seconds: Optional[int] = None
     interval_seconds: Optional[int] = None
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
+    reset_timer: bool = False
 
     @field_validator('start_time', 'end_time', mode='before')
     @classmethod

--- a/app/schemas/feeding.py
+++ b/app/schemas/feeding.py
@@ -33,6 +33,7 @@ class FeedingCreate(BaseModel):
     feeding_completion: Optional[FeedingCompletion] = None
     # Phase 3: ゲップの有無
     burped: Optional[bool] = None
+    reset_timer: bool = False
 
     @model_validator(mode="after")
     def auto_calc_duration(self) -> "FeedingCreate":

--- a/frontend/components/contraction/ContractionTimer.tsx
+++ b/frontend/components/contraction/ContractionTimer.tsx
@@ -49,19 +49,14 @@ export default function ContractionTimer({ babyId, onRecorded }: ContractionTime
             if (result) {
                 await execute(
                     async () => {
-                        // PUT (状態更新) と POST (記録作成) を並行して実行
-                        await Promise.all([
-                            api.put(`/babies/${babyId}/timer/contraction`, {
-                                status: "idle",
-                                start_time: null
-                            }),
-                            api.post("/contractions/", {
-                                baby_id: babyId,
-                                start_time: result.startTime.toISOString(),
-                                end_time: result.endTime.toISOString(),
-                                duration_seconds: result.durationSeconds,
-                            })
-                        ])
+                        // POST (記録作成) 時に reset_timer: true を指定して同一トランザクションでリセット
+                        await api.post("/contractions/", {
+                            baby_id: babyId,
+                            start_time: result.startTime.toISOString(),
+                            end_time: result.endTime.toISOString(),
+                            duration_seconds: result.durationSeconds,
+                            reset_timer: true
+                        })
                     },
                     {
                         successMessage: "記録しました",

--- a/frontend/components/feeding/feeding-form.tsx
+++ b/frontend/components/feeding/feeding-form.tsx
@@ -59,6 +59,7 @@ export function FeedingForm({ babyId, onAdd, onUpdate, initialData, onSuccess, l
         setRightSeconds,
         activeBreastSide,
         toggleTimer,
+        reset, // Use local reset from store
         resetAllTimers,
         formatTimer,
         totalSeconds
@@ -126,7 +127,7 @@ export function FeedingForm({ babyId, onAdd, onUpdate, initialData, onSuccess, l
                     bottle_content_type: nextBottleType,
                     notes: "",
                 })
-                resetAllTimers()
+                reset() // local reset only, API handled by reset_timer: true in POST
                 setFeedingCompletion(null)
                 setBurped(null)
             }
@@ -161,7 +162,8 @@ export function FeedingForm({ babyId, onAdd, onUpdate, initialData, onSuccess, l
                         activeTab,
                         feedingCompletion,
                         bottleContentType: vals.bottle_content_type ?? null,
-                        burped
+                        burped,
+                        reset_timer: true
                     }),
                     onAdd
                 )
@@ -174,7 +176,8 @@ export function FeedingForm({ babyId, onAdd, onUpdate, initialData, onSuccess, l
                         activeTab,
                         feedingCompletion,
                         bottleContentType: vals.bottle_content_type ?? null,
-                        burped
+                        burped,
+                        reset_timer: true
                     })
                 })
             }

--- a/frontend/hooks/useFeedingTimer.ts
+++ b/frontend/hooks/useFeedingTimer.ts
@@ -82,6 +82,7 @@ export function useFeedingTimer({
         setRightSeconds,
         activeBreastSide: activeSide,
         toggleTimer,
+        reset, // local reset
         resetAllTimers,
         formatTimer: formatTimeMMSS,
         totalSeconds

--- a/frontend/lib/feedingUtils.ts
+++ b/frontend/lib/feedingUtils.ts
@@ -205,6 +205,7 @@ interface BuildFeedingPayloadOptions {
     feedingCompletion: FeedingCompletion | null
     bottleContentType: BottleContentType | null
     burped?: boolean | null
+    reset_timer?: boolean
 }
 
 export function buildFeedingPayload({
@@ -213,7 +214,8 @@ export function buildFeedingPayload({
     activeTab,
     feedingCompletion,
     bottleContentType,
-    burped
+    burped,
+    reset_timer
 }: BuildFeedingPayloadOptions): FeedingCreate {
     const leftMin = values.left_breast_minutes || 0
     const rightMin = values.right_breast_minutes || 0
@@ -232,6 +234,7 @@ export function buildFeedingPayload({
         notes: values.notes || "",
         feeding_completion: feedingCompletion,
         burped: burped ?? null,
+        reset_timer: reset_timer || false,
     }
 
     if (activeTab === "BREAST") {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -868,6 +868,11 @@
             ],
             "title": "Notes"
           },
+          "reset_timer": {
+            "default": false,
+            "title": "Reset Timer",
+            "type": "boolean"
+          },
           "start_time": {
             "format": "date-time",
             "title": "Start Time",
@@ -952,6 +957,11 @@
               }
             ],
             "title": "Recorded By Display Name"
+          },
+          "reset_timer": {
+            "default": false,
+            "title": "Reset Timer",
+            "type": "boolean"
           },
           "start_time": {
             "format": "date-time",
@@ -1757,6 +1767,11 @@
             ],
             "title": "Notes"
           },
+          "reset_timer": {
+            "default": false,
+            "title": "Reset Timer",
+            "type": "boolean"
+          },
           "right_breast_minutes": {
             "anyOf": [
               {
@@ -1904,6 +1919,11 @@
               }
             ],
             "title": "Recorded By Display Name"
+          },
+          "reset_timer": {
+            "default": false,
+            "title": "Reset Timer",
+            "type": "boolean"
           },
           "right_breast_minutes": {
             "anyOf": [

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -1528,6 +1528,11 @@ export interface components {
             /** Notes */
             notes?: string | null;
             /**
+             * Reset Timer
+             * @default false
+             */
+            reset_timer: boolean;
+            /**
              * Start Time
              * Format: date-time
              */
@@ -1554,6 +1559,11 @@ export interface components {
             notes?: string | null;
             /** Recorded By Display Name */
             recorded_by_display_name?: string | null;
+            /**
+             * Reset Timer
+             * @default false
+             */
+            reset_timer: boolean;
             /**
              * Start Time
              * Format: date-time
@@ -1836,6 +1846,11 @@ export interface components {
             left_breast_minutes?: number | null;
             /** Notes */
             notes?: string | null;
+            /**
+             * Reset Timer
+             * @default false
+             */
+            reset_timer: boolean;
             /** Right Breast Minutes */
             right_breast_minutes?: number | null;
         };
@@ -1871,6 +1886,11 @@ export interface components {
             notes?: string | null;
             /** Recorded By Display Name */
             recorded_by_display_name?: string | null;
+            /**
+             * Reset Timer
+             * @default false
+             */
+            reset_timer: boolean;
             /** Right Breast Minutes */
             right_breast_minutes?: number | null;
             /**

--- a/tests/test_issue_936_timer_integration.py
+++ b/tests/test_issue_936_timer_integration.py
@@ -1,0 +1,83 @@
+import pytest
+from datetime import datetime, timezone
+
+def test_feeding_creation_resets_timer(auth_client):
+    """授乳記録作成時に reset_timer=True を指定すると、タイマーがリセットされることを確認"""
+    client = auth_client()
+    
+    # ベビー作成
+    res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "birthday": "2026-01-01"})
+    baby_id = res.json()["id"]
+
+    # 1. タイマーを開始状態にする
+    client.put(
+        f"/api/babies/{baby_id}/timer/feeding",
+        json={
+            "active_side": "LEFT",
+            "left_elapsed_seconds": 30,
+            "right_elapsed_seconds": 0,
+            "segment_start_time": "2026-01-01T10:00:00Z"
+        }
+    )
+    
+    # タイマーが開始されていることを確認
+    timer_res = client.get(f"/api/babies/{baby_id}/timer/feeding")
+    assert timer_res.json()["active_side"] == "LEFT"
+
+    # 2. 授乳記録を作成（reset_timer=True）
+    feeding_data = {
+        "baby_id": baby_id,
+        "feeding_time": "2026-01-01T11:00:00Z",
+        "feeding_type": "BREAST",
+        "left_breast_minutes": 5,
+        "right_breast_minutes": 5,
+        "reset_timer": True
+    }
+    
+    res = client.post("/api/feedings/", json=feeding_data)
+    assert res.status_code == 200
+    
+    # 3. タイマーの状態を確認
+    timer_res = client.get(f"/api/babies/{baby_id}/timer/feeding")
+    # 実装後はリセットされているはず
+    assert timer_res.json()["active_side"] is None
+    assert timer_res.json()["left_elapsed_seconds"] == 0
+    assert timer_res.json()["right_elapsed_seconds"] == 0
+    assert timer_res.json()["segment_start_time"] is None
+
+
+def test_contraction_creation_resets_timer(auth_client):
+    """陣痛記録作成時に reset_timer=True を指定すると、タイマーがリセットされることを確認"""
+    client = auth_client()
+    
+    # ベビー作成
+    res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "birthday": "2026-01-01"})
+    baby_id = res.json()["id"]
+
+    # 1. タイマーを開始状態にする
+    client.put(
+        f"/api/babies/{baby_id}/timer/contraction",
+        json={"status": "timing", "start_time": "2026-01-01T10:00:00Z"}
+    )
+    
+    # タイマーが開始されていることを確認
+    timer_res = client.get(f"/api/babies/{baby_id}/timer/contraction")
+    assert timer_res.json()["status"] == "timing"
+
+    # 2. 陣痛記録を作成（reset_timer=True）
+    contraction_data = {
+        "baby_id": baby_id,
+        "start_time": "2026-01-01T11:00:00Z",
+        "end_time": "2026-01-01T11:01:00Z",
+        "duration_seconds": 60,
+        "reset_timer": True
+    }
+    
+    res = client.post("/api/contractions/", json=contraction_data)
+    assert res.status_code == 200
+    
+    # 3. タイマーの状態を確認
+    timer_res = client.get(f"/api/babies/{baby_id}/timer/contraction")
+    # 実装後は idle になっているはず
+    assert timer_res.json()["status"] == "idle"
+    assert timer_res.json()["start_time"] is None


### PR DESCRIPTION
## 概要

Closes #936

## 変更内容

タイマー完了処理と記録作成の同一トランザクション化

## 実装方法

- Gemini CLIによる自動実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認