### PR TITLE
✍️ Scribe: [設定/権限] 未実装の体温記録(temperature)権限仕様を削除

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -325,3 +325,7 @@
 ## 2024-03-16 - [設定] baby_permissions.md と実装の乖離修正
 **学び:** 新しい記録タイプ（例: `temperature`）が追加された場合、各機能（この場合は `app/routers/temperatures.py` や `app/models/temperature.py`）は実装されるが、`baby_permissions.md` のような権限管理の仕様書への追記が漏れやすい。特に `record_type` の有効値一覧は、APIの連携にも関わるため、実装が先行しドキュメントと不整合が起きる。ただし、仕様書への追記は実装と対応させる必要があり、コード自体の更新（`app/schemas/baby_permission.py` など）は Scribe の責務外である。
 **アクション:** 仕様書 `.specify/specs/settings/baby_permissions.md` の `record_type` 一覧に `temperature` を追記し、コード（`app/routers/temperatures.py` 内の `record_type="temperature"` の使用）と整合させた。今後も新しい記録タイプが実装された際には、`baby_permissions.md` にも対応する値が含まれているか確認する。
+
+## 2026-03-17 - [未実装機能 'temperature' の仕様書からの削除]
+**学び:** `app/routers/temperatures.py` に機能自体は実装されているものの、アクセス権限管理（`app/schemas/baby_permission.py`の`VALID_RECORD_TYPES`等）には未追加の状態で、仕様書 `baby_permissions.md` にのみ先行して `"temperature"` が記載される「仕様書の先行記載（嘘の仕様書）」パターンが存在していた。
+**アクション:** `baby_permissions.md` の有効値一覧や型定義から未完全な実装である `"temperature"` を削除し、現在の実装コードと100%一致させた。

--- a/.specify/specs/settings/baby_permissions.md
+++ b/.specify/specs/settings/baby_permissions.md
@@ -51,8 +51,7 @@ Baby（赤ちゃん全体の可視性）
        ├── schedule（スケジュール）
        ├── vaccination（予防接種）
        ├── note（汎用メモ）
-       ├── milestone（マイルストーン）
-       └── temperature（体温）
+       └── milestone（マイルストーン）
 ```
 
 ### `record_type` の有効値一覧
@@ -69,7 +68,6 @@ Baby（赤ちゃん全体の可視性）
 | `"vaccination"` | 予防接種記録 | `vaccinations` |
 | `"note"` | 汎用メモ | `notes` |
 | `"milestone"` | 発育発達マイルストーン記録 | `milestones` |
-| `"temperature"` | 体温記録 | `temperature_records` |
 
 ### 権限判定ロジック
 
@@ -238,8 +236,7 @@ for record_type in VALID_RECORD_TYPES:
         { "record_type": "schedule",    "can_view": true  },
         { "record_type": "vaccination", "can_view": true  },
         { "record_type": "note",        "can_view": true  },
-        { "record_type": "milestone",   "can_view": true  },
-        { "record_type": "temperature", "can_view": true  }
+        { "record_type": "milestone",   "can_view": true  }
       ]
     }
   ]
@@ -255,7 +252,7 @@ for record_type in VALID_RECORD_TYPES:
 ### リクエスト/レスポンススキーマ
 
 ```typescript
-type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone" | "temperature";
+type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone";
 
 // 単一の権限レコード（1ユーザー × 1record_type）
 interface BabyPermissionItem {


### PR DESCRIPTION
💡 何を
- `.specify/specs/settings/baby_permissions.md` から `"temperature"`（体温）に関する記述を削除し、現在の実装コードと一致させました。
- `.jules/scribe.md` に、この「嘘の仕様書（先行記載）」パターンに関する学びを記録しました。

🔍 発見
- API側で `verify_baby_access(..., record_type="temperature")` を呼び出す機能自体は実装されていましたが、肝心の権限判定用リスト（`app/schemas/baby_permission.py` の `VALID_RECORD_TYPES` や `app/routers/baby_permissions.py` の `valid_types`、フロントエンドの `ALL_RECORD_TYPES`）に `"temperature"` が追加されていませんでした。
- にもかかわらず、仕様書 `.specify/specs/settings/baby_permissions.md` には既に `"temperature"` が有効な `record_type` として記載されており、実装が伴っていない「嘘の仕様書（Ghost Features）」状態になっていました。

🎯 影響
- 仕様書が現在の実際の実装（真実）を正確に反映するようになり、今後の開発者が「体温の権限設定が既に機能している」と誤解してバグや手戻りを生むリスクを防止しました。

---
*PR created automatically by Jules for task [13654566741600143992](https://jules.google.com/task/13654566741600143992) started by @eburairu*