### PR TITLE
fix: 授乳記録追加後にグラフが更新されない不具合を修正

### DIFF
--- a/frontend/app/(dashboard)/feeding/page.tsx
+++ b/frontend/app/(dashboard)/feeding/page.tsx
@@ -63,9 +63,10 @@ export default function FeedingPage() {
             <TipsCard {...feedingTips} />
 
             {canWrite && babyId && (
-                <FeedingForm 
-                    babyId={typeof babyId === 'string' ? parseInt(babyId, 10) : (babyId || 0)} 
-                    onAdd={handleAddFeeding} 
+                <FeedingForm
+                    babyId={typeof babyId === 'string' ? parseInt(babyId, 10) : (babyId || 0)}
+                    onAdd={handleAddFeeding}
+                    onSuccess={refreshFeedings}
                     lastMilkAmount={summary.lastMilkAmount}
                     lastBottleContentType={summary.lastBottleContentType}
                 />


### PR DESCRIPTION
## 概要

授乳記録を新規追加した後、FeedingChart（グラフ）が更新されない不具合を修正。

## 原因

`feeding/page.tsx` の `<FeedingForm>` に `onSuccess` コールバックが渡されていなかった。

- `FeedingEditDialog` や `FeedingHistory` の削除では `onSuccess`/`onRefresh` が設定されており正常動作
- 新規追加フォームのみ `onSuccess={refreshFeedings}` が欠落していた

## 修正内容

`<FeedingForm>` に `onSuccess={refreshFeedings}` を追加。記録保存後に SWR キャッシュを明示的に再検証し、グラフ・統計が即時更新されるよう修正。

## テスト

フロントエンドビルド確認済み。