### PR TITLE
✍️ Scribe: [プロフィール設定仕様書の仕様乖離修正 - FamilyMemberResponseのUserRole反映漏れ]

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -325,3 +325,7 @@
 ## 2024-03-16 - [設定] baby_permissions.md と実装の乖離修正
 **学び:** 新しい記録タイプ（例: `temperature`）が追加された場合、各機能（この場合は `app/routers/temperatures.py` や `app/models/temperature.py`）は実装されるが、`baby_permissions.md` のような権限管理の仕様書への追記が漏れやすい。特に `record_type` の有効値一覧は、APIの連携にも関わるため、実装が先行しドキュメントと不整合が起きる。ただし、仕様書への追記は実装と対応させる必要があり、コード自体の更新（`app/schemas/baby_permission.py` など）は Scribe の責務外である。
 **アクション:** 仕様書 `.specify/specs/settings/baby_permissions.md` の `record_type` 一覧に `temperature` を追記し、コード（`app/routers/temperatures.py` 内の `record_type="temperature"` の使用）と整合させた。今後も新しい記録タイプが実装された際には、`baby_permissions.md` にも対応する値が含まれているか確認する。
+
+## 2024-03-16 - [プロフィール設定仕様書の仕様乖離 - FamilyMemberResponseのUserRole反映漏れ]
+**学び:** `app/schemas/family.py` の `FamilyMemberResponse` モデルで `role` フィールドの型が `str` から `UserRole` Enumにアップデートされているにもかかわらず、対応する仕様書 `.specify/specs/settings/profile_settings.md` では古い型 `str` が残っていた。`family_settings.md` は更新されていたため、モデルが複数の仕様書に記載されていると片方の更新が漏れやすい。
+**アクション:** 今後、共通のレスポンスモデルのフィールド型（特にEnumへの移行など）に変更があった場合は、それが参照されている全てのマークダウン仕様書を検索し、漏れなく更新・同期するようにする。

--- a/.specify/specs/settings/profile_settings.md
+++ b/.specify/specs/settings/profile_settings.md
@@ -209,7 +209,7 @@ class FamilyMemberResponse(BaseModel):
     user_id: int
     username: str
     display_name: Optional[str] = None   # ← 追加
-    role: str
+    role: UserRole
     joined_at: datetime
 
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
💡 何を
- `.specify/specs/settings/profile_settings.md` に記載されている `FamilyMemberResponse` の `role` フィールドの型を `str` から実装に即した `UserRole` Enum に更新しました。
- `.jules/scribe.md` に、共通レスポンスモデルが複数の仕様書で参照されている場合の更新漏れパターンに関する学びとアクションプランを追加しました。

🔍 発見
- `app/schemas/family.py` の `FamilyMemberResponse` モデルで `role` フィールドの型が `str` から `UserRole` Enumにアップデートされていました。
- `family_settings.md` では `UserRole` への更新が行われていましたが、`profile_settings.md` の方は古い型 `str` が残ったままでした。共通レスポンスモデルの機能拡張・型変更時、対応する各仕様書への追記・修正が漏れやすいことが分かりました。

🎯 影響
- フロントエンド開発者が `profile_settings.md` を参照した際、`role` の型が `str` であると誤認し、正しく `UserRole` 型を使用できなくなることや型エラーの原因になることを防ぎます。
- ドキュメントが現在のバックエンドの実装と完全に一致し、生きた仕様書として機能し続けるようになります。

---
*PR created automatically by Jules for task [14699651494112612084](https://jules.google.com/task/14699651494112612084) started by @eburairu*