### PR TITLE
⚡ Bolt: [フロントエンド] RecordListItemの不要な再レンダリングを防止

### DIFF
--- a/frontend/components/records/RecordListItem.tsx
+++ b/frontend/components/records/RecordListItem.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react"
+import React, { ReactNode } from "react"
 import { cn } from "@/lib/utils"
 
 interface RecordListItemProps {
@@ -14,7 +14,8 @@ interface RecordListItemProps {
     onClick?: () => void
 }
 
-export function RecordListItem({
+// ⚡ Bolt: React.memoを追加し、親コンポーネントの状態変更（ダイアログ開閉等）によるリストアイテムの不要な再レンダリングを防止
+export const RecordListItem = React.memo(function RecordListItem({
     icon,
     children,
     actions,
@@ -48,4 +49,4 @@ export function RecordListItem({
             )}
         </div>
     )
-}
+})


### PR DESCRIPTION
💡 何を: 履歴表示等で多用される `RecordListItem` コンポーネントを `React.memo` でラップしました。
🎯 なぜ: リストの親コンポーネント（履歴やダッシュボード）でモーダルを開閉する際などに、リスト内のすべてのアイテムが不要に再レンダリングされる問題を防ぐためです。
📊 影響: 大量の履歴が表示されるページでの不要な再レンダリングが防がれ、UI操作時のパフォーマンス（メモリ消費と描画時間）が改善されます。
🔬 測定: React DevToolsのProfilerを使用して、履歴ページでの操作時に `RecordListItem` が再レンダリングされないことを確認できます。

---
*PR created automatically by Jules for task [16592699574370534810](https://jules.google.com/task/16592699574370534810) started by @eburairu*