### PR TITLE
🎨 Palette: HexagonButtonにツールチップを追加

### DIFF
--- a/frontend/components/ui/hexagon-button.tsx
+++ b/frontend/components/ui/hexagon-button.tsx
@@ -72,6 +72,7 @@ export const HexagonButton = React.forwardRef<HTMLButtonElement, HexagonButtonPr
       disabled={loading}
       aria-busy={loading}
       aria-pressed={active}
+      title={props.title || props["aria-label"] || label}
       {...props}
       style={{ width, height, ...props.style } as React.CSSProperties}
     >


### PR DESCRIPTION
💡 何を:
`HexagonButton` コンポーネントに `title` 属性を動的に付与するロジックを追加しました。`title` 属性が明示的に渡されていない場合は、`aria-label` 属性、または `label` プロパティの値をフォールバックとして使用します。

🎯 なぜ:
`QuickActionBar` などで多用されている `HexagonButton` は、アイコンのみの表示となることが多く、マウスユーザーにとって何のボタンなのか一目で分かりにくい場合がありました。この変更により、ボタンにマウスをホバーするとネイティブのツールチップが表示されるようになり、ユーザビリティ（自己説明性）が向上します。

📸 Before/After:
（視覚的なUIコンポーネントのレイアウト変更はありません。マウスホバー時のみOSネイティブのツールチップが表示されます。）

♿ アクセシビリティ:
スクリーンリーダー向けに設定されている `aria-label` をマウスユーザーの視覚的なヒント（`title`）としても再利用することで、開発者が意識せずともアクセシブルかつ使いやすいボタンを提供できるようになりました。

---
*PR created automatically by Jules for task [15166218290273569718](https://jules.google.com/task/15166218290273569718) started by @eburairu*