### PR TITLE
✍️ Scribe: [AI設定のAPIスキーマ定義追加]

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -329,3 +329,7 @@
 ## 2024-03-16 - [プロフィール設定仕様書の仕様乖離 - FamilyMemberResponseのUserRole反映漏れ]
 **学び:** `app/schemas/family.py` の `FamilyMemberResponse` モデルで `role` フィールドの型が `str` から `UserRole` Enumにアップデートされているにもかかわらず、対応する仕様書 `.specify/specs/settings/profile_settings.md` では古い型 `str` が残っていた。`family_settings.md` は更新されていたため、モデルが複数の仕様書に記載されていると片方の更新が漏れやすい。
 **アクション:** 今後、共通のレスポンスモデルのフィールド型（特にEnumへの移行など）に変更があった場合は、それが参照されている全てのマークダウン仕様書を検索し、漏れなく更新・同期するようにする。
+
+## 2024-05-18 - [AI設定のAPIスキーマ定義追加]
+**学び:** `ai_settings.md` に、バックエンドのPydanticスキーマ（`AISettingResponse`, `AISettingsPatch`, `AIModel`, `AISettingsSummary`）に対応するTypeScriptのインターフェース定義（`AISettings`, `AIModel`, `AISettingsSummary`, `AISettingsPatch`）が欠落している仕様乖離パターン（Specification Drift）を発見しました。
+**アクション:** 次回以降、新しい設定ページや機能が追加される際に、APIのエンドポイント定義だけでなく、リクエストとレスポンスの型定義（TypeScript interface）が仕様書に記載されているか確認します。

--- a/.specify/specs/settings/ai_settings.md
+++ b/.specify/specs/settings/ai_settings.md
@@ -61,8 +61,37 @@ Botoro の現在の設計思想に基づき、**システム全体のデフォ�
 - **概要**: AI 設定値を更新する。
 - **権限**: `admin` ロールのみ。
 - **バリデーション**: `llm_temperature` は 0.0〜2.0 の範囲内であること等。
+### 3.2 リクエスト/レスポンススキーマ
 
-### 3.2 サービスロジックの変更
+```typescript
+interface AIModel {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface AISettings {
+  llm_model: string;
+  llm_temperature: number;
+  llm_max_tokens: number;
+  ai_enabled_chat: boolean;
+  ai_enabled_summary: boolean;
+  ai_enabled_feedback: boolean;
+}
+
+interface AISettingsSummary {
+  settings: AISettings;
+  available_models: AIModel[];
+}
+
+interface AISettingsPatch {
+  settings: Record<string, string>; // key -> value (文字列ベース) の辞書
+}
+```
+
+
+
+### 3.3 サービスロジックの変更
 
 既存の AI サービス（`ai_summary.py`, `chatbot.py`, `ai_feedback.py`）は、環境変数 `LLM_MODEL` の代わりに、DB から取得した設定値を使用するように変更する。
 


### PR DESCRIPTION
💡 **何を (What)**:
`.specify/specs/settings/ai_settings.md` に欠落していたリクエスト/レスポンスのスキーマ定義（TypeScript のインターフェース）を追記しました。

🔎 **発見 (Discovery)**:
`ai_settings.md` の仕様書には、バックエンドのPydanticスキーマ（`AISettingResponse`, `AISettingsPatch`, `AIModel`, `AISettingsSummary`）に対応するTypeScriptのインターフェース定義が記述されておらず、フロントエンド側の実装（`useAISettings.ts` 等）で利用する型定義と仕様書が乖離している（Specification Drift）状態でした。

🎯 **影響 (Impact)**:
APIのエンドポイント定義だけでなく、リクエスト・レスポンスの正確な型定義（TypeScript interface）が仕様書に記載されることで、開発者が古い仕様書や不完全な情報を読んで実装することによる誤解や手戻りを防ぎます。

（※今回の変更内容はドキュメントのみであり、プロダクションのコードやロジックには影響しません）

---
*PR created automatically by Jules for task [3574150357914334410](https://jules.google.com/task/3574150357914334410) started by @eburairu*