### PR TITLE
🧹 Tidy: DiaryEditDialog の保存状態管理を useAsyncAction で共通化

### DIFF
--- a/frontend/components/diary/DiaryEditDialog.tsx
+++ b/frontend/components/diary/DiaryEditDialog.tsx
@@ -9,6 +9,7 @@ import { DailySummary } from "@/types/dailySummary"
 import { compressImage, ImageTooLargeError } from "@/lib/imageCompression"
 import { uploadImage } from "@/lib/uploadImage"
 import { EditDialogBase } from "@/components/records/EditDialogBase"
+import { useAsyncAction } from "@/hooks/useAsyncAction"
 
 const MAX_IMAGES = 10
 
@@ -26,7 +27,7 @@ export function DiaryEditDialog({ summary, open, onOpenChange, onSave, canWrite 
     const [isUploading, setIsUploading] = useState(false)
     const [uploadError, setUploadError] = useState<string | null>(null)
     const [saveError, setSaveError] = useState<string | null>(null)
-    const [saving, setSaving] = useState(false)
+    const { loading: saving, execute } = useAsyncAction()
     const fileInputRef = useRef<HTMLInputElement>(null)
 
     useEffect(() => {
@@ -87,21 +88,23 @@ export function DiaryEditDialog({ summary, open, onOpenChange, onSave, canWrite 
 
     const handleSave = async () => {
         if (!summary) return
-        setSaving(true)
         setSaveError(null)
-        try {
-            await onSave(summary.summary_date, content.trim() || null, pendingImages, summary.updated_at)
-            onOpenChange(false)
-        } catch (error: unknown) {
-            const err = error as { response?: { status?: number } };
-            if (err?.response?.status === 409) {
-                setSaveError("他のユーザーによってデータが更新されました。画面を更新して最新のデータを取得してください。")
-            } else {
-                setSaveError("保存に失敗しました。時間をおいて再度お試しください。")
+        await execute(
+            async () => {
+                await onSave(summary.summary_date, content.trim() || null, pendingImages, summary.updated_at)
+                onOpenChange(false)
+            },
+            {
+                onError: (error: unknown) => {
+                    const err = error as { response?: { status?: number } };
+                    if (err?.response?.status === 409) {
+                        setSaveError("他のユーザーによってデータが更新されました。画面を更新して最新のデータを取得してください。")
+                    } else {
+                        setSaveError("保存に失敗しました。時間をおいて再度お試しください。")
+                    }
+                }
             }
-        } finally {
-            setSaving(false)
-        }
+        )
     }
 
     return (


### PR DESCRIPTION
💡 何を:
`frontend/components/diary/DiaryEditDialog.tsx` コンポーネントにおいて、非同期保存処理を手動の状態管理 (`saving`, `saveError`) と `try/catch/finally` ブロックから、プロジェクトで共通化されている `useAsyncAction` フックを使用するように書き換えました。

🎯 なぜ:
- 状態管理とエラーハンドリングのロジックがコンポーネント内に散在しており、他のコンポーネントでも同様の記述が繰り返される原因になっていました。
- 共通フック `useAsyncAction` に処理を委譲することで、コンポーネント自体の責務を UI のレンダリングに集中させ、コードの可読性と保守性を向上させる（DRY原則の適用）ためです。

🛡️ 安全性:
- `useAsyncAction` は元々実装されていたエラーのトースト通知や状態のトグル機能を内包しているため、振る舞いは変わりません。
- 具体的なエラーである「ステータスコード 409 (Conflict)」のハンドリングは、`execute` の `onError` コールバック内で既存と同じように `setSaveError` を呼び出す形で維持しています。
- 修正後に `pnpm test --run` による既存テストの全パスと `pnpm build` によるビルド成功を確認し、リグレッションがないことを保証しています。

---
*PR created automatically by Jules for task [15045507295373085927](https://jules.google.com/task/15045507295373085927) started by @eburairu*