### PR TITLE
fix: CI pytest警告を3件解消

### DIFF
--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -17,7 +17,7 @@ from app.schemas.notification import (
 
 router = APIRouter(prefix="/api/notifications", tags=["notifications"])
 
-test_notification_limiter = RateLimiter(
+notification_rate_limiter = RateLimiter(
     requests_limit=constants.RATE_LIMIT_NOTIFICATION_REQUESTS,
     time_window=constants.RATE_LIMIT_NOTIFICATION_WINDOW,
     error_message="Too many test notifications requested. Please try again later.",
@@ -192,7 +192,7 @@ def send_test_notification(
     current_user: User = Depends(get_current_user)
 ):
     """テスト通知を自分自身に送信する"""
-    test_notification_limiter.check(f"user_{current_user.id}")
+    notification_rate_limiter.check(f"user_{current_user.id}")
     from app.utils.notifications import send_push_notification
 
     subscriptions = db.query(PushSubscription).filter(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,7 +164,8 @@ def db():
         yield session
     finally:
         session.close()
-        transaction.rollback()
+        if transaction.is_active:
+            transaction.rollback()
         connection.close()
         _current_connection = None
 

--- a/tests/test_rate_limit_params.py
+++ b/tests/test_rate_limit_params.py
@@ -1,7 +1,7 @@
 from app.routers.auth import login_limiter, change_password_limiter, register_limiter
 from app.routers.ai_feedback import record_feedback_limiter
 from app.routers.comments import comment_limiter
-from app.routers.notifications import test_notification_limiter
+from app.routers.notifications import notification_rate_limiter
 from app.routers.family import reset_password_limiter, join_family_limiter
 from app.routers.ai_summary import daily_summary_limiter
 from app.routers.upload import upload_limiter
@@ -28,8 +28,8 @@ def test_rate_limit_constants_usage():
     assert comment_limiter.time_window == constants.RATE_LIMIT_COMMENT_WINDOW
 
     # Notifications
-    assert test_notification_limiter.requests_limit == constants.RATE_LIMIT_NOTIFICATION_REQUESTS
-    assert test_notification_limiter.time_window == constants.RATE_LIMIT_NOTIFICATION_WINDOW
+    assert notification_rate_limiter.requests_limit == constants.RATE_LIMIT_NOTIFICATION_REQUESTS
+    assert notification_rate_limiter.time_window == constants.RATE_LIMIT_NOTIFICATION_WINDOW
 
     # Family
     assert reset_password_limiter.requests_limit == constants.RATE_LIMIT_RESET_PASSWORD_REQUESTS

--- a/tests/test_session_token_hashing.py
+++ b/tests/test_session_token_hashing.py
@@ -79,8 +79,6 @@ def test_logout_with_hashed_token(client, test_user, db):
 def test_tampered_token_is_rejected(client):
     """改ざんされたトークンで認証が通らない"""
     # 有効なセッションなしで偽トークンだけ送信
-    response = client.get(
-        "/api/auth/me",
-        cookies={"access_token": "tampered_token_value"},
-    )
+    client.cookies.set("access_token", "tampered_token_value")
+    response = client.get("/api/auth/me")
     assert response.status_code == 401


### PR DESCRIPTION
## Summary

- `test_notification_limiter` → `notification_rate_limiter` にリネーム（`PytestCollectionWarning` 対策。pytest が変数名 `test_*` をテスト関数として収集しようとしていた）
- `conftest.py` の `transaction.rollback()` を `is_active` チェックで条件化（`SAWarning: transaction already deassociated from connection` 対策）
- `test_tampered_token_is_rejected` のリクエスト単位 cookie 設定を `client.cookies.set()` に変更（Starlette の `DeprecationWarning` 対策）

## Test plan
- [ ] CI の pytest 実行で warnings summary が 0 件になることを確認