### PR TITLE
fix: #1012 APIクライアントでの 401 Unauthorized グローバルハンドリングと状態リセットの確実化

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from "vitest"
-import { api, fetcher, isApiError, ApiError } from "@/lib/api"
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
+import { api, fetcher, isApiError, ApiError, _nav } from "@/lib/api"
 
 // Mock fetch globally
 const fetchMock = vi.fn()
@@ -222,6 +222,97 @@ describe("API Utilities", () => {
             expect(isApiError(null)).toBe(false)
             expect(isApiError(undefined)).toBe(false)
             expect(isApiError("string")).toBe(false)
+        })
+    })
+
+    describe("401 Unauthorized グローバルハンドリング", () => {
+        let redirectSpy: ReturnType<typeof vi.spyOn>
+
+        beforeEach(() => {
+            redirectSpy = vi.spyOn(_nav, "redirectTo").mockImplementation(() => {})
+            localStorage.clear()
+            // デフォルトはダッシュボードページ（非認証ページ）
+            Object.defineProperty(window, "location", {
+                value: { pathname: "/dashboard" },
+                writable: true,
+                configurable: true,
+            })
+        })
+
+        it("非認証ページで 401 を受け取ったとき /login にリダイレクトする", async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                text: async () => JSON.stringify({ detail: "Unauthorized" }),
+                statusText: "Unauthorized",
+            })
+
+            await expect(fetcher("/test")).rejects.toThrow(ApiError)
+            expect(redirectSpy).toHaveBeenCalledWith("/login")
+        })
+
+        it("401 時に永続化ストアをクリアする", async () => {
+            localStorage.setItem("baby-store", JSON.stringify({ state: { selectedBabyId: "123" } }))
+            localStorage.setItem("offline-sync-store", JSON.stringify({ state: {} }))
+
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                text: async () => JSON.stringify({ detail: "Unauthorized" }),
+                statusText: "Unauthorized",
+            })
+
+            await expect(fetcher("/test")).rejects.toThrow(ApiError)
+            expect(localStorage.getItem("baby-store")).toBeNull()
+            expect(localStorage.getItem("offline-sync-store")).toBeNull()
+        })
+
+        it("/login ページにいるときは 401 でリダイレクトしない", async () => {
+            Object.defineProperty(window, "location", {
+                value: { pathname: "/login" },
+                writable: true,
+                configurable: true,
+            })
+
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                text: async () => JSON.stringify({ detail: "Unauthorized" }),
+                statusText: "Unauthorized",
+            })
+
+            await expect(fetcher("/test")).rejects.toThrow(ApiError)
+            expect(redirectSpy).not.toHaveBeenCalled()
+        })
+
+        it("/register ページにいるときは 401 でリダイレクトしない", async () => {
+            Object.defineProperty(window, "location", {
+                value: { pathname: "/register" },
+                writable: true,
+                configurable: true,
+            })
+
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                text: async () => JSON.stringify({ detail: "Unauthorized" }),
+                statusText: "Unauthorized",
+            })
+
+            await expect(fetcher("/test")).rejects.toThrow(ApiError)
+            expect(redirectSpy).not.toHaveBeenCalled()
+        })
+
+        it("401 以外のエラーではリダイレクトしない", async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+                status: 403,
+                text: async () => JSON.stringify({ detail: "Forbidden" }),
+                statusText: "Forbidden",
+            })
+
+            await expect(fetcher("/test")).rejects.toThrow(ApiError)
+            expect(redirectSpy).not.toHaveBeenCalled()
         })
     })
 })

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,6 +1,24 @@
 const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? '') + '/api';
 import * as Sentry from "@sentry/nextjs";
 
+const AUTH_PAGES = ['/login', '/register'];
+
+/** テスト可能にするためのナビゲーション抽象 */
+export const _nav = {
+    redirectTo: (url: string) => { window.location.href = url },
+};
+
+function handleUnauthorized(): void {
+    if (typeof window === 'undefined') return;
+    if (AUTH_PAGES.some(page => window.location.pathname.startsWith(page))) return;
+
+    // 永続化ストアをクリア
+    localStorage.removeItem('baby-store');
+    localStorage.removeItem('offline-sync-store');
+
+    _nav.redirectTo('/login');
+}
+
 export class ApiError extends Error {
     info: unknown;
     status: number;
@@ -69,6 +87,9 @@ async function request<T>(
     if (!res.ok) {
         const errorBody = await parseErrorBody(res);
         Sentry.logger.error("API request failed", { url, status: res.status, body: errorBody });
+        if (res.status === 401) {
+            handleUnauthorized();
+        }
         throw new ApiError(
             errorMessage,
             errorBody,


### PR DESCRIPTION
## 概要

Closes #1012

## 変更内容

APIクライアントでの 401 Unauthorized グローバルハンドリングと状態リセットの確実化

## 実装方法

- Claude Codeによる実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認