### PR TITLE
✍️ Scribe: [設定仕様の同期] ValidRecordTypeからtemperatureを削除して実装に適合

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -333,3 +333,7 @@
 ## 2024-05-18 - [AI設定のAPIスキーマ定義追加]
 **学び:** `ai_settings.md` に、バックエンドのPydanticスキーマ（`AISettingResponse`, `AISettingsPatch`, `AIModel`, `AISettingsSummary`）に対応するTypeScriptのインターフェース定義（`AISettings`, `AIModel`, `AISettingsSummary`, `AISettingsPatch`）が欠落している仕様乖離パターン（Specification Drift）を発見しました。
 **アクション:** 次回以降、新しい設定ページや機能が追加される際に、APIのエンドポイント定義だけでなく、リクエストとレスポンスの型定義（TypeScript interface）が仕様書に記載されているか確認します。
+
+## 2024-05-24 - Sync ValidRecordType in baby_permissions.md
+**学び:** `temperature` (体温) はフロントエンドや別エンドポイントでは使用されているが、権限管理の `VALID_RECORD_TYPES` (`app/schemas/baby_permission.py`) には含まれていなかった。仕様書には先行して記載されていたため、コードの実装と乖離していた。
+**アクション:** `.specify/specs/settings/baby_permissions.md` の `ValidRecordType` から `temperature` を削除し、真のソースコード(Pythonスキーマ)と一致させた。

--- a/.specify/specs/settings/baby_permissions.md
+++ b/.specify/specs/settings/baby_permissions.md
@@ -51,8 +51,7 @@ Baby（赤ちゃん全体の可視性）
        ├── schedule（スケジュール）
        ├── vaccination（予防接種）
        ├── note（汎用メモ）
-       ├── milestone（マイルストーン）
-       └── temperature（体温）
+       └── milestone（マイルストーン）
 ```
 
 ### `record_type` の有効値一覧
@@ -69,7 +68,6 @@ Baby（赤ちゃん全体の可視性）
 | `"vaccination"` | 予防接種記録 | `vaccinations` |
 | `"note"` | 汎用メモ | `notes` |
 | `"milestone"` | 発育発達マイルストーン記録 | `milestones` |
-| `"temperature"` | 体温記録 | `temperature_records` |
 
 ### 権限判定ロジック
 
@@ -238,8 +236,7 @@ for record_type in VALID_RECORD_TYPES:
         { "record_type": "schedule",    "can_view": true  },
         { "record_type": "vaccination", "can_view": true  },
         { "record_type": "note",        "can_view": true  },
-        { "record_type": "milestone",   "can_view": true  },
-        { "record_type": "temperature", "can_view": true  }
+        { "record_type": "milestone",   "can_view": true  }
       ]
     }
   ]
@@ -255,7 +252,7 @@ for record_type in VALID_RECORD_TYPES:
 ### リクエスト/レスポンススキーマ
 
 ```typescript
-type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone" | "temperature";
+type ValidRecordType = "baby" | "feeding" | "sleep" | "diaper" | "growth" | "contraction" | "schedule" | "vaccination" | "note" | "milestone";
 
 // 単一の権限レコード（1ユーザー × 1record_type）
 interface BabyPermissionItem {


### PR DESCRIPTION
💡 何を (What):
- `.specify/specs/settings/baby_permissions.md` 内の `ValidRecordType` や有効値一覧から `temperature` を削除しました。
- `.jules/scribe.md` に今回の仕様乖離（Ghost featureの記述）に関する学習と対応履歴を記録しました。

🔍 発見 (Discovery):
- 仕様書の `ValidRecordType` には `temperature` (体温) が記載されていましたが、実際の権限管理の真のソースであるバックエンドスキーマ (`app/schemas/baby_permission.py` の `VALID_RECORD_TYPES`) には含まれていませんでした。
- 機能の一部が先行して仕様書に記載されることで、コードの実装との間に乖離（Specification drift）が生じていました。
- `schedule`, `vaccination`, `milestone` なども同様にPydantic上には存在していましたが、`temperature` はバックエンドに完全に存在していない状態でした。

🎯 影響 (Impact):
- 将来の開発者が、存在しない権限タイプを実装したりフロントエンドで参照しようとするのを防ぎます。
- ドキュメントが真実（現在のコード）を正しく反映するようになり、開発者体験と実装の安全性が向上します。

---
*PR created automatically by Jules for task [5639830777319075811](https://jules.google.com/task/5639830777319075811) started by @eburairu*