### PR TITLE
✍️ Scribe: AI 設定仕様書 (SuperAdmin 権限への移行) の同期

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -333,3 +333,7 @@
 ## 2024-05-18 - [AI設定のAPIスキーマ定義追加]
 **学び:** `ai_settings.md` に、バックエンドのPydanticスキーマ（`AISettingResponse`, `AISettingsPatch`, `AIModel`, `AISettingsSummary`）に対応するTypeScriptのインターフェース定義（`AISettings`, `AIModel`, `AISettingsSummary`, `AISettingsPatch`）が欠落している仕様乖離パターン（Specification Drift）を発見しました。
 **アクション:** 次回以降、新しい設定ページや機能が追加される際に、APIのエンドポイント定義だけでなく、リクエストとレスポンスの型定義（TypeScript interface）が仕様書に記載されているか確認します。
+
+## 2024-05-19 - AI設定仕様書の権限モデルのズレ (SuperAdmin)
+**学び:** `admin` ロールから `SuperAdmin` (is_superadmin) への権限モデルの移行や、それに伴うルーティングの変更 (`/settings/ai` -> `/admin/ai`) が行われた場合、仕様書が古いまま取り残される「Specification Drift」が発生しやすい。
+**アクション:** 新しい機能が `SuperAdmin` 向けに追加されたり、既存機能が `SuperAdmin` に移行したりした場合は、関連する仕様書の権限記述とフロントエンドのルート設計を必ず見直す。

--- a/.specify/specs/settings/ai_settings.md
+++ b/.specify/specs/settings/ai_settings.md
@@ -54,12 +54,12 @@ Botoro の現在の設計思想に基づき、**システム全体のデフォ�
 #### `GET /api/ai/settings`
 
 - **概要**: 現在の AI 設定値を取得する。
-- **権限**: 全ユーザー（参照のみ）、または admin のみ（画面要件に依存）。基本は **admin のみ**とする。
+- **権限**: 全ユーザー（参照のみ）、または SuperAdmin のみ（画面要件に依存）。基本は **SuperAdmin のみ**とする。
 
 #### `PATCH /api/ai/settings`
 
 - **概要**: AI 設定値を更新する。
-- **権限**: `admin` ロールのみ。
+- **権限**: `SuperAdmin` 権限（`is_superadmin = true`）のみ。
 - **バリデーション**: `llm_temperature` は 0.0〜2.0 の範囲内であること等。
 ### 3.2 リクエスト/レスポンススキーマ
 
@@ -104,7 +104,7 @@ def get_llm_config(db: Session):
 
 ## 4. フロントエンド設計
 
-### 4.1 管理画面 (`/settings/ai`)
+### 4.1 管理画面 (`/admin/ai`)
 
 設定ナビゲーションから「AI 設定」としてアクセス可能にする。
 
@@ -134,8 +134,8 @@ def get_llm_config(db: Session):
 
 ## 5. 権限制御
 
-- 設定の閲覧・変更は、現在ログインしているユーザーの `FamilyUser.role` が `admin` である場合にのみ許可する。
-- 非 admin ユーザーが `/settings/ai` に直接アクセスしようとした場合は、403 エラーを表示し設定トップにリダイレクトする。
+- 設定の閲覧・変更は、現在ログインしているユーザーが `SuperAdmin` (`is_superadmin = true`) である場合にのみ許可する。
+- 非 SuperAdmin ユーザーが `/admin/ai` に直接アクセスしようとした場合は、403 エラーを表示しトップにリダイレクトする。
 
 ## 6. 実装チェックリスト
 
@@ -143,11 +143,11 @@ def get_llm_config(db: Session):
 - [ ] `system_settings` テーブルの作成 (Alembic)
 - [ ] `GET /api/ai/available-models` 実装 (Google AI SDK 連携)
 - [ ] `GET /api/ai/settings` 実装
-- [ ] `PATCH /api/ai/settings` 実装 (admin 権限チェック)
+- [ ] `PATCH /api/ai/settings` 実装 (SuperAdmin 権限チェック)
 - [ ] 既存 AI サービスの設定値取得ロジックの置換
 
 ### フロントエンド
 - [ ] `useAISettings.ts` フック作成
-- [ ] `/settings/ai` ページの作成
+- [ ] `/admin/ai` ページの作成
 - [ ] `settings_navigation.md` への項目追加
-- [ ] admin 以外へのアクセスガード実装
+- [ ] SuperAdmin 以外へのアクセスガード実装


### PR DESCRIPTION
💡 何を (What)
`.specify/specs/settings/ai_settings.md` に記載されている AI 設定画面の権限制御とルーティングを、現在のコード実装に合わせて修正しました。

🔍 発見 (Discovery)
仕様書では AI 設定の権限が「`FamilyUser.role` が `admin`」と定義されており、画面パスも `/settings/ai` とされていました。しかし実際のコード（`app/routers/ai_settings.py` と `frontend/app/admin/ai/page.tsx`）を確認すると、SuperAdmin（`is_superadmin = true`）権限を持つユーザーのみがアクセス可能となっており、フロントエンドの画面も `/admin/ai` に配置されていました。

🎯 影響 (Impact)
この更新により、開発者が仕様書を読んで誤って Family Admin 向けの機能として AI 設定を実装してしまうリスクを防ぎます。また、SuperAdmin と Family Admin の権限境界（セキュリティモデル）に関するドキュメントの正確性が向上します。

---
*PR created automatically by Jules for task [14685993893082213415](https://jules.google.com/task/14685993893082213415) started by @eburairu*