### PR TITLE
🧹 Tidy: [DRY] BabyFormの冗長なdisabledプロパティを削除

### DIFF
--- a/frontend/components/settings/BabyForm.tsx
+++ b/frontend/components/settings/BabyForm.tsx
@@ -244,7 +244,6 @@ export function BabyForm({
                     </Button>
                     <Button
                         type="submit"
-                        disabled={isSubmitting}
                         loading={isSubmitting}
                         className="bg-indigo-600 hover:bg-indigo-700 text-white"
                     >


### PR DESCRIPTION
💡 何を
`frontend/components/settings/BabyForm.tsx` にある送信ボタン(`<Button type="submit">`)から、冗長な `disabled={isSubmitting}` プロパティを削除しました。

🎯 なぜ
コードの重複を排除（DRY）するためです。使用されているカスタム `<Button>` コンポーネントは、`loading` プロパティを受け取ると内部で自動的に `disabled={loading || props.disabled}` を適用する仕組みになっています。そのため、`loading={isSubmitting}` を指定している状態で同時に `disabled={isSubmitting}` を渡すのは機能的に重複しており、コードの可読性を下げるノイズとなっていました。

🛡️ 安全性
- 静的解析 (`pnpm lint`), 単体テスト (`pnpm test`), プロダクションビルド (`pnpm build`) がすべて成功することを確認しました。
- Playwrightを用いたUI検証にて、コンポーネントが正常にレンダリングされることを確認しました。
- 対象がプロパティの冗長性の削除のみであり、実際のHTML出力やUIの振る舞い（ローディング中はボタンが押せなくなること）に変更がないため、既存機能への影響はありません。

---
*PR created automatically by Jules for task [18369733389449420185](https://jules.google.com/task/18369733389449420185) started by @eburairu*