### PR TITLE
fix: Closes #0 を含むコミットを commit-msg フックで弾く

### DIFF
--- a/scripts/check_commit_msg.sh
+++ b/scripts/check_commit_msg.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# scripts/check_commit_msg.sh
+# コミットメッセージの禁止パターンをチェックする
+# 使い方: sh scripts/check_commit_msg.sh <commit-msg-file>
+
+COMMIT_MSG_FILE="${1:-.git/COMMIT_EDITMSG}"
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+# "Closes #0" / "Fixes #0" / "Resolves #0" 等の無効な issue 参照を禁止
+# semantic-release が #0 を解釈して GitHub API エラーになるため
+if echo "$COMMIT_MSG" | grep -qiE '(closes|fixes|resolves|refs?) #0\b'; then
+  echo "❌ コミットメッセージに無効な issue 参照 '#0' が含まれています。"
+  echo "   実際の issue 番号を指定するか、'Closes #0' を削除してください。"
+  exit 1
+fi
+
+exit 0

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -21,6 +21,7 @@ HOOK_FILE="$HOOKS_DIR/pre-commit"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CHECK_SCRIPT="$SCRIPT_DIR/check_staged_files.sh"
 CHECK_OPENAPI_SCRIPT="$SCRIPT_DIR/check_openapi_hook.sh"
+CHECK_COMMIT_MSG_SCRIPT="$SCRIPT_DIR/check_commit_msg.sh"
 
 if [ ! -f "$CHECK_SCRIPT" ]; then
   echo "Error: $CHECK_SCRIPT が見つかりません。"
@@ -29,6 +30,11 @@ fi
 
 if [ ! -f "$CHECK_OPENAPI_SCRIPT" ]; then
   echo "Error: $CHECK_OPENAPI_SCRIPT が見つかりません。"
+  exit 1
+fi
+
+if [ ! -f "$CHECK_COMMIT_MSG_SCRIPT" ]; then
+  echo "Error: $CHECK_COMMIT_MSG_SCRIPT が見つかりません。"
   exit 1
 fi
 
@@ -44,3 +50,14 @@ EOF
 
 chmod +x "$HOOK_FILE"
 echo "✅ pre-commit hook をインストールしました: $HOOK_FILE"
+
+# commit-msg フック
+COMMIT_MSG_HOOK_FILE="$HOOKS_DIR/commit-msg"
+cat > "$COMMIT_MSG_HOOK_FILE" <<EOF
+#!/bin/bash
+# commit-msg hook: コミットメッセージの禁止パターンをチェック
+sh "$CHECK_COMMIT_MSG_SCRIPT" "\$1"
+EOF
+
+chmod +x "$COMMIT_MSG_HOOK_FILE"
+echo "✅ commit-msg hook をインストールしました: $COMMIT_MSG_HOOK_FILE"


### PR DESCRIPTION
## 問題

`feat: auto-auditで作成されるissueに優先度ラベルを付与` コミットに `Closes #0` が含まれており、semantic-release の success ステップが存在しない issue #0 に GitHub API でコメントしようとして失敗していた。

リリース自体 (v1.129.0) は正常に作成されているが、ジョブが exit 1 で終わる。

## 修正

- `scripts/check_commit_msg.sh` を追加: `Closes/Fixes/Resolves #0` パターンを検出して拒否
- `scripts/install_hooks.sh` に commit-msg フックとして組み込み

## 再発防止

新しいワークツリー作成時に `install_hooks.sh` が commit-msg フックも設定するため、以後 `Closes #0` を含むコミットはローカルで弾かれる。