### PR TITLE
✍️ Scribe: AI設定仕様書 (llm_reasoning_effort) の同期

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,3 @@
+## 2026-03-19 - AI Settings API Specification Drift
+**学び:** A pattern of specification drift occurs when new backend configuration properties (like `llm_reasoning_effort` in `app/services/ai_settings.py`) are introduced but omitted from the corresponding TypeScript interfaces (e.g., `AISettings`) and initial seed data documented in `.specify/specs/settings/ai_settings.md`.
+**アクション:** When analyzing AI settings endpoints, verify that any new backend configuration parameters are accurately reflected in the frontend's TypeScript interface definitions and initial seed data documentation.

--- a/.specify/specs/settings/ai_settings.md
+++ b/.specify/specs/settings/ai_settings.md
@@ -40,6 +40,7 @@ Botoro の現在の設計思想に基づき、**システム全体のデフォ�
 - `ai_enabled_feedback`: `"true"`
 - `llm_temperature`: `"0.7"`
 - `llm_max_tokens`: `"800"`
+- `llm_reasoning_effort`: `"none"`
 
 ## 3. バックエンド設計
 
@@ -74,6 +75,7 @@ interface AISettings {
   llm_model: string;
   llm_temperature: number;
   llm_max_tokens: number;
+  llm_reasoning_effort: string;
   ai_enabled_chat: boolean;
   ai_enabled_summary: boolean;
   ai_enabled_feedback: boolean;


### PR DESCRIPTION
💡 **何を**:
- `.specify/specs/settings/ai_settings.md` に、バックエンドで追加されていた `llm_reasoning_effort` の初期シードデータとTypeScriptインターフェース（`AISettings`）への型定義を追加しました。
- この仕様ドリフトのパターンを `.jules/scribe.md` に記録しました。

🔍 **発見**:
バックエンド (`app/services/ai_settings.py`) にてAIの推論・思考レベルを調整する設定 `llm_reasoning_effort` が新しく導入されていましたが、設定画面・API仕様を定義する仕様書には初期値やTypeScriptの型として反映されておらず、コードの実装とドキュメント間に乖離が生じていました。

🎯 **影響**:
この仕様書の更新により、新しく追加されたAIパラメータの存在がドキュメント上で明確になります。将来のフロントエンド開発者が設定画面にこのパラメータを追加する際や、インターフェースを更新する際に、正しい仕様と型定義を把握できるようになり、開発の混乱や手戻りを防ぎます。

---
*PR created automatically by Jules for task [7495875154698796988](https://jules.google.com/task/7495875154698796988) started by @eburairu*