### PR TITLE
✍️ Scribe: AI設定仕様書への `llm_reasoning_effort` の追加

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - AI Settings Drift Pattern
+**学び:** バックエンド（app/services/ai_settings.py）で新しいシステム設定（llm_reasoning_effort）が追加されたが、対応する仕様書（.specify/specs/settings/ai_settings.md）の初期シードデータとTypeScriptインターフェース（AISettings）が更新されておらず、乖離が生じていた。
+**アクション:** バックエンドで新しい設定プロパティを導入する際は、設定画面の仕様書のシードデータおよびフロントエンドで用いる型定義に必ず追記するよう監視する。

--- a/.specify/specs/settings/ai_settings.md
+++ b/.specify/specs/settings/ai_settings.md
@@ -40,6 +40,7 @@ Botoro の現在の設計思想に基づき、**システム全体のデフォ�
 - `ai_enabled_feedback`: `"true"`
 - `llm_temperature`: `"0.7"`
 - `llm_max_tokens`: `"800"`
+- `llm_reasoning_effort`: `"none"`
 
 ## 3. バックエンド設計
 
@@ -77,6 +78,7 @@ interface AISettings {
   ai_enabled_chat: boolean;
   ai_enabled_summary: boolean;
   ai_enabled_feedback: boolean;
+  llm_reasoning_effort: string;
 }
 
 interface AISettingsSummary {


### PR DESCRIPTION
💡 何を (What):
- `.specify/specs/settings/ai_settings.md` の「初期シードデータ」に `llm_reasoning_effort` を追加。
- 同じく `ai_settings.md` のTypeScriptインターフェース `AISettings` に `llm_reasoning_effort: string` を追加。
- この仕様の乖離パターン（設定項目の追加漏れ）を `.jules/scribe.md` にジャーナルとして記録。

🔍 発見 (Discovery):
バックエンドのAI関連サービス (`ai_settings.py`, `ai_summary.py` 等) において、Google Geminiの推論・思考レベルを制御するための設定値 `llm_reasoning_effort` (デフォルト値 `"none"`) が追加されていました。しかし、仕様書 (`ai_settings.md`) のデータベースシード値およびフロントエンドとのI/Fを定義するTypeScript型にはこれが記載されておらず、設定管理に関する真実の源（Single Source of Truth）としての役割が損なわれていました。

🎯 影響 (Impact):
この更新により、フロントエンド開発者が将来的に「AI思考レベル設定」のUIを実装する際、正確なプロパティ名と初期値に基づいて型安全な実装が可能になります。また、管理者が新しい設定値の存在をドキュメント上で明確に把握できるようになり、システム全体の設定状態とドキュメントが再び同期されました。

---
*PR created automatically by Jules for task [3547470665623562314](https://jules.google.com/task/3547470665623562314) started by @eburairu*