### PR TITLE
🧹 Tidy: 設定画面のカードUIをSettingsCardに統一

### DIFF
--- a/frontend/components/settings/FamilyNameForm.tsx
+++ b/frontend/components/settings/FamilyNameForm.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { api } from "@/lib/api"
 import { useAsyncAction } from "@/hooks/useAsyncAction"
+import { SettingsCard } from "./SettingsCard"
 
 interface Props {
     name: string
@@ -44,7 +45,7 @@ export function FamilyNameForm({ name, isAdmin, onUpdated }: Props) {
     }
 
     return (
-        <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 transition-colors">
+        <SettingsCard>
             <div className="flex items-center gap-2 mb-3">
                 <span className="text-violet-600 dark:text-violet-400 font-semibold text-sm">👨‍👩‍👧 家族名</span>
             </div>
@@ -83,6 +84,6 @@ export function FamilyNameForm({ name, isAdmin, onUpdated }: Props) {
                     )}
                 </div>
             )}
-        </div>
+        </SettingsCard>
     )
 }

--- a/frontend/components/settings/InviteCodeCard.tsx
+++ b/frontend/components/settings/InviteCodeCard.tsx
@@ -15,6 +15,7 @@ import {
 import { api } from "@/lib/api"
 import { useClipboard } from "@/hooks/useClipboard"
 import { useAsyncAction } from "@/hooks/useAsyncAction"
+import { SettingsCard } from "./SettingsCard"
 
 interface Props {
     inviteCode: string
@@ -45,7 +46,7 @@ export function InviteCodeCard({ inviteCode, isAdmin, onRegenerated }: Props) {
     if (!isAdmin) return null
 
     return (
-        <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 transition-colors">
+        <SettingsCard>
             <div className="flex items-center gap-2 mb-3">
                 <span className="text-violet-600 dark:text-violet-400 font-semibold text-sm">🔑 招待コード</span>
             </div>
@@ -92,6 +93,6 @@ export function InviteCodeCard({ inviteCode, isAdmin, onRegenerated }: Props) {
                     </AlertDialogContent>
                 </AlertDialog>
             </div>
-        </div>
+        </SettingsCard>
     )
 }

--- a/frontend/components/settings/MemberList.tsx
+++ b/frontend/components/settings/MemberList.tsx
@@ -20,6 +20,7 @@ import { formatDate } from "@/lib/dateUtils"
 import { UserRole } from "@/lib/constants"
 import { FamilyMember } from "@/types/family"
 import { useAsyncAction } from "@/hooks/useAsyncAction"
+import { SettingsCard } from "./SettingsCard"
 
 interface Props {
     members: FamilyMember[]
@@ -50,7 +51,7 @@ export function MemberList({ members, currentUserId, isAdmin, onUpdated }: Props
     }
 
     return (
-        <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 transition-colors">
+        <SettingsCard>
             <div className="flex items-center gap-2 mb-3">
                 <span className="text-violet-600 dark:text-violet-400 font-semibold text-sm">
                     👥 メンバー ({members.length}名)
@@ -145,6 +146,6 @@ export function MemberList({ members, currentUserId, isAdmin, onUpdated }: Props
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
-        </div>
+        </SettingsCard>
     )
 }

--- a/frontend/components/settings/MemberPermissionCard.tsx
+++ b/frontend/components/settings/MemberPermissionCard.tsx
@@ -3,6 +3,7 @@
 import { AlertTriangle } from "lucide-react"
 import type { MemberPermissions } from "@/hooks/usePermissionsPage"
 import { BabyAccessRow } from "./BabyAccessRow"
+import { SettingsCard } from "./SettingsCard"
 
 const ROLE_LABELS: Record<string, string> = {
   member: "メンバー",
@@ -24,7 +25,7 @@ export function MemberPermissionCard({ member, onSaved }: Props) {
   )
 
   return (
-    <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 space-y-3">
+    <SettingsCard className="space-y-3">
       {/* メンバー名・ロール */}
       <div className="flex items-center justify-between border-b border-gray-100 dark:border-zinc-800 pb-2">
         <div>
@@ -66,6 +67,6 @@ export function MemberPermissionCard({ member, onSaved }: Props) {
           </p>
         )}
       </div>
-    </div>
+    </SettingsCard>
   )
 }


### PR DESCRIPTION
💡 何を: 
設定画面内の複数のコンポーネント (`InviteCodeCard.tsx`, `MemberPermissionCard.tsx`, `MemberList.tsx`, `FamilyNameForm.tsx`) でハードコードされていた `<div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm p-4 transition-colors">` を、既存の共通コンポーネントである `<SettingsCard>` に置き換えました。

🎯 なぜ:
- **DRY原則の適用:** 全く同じTailwindクラス群が複数のファイルに散在していたため、デザイン変更時に修正漏れが発生するリスクがありました。共通の `SettingsCard` を使用することで、スタイルを一元管理でき、保守性と可読性が向上します。
- **意図の明確化:** `div` よりも `SettingsCard` という名前の方が、その要素の役割（設定画面用のカードであること）をより明確に伝えます。

🛡️ 安全性:
- 機能追加やUIの見た目の変更はありません。単なるラッパーの置き換えです。
- `pnpm lint`, `pnpm test --run`, `pnpm build` を実行し、既存の型チェックやテストがすべてパスすること、ビルドが正常に完了することを確認済みです。
- 対象となるファイルの内容を `cat` コマンドで目視確認し、意図した通りに置換が行われていることを検証しました。

---
*PR created automatically by Jules for task [18331652202048994453](https://jules.google.com/task/18331652202048994453) started by @eburairu*