### PR TITLE
✍️ Scribe: AI設定仕様書の実装との同期 (llm_reasoning_effortの追加)

### DIFF
--- a/.specify/specs/settings/ai_settings.md
+++ b/.specify/specs/settings/ai_settings.md
@@ -40,6 +40,7 @@ Botoro の現在の設計思想に基づき、**システム全体のデフォ�
 - `ai_enabled_feedback`: `"true"`
 - `llm_temperature`: `"0.7"`
 - `llm_max_tokens`: `"800"`
+- `llm_reasoning_effort`: `"none"`
 
 ## 3. バックエンド設計
 
@@ -74,6 +75,7 @@ interface AISettings {
   llm_model: string;
   llm_temperature: number;
   llm_max_tokens: number;
+  llm_reasoning_effort: string;
   ai_enabled_chat: boolean;
   ai_enabled_summary: boolean;
   ai_enabled_feedback: boolean;


### PR DESCRIPTION
💡 何を (What):
`.specify/specs/settings/ai_settings.md` ファイル内の初期シードデータ一覧と `AISettings` TypeScriptインターフェースの定義に `llm_reasoning_effort` を追加しました。

🔍 発見 (Discovery):
バックエンドの `app/services/ai_settings.py` の実装で `llm_reasoning_effort` という設定値が新しく追加・利用されるようになっていましたが、対応するAI設定の仕様書（`.specify/specs/settings/ai_settings.md`）には、この設定値に関する記載が漏れていました。これにより、初期データ定義およびフロントエンドでの型定義の仕様に乖離が生じていました。

🎯 影響 (Impact):
この更新により、仕様書と実際の実装間のズレが解消され、将来的にフロントエンドやバックエンドでこの設定値を扱う際（例: 設定画面へのUI追加や型定義の更新など）の開発者の誤解を防ぎ、安全な開発体験を維持できます。

---
*PR created automatically by Jules for task [2904721139835272791](https://jules.google.com/task/2904721139835272791) started by @eburairu*