### PR TITLE
fix: 記録追加後に授乳比較グラフが即時更新されない問題を修正

### DIFF
--- a/frontend/__tests__/feedingUtils.test.ts
+++ b/frontend/__tests__/feedingUtils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { calculateFeedingStats, NormalizedFeeding } from '../lib/feedingUtils'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { calculateFeedingStats, buildFeedingHourlyComparison, NormalizedFeeding } from '../lib/feedingUtils'
 
 describe('calculateFeedingStats', () => {
   it('should return lastMilkAmount and lastBottleContentType correctly', () => {
@@ -32,5 +32,94 @@ describe('calculateFeedingStats', () => {
     
     expect(result.lastMilkAmount).toBe(100)
     expect(result.lastBottleContentType).toBe('FORMULA')
+  })
+})
+
+describe('buildFeedingHourlyComparison', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // JST 2026-03-19 10:00:00 を固定する（UTC: 2026-03-19T01:00:00Z）
+  const NOW_UTC = '2026-03-19T01:00:00Z'
+
+  it('今日の記録が正しくカウントされる', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(NOW_UTC))
+
+    // 今日 JST 09:00（UTC 00:00）の授乳
+    const todayFeeding: NormalizedFeeding = {
+      id: 1,
+      timestamp: '2026-03-19T00:00:00+00:00', // 09:00 JST
+      type: 'BREAST',
+      amount: 0,
+      duration: 10,
+      leftDuration: 5,
+      rightDuration: 5,
+      lastBreastSide: 'RIGHT',
+      bottleContentType: null,
+    }
+
+    const result = buildFeedingHourlyComparison([todayFeeding])
+
+    // 時刻 9（JST 09:xx）以降の累積カウントが 1 になる
+    expect(result[9].todayCount).toBe(1)
+    expect(result[10].todayCount).toBe(1) // 現在時刻（10時）も含む
+    expect(result[23].todayCount).toBe(1)
+    // 9時より前は 0
+    expect(result[8].todayCount).toBe(0)
+  })
+
+  it('今日の記録を追加すると比較データが変化する', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(NOW_UTC))
+
+    // 追加前: 記録なし
+    const before = buildFeedingHourlyComparison([])
+    expect(before[9].todayCount).toBe(0)
+
+    // 追加後: 今日 JST 09:00 の記録を加える
+    const newFeeding: NormalizedFeeding = {
+      id: 2,
+      timestamp: '2026-03-19T00:00:00+00:00', // 09:00 JST
+      type: 'BOTTLE',
+      amount: 120,
+      duration: 0,
+      leftDuration: 0,
+      rightDuration: 0,
+      lastBreastSide: null,
+      bottleContentType: 'FORMULA',
+    }
+
+    const after = buildFeedingHourlyComparison([newFeeding])
+    expect(after[9].todayCount).toBe(1)
+    expect(after[9].todayMl).toBe(120)
+  })
+
+  it('昨日以前の記録は今日のカウントに含まれない', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(NOW_UTC))
+
+    // 昨日 JST 09:00（UTC 2026-03-18T00:00:00Z）
+    const yesterdayFeeding: NormalizedFeeding = {
+      id: 3,
+      timestamp: '2026-03-18T00:00:00+00:00', // 昨日 JST 09:00
+      type: 'BREAST',
+      amount: 0,
+      duration: 15,
+      leftDuration: 8,
+      rightDuration: 7,
+      lastBreastSide: 'LEFT',
+      bottleContentType: null,
+    }
+
+    const result = buildFeedingHourlyComparison([yesterdayFeeding])
+
+    // 今日のカウントは常に 0
+    result.forEach(p => {
+      expect(p.todayCount).toBe(0)
+    })
+    // 7日平均には含まれる（yesterday は直近7日のうちの1日）
+    expect(result[9].avg7Count).toBeGreaterThan(0)
   })
 })

--- a/frontend/hooks/useBaseRecord.ts
+++ b/frontend/hooks/useBaseRecord.ts
@@ -43,7 +43,12 @@ export function useBaseRecord<T, TCreate, TUpdate>(
     }
 
     const newRecord = await api.post<T, TCreate>(`/${endpoint}/`, record);
-    mutate();
+    // 楽観的更新: 新レコードを即座にキャッシュ先頭に追加してチャートを即時更新し、
+    // バックグラウンドで再検証して最新データを取得する
+    await mutate(
+      (current: T[] | undefined) => (newRecord ? [newRecord, ...(current ?? [])] : (current ?? [])),
+      { revalidate: true }
+    );
     // 実績解除があれば通知
     const r = newRecord as Record<string, unknown> | undefined;
     if (r && Array.isArray(r.unlocked_achievements) && r.unlocked_achievements.length > 0) {


### PR DESCRIPTION
## 問題

授乳ページの「比較」ビュー（今日 vs 7日平均グラフ）で、記録を追加してもグラフが更新されなかった。

## 原因

`useBaseRecord.add()` 内で `mutate()` を fire-and-forget（await なし）で呼んでいたため、SWRの再検証（GETリクエスト）が完了するまでキャッシュが更新されなかった。

## 修正

オプティミスティック更新に変更：
1. POST完了直後に新レコードをSWRキャッシュ先頭へ即座に挿入
2. `revalidate: true` でバックグラウンド再検証も継続

授乳・おむつ・睡眠などすべての記録タイプで記録追加後にチャートが即時更新される。

## テスト

`buildFeedingHourlyComparison` のユニットテストを追加（今日の記録フィルタリング・累積集計の検証）