### PR TITLE
✍️ Scribe: AI設定仕様書のデータモデル定義の重複を修正

### DIFF
--- a/.specify/specs/settings/ai_settings.md
+++ b/.specify/specs/settings/ai_settings.md
@@ -79,7 +79,6 @@ interface AISettings {
   ai_enabled_chat: boolean;
   ai_enabled_summary: boolean;
   ai_enabled_feedback: boolean;
-  llm_reasoning_effort: string;
 }
 
 interface AISettingsSummary {


### PR DESCRIPTION
💡 何を: `.specify/specs/settings/ai_settings.md` 内の `AISettings` インターフェースから、重複していた `llm_reasoning_effort: string;` の一方を削除しました。
🔍 発見: ドキュメントのインターフェース定義内で、同一のプロパティが不注意により2回記述されており、実際のTypeScriptインターフェース（`frontend/hooks/useAISettings.ts`等）と合致しない不整合状態にありました。
🎯 影響: 仕様書の型定義が正確になることで、開発者がインターフェースを参照する際の混乱（なぜ2つあるのか等）を防ぎます。

---
*PR created automatically by Jules for task [3764655748405964532](https://jules.google.com/task/3764655748405964532) started by @eburairu*