### PR TITLE
fix: Pythonコードレビューで指摘されたHIGH/MEDIUM問題を修正

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -78,7 +78,7 @@ def get_current_user(request: Request, response: Response, db: db_dependency):
     return user
 
 
-def get_current_superadmin(current_user=Depends(get_current_user)):
+def get_current_superadmin(current_user: User = Depends(get_current_user)) -> User:
     if not current_user.is_superadmin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -87,8 +87,8 @@ def get_current_superadmin(current_user=Depends(get_current_user)):
     return current_user
 
 
-user_dependency = Annotated[object, Depends(get_current_user)]
-superadmin_dependency = Annotated[object, Depends(get_current_superadmin)]
+user_dependency = Annotated[User, Depends(get_current_user)]
+superadmin_dependency = Annotated[User, Depends(get_current_superadmin)]
 
 
 def verify_baby_access(

--- a/app/main.py
+++ b/app/main.py
@@ -51,7 +51,13 @@ app.add_middleware(
 app.add_middleware(SecurityHeadersMiddleware)
 
 # Trusted Host Middleware (Security Enhancement)
-allowed_hosts = os.getenv("ALLOWED_HOSTS", "*").split(",")
+_allowed_hosts_env = os.getenv("ALLOWED_HOSTS", "*")
+if _allowed_hosts_env == "*":
+    logger.warning(
+        "ALLOWED_HOSTS is set to '*' — TrustedHostMiddleware is effectively disabled. "
+        "Set ALLOWED_HOSTS to a comma-separated list of allowed hostnames in production."
+    )
+allowed_hosts = _allowed_hosts_env.split(",")
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=allowed_hosts)
 
 from app.routers import auth, family, baby, notifications, admin

--- a/app/routers/ai_settings.py
+++ b/app/routers/ai_settings.py
@@ -15,6 +15,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/ai", tags=["ai-settings"])
 
+# 書き込み可能なAI設定キーの許可リスト
+ALLOWED_AI_SETTING_KEYS = {
+    "ai_enabled_summary",
+    "ai_enabled_chat",
+    "ai_enabled_feedback",
+    "llm_model",
+    "llm_temperature",
+    "llm_max_tokens",
+    "llm_reasoning_effort",
+}
+
 ai_settings_limiter = RateLimiter(
     requests_limit=RATE_LIMIT_AI_SETTINGS_REQUESTS,
     time_window=RATE_LIMIT_AI_SETTINGS_WINDOW,
@@ -26,7 +37,7 @@ def verify_admin_access(db: Session, user: User):
     ユーザーが SuperAdmin であるか検証する。
     """
     if not user.is_superadmin:
-        logger.warning(f"Unauthorized superadmin access attempt by user {user.id}")
+        logger.warning("Unauthorized superadmin access attempt by user %s", user.id)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="SuperAdmin access required"
@@ -64,6 +75,14 @@ def update_ai_settings(
     """
     verify_admin_access(db, current_user)
     
+    # 許可リストにないキーは拒否
+    unknown_keys = set(payload.settings.keys()) - ALLOWED_AI_SETTING_KEYS
+    if unknown_keys:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown setting keys: {', '.join(sorted(unknown_keys))}",
+        )
+
     updated_keys = []
     for key, value in payload.settings.items():
         # 既存の設定を確認

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -82,24 +82,23 @@ async def change_password(
 ) -> None:
     if not await verify_password_async(req.current_password, current_user.hashed_password):
         raise HTTPException(status_code=400, detail="Current password is incorrect")
-    current_user.hashed_password = await get_password_hash_async(req.new_password)
+
+    ip_address = get_client_ip(request)
     current_token = request.cookies.get("access_token")
     current_token_hash = hash_token(current_token) if current_token else None
-    
-    def logout_other_sessions():
-        db.query(UserSession).filter(
-            UserSession.user_id == current_user.id,
-            UserSession.token != current_token_hash,
-        ).delete()
-        db.commit()
 
-    await run_in_threadpool(logout_other_sessions)
-    
+    current_user.hashed_password = await get_password_hash_async(req.new_password)
+    db.query(UserSession).filter(
+        UserSession.user_id == current_user.id,
+        UserSession.token != current_token_hash,
+    ).delete()
+    db.commit()
+
     background_tasks.add_task(
         log_event,
-        action="PASSWORD_CHANGE", 
-        user_id=current_user.id, 
-        ip_address=get_client_ip(request)
+        action="PASSWORD_CHANGE",
+        user_id=current_user.id,
+        ip_address=ip_address,
     )
 
 
@@ -194,7 +193,7 @@ async def register_family(
         action="REGISTER_FAMILY",
         user_id=new_user.id,
         details={"family_id": new_family.id, "family_name": new_family.name},
-        ip_address=get_client_ip(request)
+        ip_address=ip_address,
     )
     
     return new_family
@@ -268,9 +267,9 @@ async def join_family(
         action="JOIN_FAMILY",
         user_id=new_user.id,
         details={"family_id": family.id, "family_name": family.name},
-        ip_address=get_client_ip(request)
+        ip_address=ip_address,
     )
-    
+
     return UserResponse(
         id=new_user.id,
         username=new_user.username,
@@ -334,7 +333,7 @@ async def login(
         log_event,
         action="LOGIN",
         user_id=user.id,
-        ip_address=get_client_ip(request)
+        ip_address=ip_address,
     )
     
     return UserResponse(

--- a/app/routers/baby.py
+++ b/app/routers/baby.py
@@ -366,8 +366,7 @@ def get_records(
                 for rt, rid, count in counts:
                     comment_counts[(rt, rid)] = count
             except Exception as e:
-                # In case table doesn't exist or query fails
-                pass
+                logger.warning("Failed to fetch comment counts for baby %s: %s", baby_id, e)
 
     # User を一括取得してマップを作成（truncatedされたレコード群のみ）
     user_ids = {r[2] for r in truncated_records if r[2] is not None}

--- a/app/services/ai_settings.py
+++ b/app/services/ai_settings.py
@@ -1,9 +1,12 @@
+import logging
 import os
 from typing import Dict, Any, List
 from sqlalchemy.orm import Session
 from google import genai
 from app.models.system_settings import SystemSetting
 from app.core.constants import AI_MAX_TOKENS, AI_TEMPERATURE
+
+logger = logging.getLogger(__name__)
 
 
 def get_ai_config(db: Session) -> Dict[str, Any]:
@@ -63,7 +66,7 @@ def get_available_llm_models() -> List[Dict[str, str]]:
                 })
         return models
     except Exception as e:
-        print(f"Error fetching models: {e}")
+        logger.warning("Error fetching available LLM models: %s", e)
         # フォールバックとして主要なモデルを返す
         return [
             {"id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro", "description": "Highly capable model"},

--- a/app/utils/audit.py
+++ b/app/utils/audit.py
@@ -13,19 +13,32 @@ def get_client_ip(request: Request) -> Optional[str]:
     """
     Safely extract the client IP address from the request.
     Handles X-Forwarded-For headers from proxies like Render.
+
+    Uses the rightmost IP in X-Forwarded-For to prevent spoofing:
+    clients can inject arbitrary values at the start of the header,
+    but the trusted proxy (Render) always appends the real client IP
+    at the end. Set TRUSTED_PROXY_COUNT to the number of proxy hops
+    (default 1) to pick the correct entry from the right.
     """
+    import os
     x_forwarded_for = request.headers.get("X-Forwarded-For")
     if x_forwarded_for:
-        # X-Forwarded-For can be a comma-separated list of IPs.
-        # The first one is typically the original client IP.
-        client_ip = x_forwarded_for.split(",")[0].strip()
-        if client_ip:
-            return client_ip
-            
+        ips = [ip.strip() for ip in x_forwarded_for.split(",") if ip.strip()]
+        if ips:
+            try:
+                trusted_proxy_count = int(os.environ.get("TRUSTED_PROXY_COUNT", "1"))
+            except ValueError:
+                trusted_proxy_count = 1
+            # The client IP is at index -(trusted_proxy_count) from the right.
+            # With 1 trusted proxy, the last entry was appended by that proxy
+            # and reflects the real client.
+            idx = max(0, len(ips) - trusted_proxy_count)
+            return ips[idx]
+
     # Fallback to standard client host
     if request.client and request.client.host:
         return request.client.host
-        
+
     return None
 
 def log_event(
@@ -55,7 +68,7 @@ def log_event(
         db.add(audit_entry)
         db.commit()
     except Exception as e:
-        logger.error(f"Failed to record audit log: {e}")
+        logger.error("Failed to record audit log: %s", e)
     finally:
         db.close()
 
@@ -66,9 +79,9 @@ def cleanup_old_audit_logs(db: Session, days: int = 90) -> int:
     """
     try:
         threshold_date = datetime.now(timezone.utc) - timedelta(days=days)
-        
+
         deleted_count = db.query(AuditLog).filter(AuditLog.created_at < threshold_date).delete(synchronize_session=False)
         return deleted_count
     except Exception as e:
-        logger.error(f"Failed to cleanup old audit logs: {e}")
+        logger.error("Failed to cleanup old audit logs: %s", e)
         return 0

--- a/app/utils/rate_limit.py
+++ b/app/utils/rate_limit.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import threading
 import time
 from fastapi import Request, HTTPException, status
 from app.utils.audit import get_client_ip
@@ -19,6 +20,7 @@ class RateLimiter:
         self.max_size = max_size
         self.error_message = error_message
         self.requests = defaultdict(list)
+        self._lock = threading.Lock()
 
     def check(self, key: str):
         """
@@ -27,35 +29,36 @@ class RateLimiter:
         """
         now = time.time()
 
-        # Clean up old requests for this key first
-        if key in self.requests:
-            self.requests[key] = [
-                req_time for req_time in self.requests[key]
-                if now - req_time < self.time_window
-            ]
-            # If the key becomes empty, remove it
-            if not self.requests[key]:
-                del self.requests[key]
+        with self._lock:
+            # Clean up old requests for this key first
+            if key in self.requests:
+                self.requests[key] = [
+                    req_time for req_time in self.requests[key]
+                    if now - req_time < self.time_window
+                ]
+                # If the key becomes empty, remove it
+                if not self.requests[key]:
+                    del self.requests[key]
 
-        # If this is a new key (or was deleted above), check max_size before adding
-        if key not in self.requests and len(self.requests) >= self.max_size:
-            # Instead of clearing everything (DoS vulnerability), remove the oldest entry
-            try:
-                oldest_key = next(iter(self.requests))
-                del self.requests[oldest_key]
-            except StopIteration:
-                pass  # Should not happen if len >= max_size > 0
+            # If this is a new key (or was deleted above), check max_size before adding
+            if key not in self.requests and len(self.requests) >= self.max_size:
+                # Instead of clearing everything (DoS vulnerability), remove the oldest entry
+                try:
+                    oldest_key = next(iter(self.requests))
+                    del self.requests[oldest_key]
+                except StopIteration:
+                    pass  # Should not happen if len >= max_size > 0
 
-        # Check request limit
-        # Accessing self.requests[key] creates the list if it doesn't exist (defaultdict)
-        current_requests = self.requests[key]
-        if len(current_requests) >= self.requests_limit:
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail=self.error_message,
-            )
+            # Check request limit
+            # Accessing self.requests[key] creates the list if it doesn't exist (defaultdict)
+            current_requests = self.requests[key]
+            if len(current_requests) >= self.requests_limit:
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail=self.error_message,
+                )
 
-        current_requests.append(now)
+            current_requests.append(now)
 
     async def __call__(self, request: Request):
         # Safely extract IP considering X-Forwarded-For

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,18 +1,38 @@
 from fastapi import Request
 from app.utils.audit import get_client_ip
 
-def test_get_client_ip_with_x_forwarded_for():
-    # Simulate a request from a proxy (e.g. Render)
+
+def test_get_client_ip_with_single_x_forwarded_for():
+    # 正常ケース: Render が1ホップで client IP を1エントリ追加した場合
     scope = {
         "type": "http",
         "headers": [
-            (b"x-forwarded-for", b"203.0.113.195, 10.0.0.1")
+            (b"x-forwarded-for", b"203.0.113.195")
         ],
-        "client": ("10.0.0.2", 12345),
+        "client": ("10.0.0.1", 12345),
     }
     request = Request(scope)
     ip = get_client_ip(request)
     assert ip == "203.0.113.195"
+
+
+def test_get_client_ip_anti_spoofing(monkeypatch):
+    # セキュリティテスト: クライアントが X-Forwarded-For をスプーフィングした場合
+    # クライアント (real_ip=203.0.113.195) が "X-Forwarded-For: spoofed_ip" を送信
+    # → Render が real_ip を末尾に追加: "spoofed_ip, 203.0.113.195"
+    # TRUSTED_PROXY_COUNT=1 ならば末尾の 203.0.113.195 (Render が追加した本物) を返す
+    monkeypatch.setenv("TRUSTED_PROXY_COUNT", "1")
+    scope = {
+        "type": "http",
+        "headers": [
+            (b"x-forwarded-for", b"spoofed_ip, 203.0.113.195")
+        ],
+        "client": ("10.0.0.1", 12345),
+    }
+    request = Request(scope)
+    ip = get_client_ip(request)
+    assert ip == "203.0.113.195"
+
 
 def test_get_client_ip_without_x_forwarded_for():
     # Simulate a direct request
@@ -24,6 +44,7 @@ def test_get_client_ip_without_x_forwarded_for():
     request = Request(scope)
     ip = get_client_ip(request)
     assert ip == "192.168.1.100"
+
 
 def test_get_client_ip_empty():
     scope = {


### PR DESCRIPTION
## Summary

- **[HIGH] RateLimiter スレッド安全性**: `threading.Lock` を追加。並行リクエスト時のデータ競合を防止
- **[HIGH] X-Forwarded-For スプーフィング対策**: `TRUSTED_PROXY_COUNT` 環境変数（デフォルト1）で末尾からN番目のIPを使用。クライアントが先頭に偽装IPを挿入しても本物のIPを取得できる
- **[HIGH] TrustedHostMiddleware**: `ALLOWED_HOSTS="*"` 時に起動ログへ警告を出力
- **[HIGH] AI設定allowlist**: `PATCH /api/ai/settings` で許可キー以外を422で拒否
- **[HIGH] 型アノテーション修正**: `user_dependency` / `superadmin_dependency` の型を `object` → `User` に変更
- **[MEDIUM] change_password アトミック化**: パスワード更新とセッション削除を単一 `db.commit()` にまとめ、`run_in_threadpool` を除去
- **[MEDIUM] get_client_ip 二重呼び出し削除**: background_tasks で再度 `get_client_ip(request)` を呼んでいた箇所を事前抽出した変数に統一
- **[MEDIUM] except Exception: pass の除去**: `baby.py` で例外を握りつぶしていた箇所を `logger.warning` に置き換え
- **[MEDIUM] print() → logging**: `services/ai_settings.py` の `print()` を `logger.warning()` に変更
- **[LOW] f-string ロギング統一**: `audit.py` の `logger.error(f"...")` を `%s` 形式に変更

## Test plan

- [x] 全テスト通過: 335 passed, 1 skipped (164s)
- [x] `test_audit.py`: スプーフィング防止モデルのテストケースを追加
- [ ] レート制限の動作確認（スレッド競合なし）
- [ ] AI設定の不正キーが422になること