### PR TITLE
⚡ Bolt: `AchievementTab` の不要な再計算を削減

### DIFF
--- a/frontend/components/achievements/AchievementTab.tsx
+++ b/frontend/components/achievements/AchievementTab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useMemo } from "react"
 import useSWR from "swr"
 import { fetcher } from "@/lib/api"
 import { RARITY_COLOR, RARITY_LABEL, CATEGORY_LABEL } from "@/lib/achievements"
@@ -33,6 +33,18 @@ export function AchievementTab({ babyId }: AchievementTabProps) {
     )
     const [selected, setSelected] = useState<BabyAchievementResponse | null>(null)
 
+    // カテゴリ別にグループ化
+    const grouped = useMemo(() => {
+        if (!data) return {}
+        return CATEGORY_ORDER.reduce<Record<string, BabyAchievementResponse[]>>(
+            (acc, cat) => {
+                acc[cat] = data.filter((a) => a.category === cat)
+                return acc
+            },
+            {}
+        )
+    }, [data])
+
     if (isLoading) {
         return (
             <div className="py-8 text-center text-sm text-gray-400 dark:text-zinc-500">
@@ -54,15 +66,6 @@ export function AchievementTab({ babyId }: AchievementTabProps) {
             </div>
         )
     }
-
-    // カテゴリ別にグループ化
-    const grouped = CATEGORY_ORDER.reduce<Record<string, BabyAchievementResponse[]>>(
-        (acc, cat) => {
-            acc[cat] = data.filter((a) => a.category === cat)
-            return acc
-        },
-        {}
-    )
 
     return (
         <>


### PR DESCRIPTION
💡 何を:
`AchievementTab` コンポーネント内で実績データ（`data`）をカテゴリ別にグループ化する `reduce` 処理を `useMemo` でラップしました。また、フックの呼び出し順序違反（`rules-of-hooks`）を防ぐため、`useMemo` を早期リターン（`if (isLoading)`）の前に配置しました。

🎯 なぜ:
ローカルステート（`selected`）が変更された際（例：実績カードをタップしてモーダルを開く際）に、実績データの再グループ化計算が不要に実行されるのを防ぐためです。

📊 影響:
モーダル開閉時の不要な配列の走査およびオブジェクトの生成がスキップされ、再レンダリングが軽量化されます。

🔬 測定:
`frontend` ディレクトリ内で `pnpm test --run` および `pnpm eslint components/achievements/AchievementTab.tsx` を実行し、既存のテストとLintがすべて通過することを確認しました。

---
*PR created automatically by Jules for task [14348273466984131092](https://jules.google.com/task/14348273466984131092) started by @eburairu*