### PR TITLE
feat: ダッシュボードにAIフィードバック警告バッジを表示

### DIFF
--- a/app/routers/baby.py
+++ b/app/routers/baby.py
@@ -36,6 +36,8 @@ class UnifiedRecord(BaseModel):
     timestamp: datetime
     details: dict
     comment_count: int = 0
+    has_ai_feedback: bool = False
+    has_ai_concern: bool = False
     recorded_by_display_name: Optional[str] = None
     updated_at: Optional[datetime] = None
 
@@ -337,6 +339,8 @@ def get_records(
 
     # Fetch comment counts ONLY for the truncated records
     comment_counts = {}
+    ai_feedback_set: set[tuple[str, int]] = set()
+    ai_concern_set: set[tuple[str, int]] = set()
     record_ids_by_type = defaultdict(list)
     for r in truncated_records:
         rec_id, rec_type = r[0], r[1]
@@ -365,6 +369,23 @@ def get_records(
 
                 for rt, rid, count in counts:
                     comment_counts[(rt, rid)] = count
+
+                            # AIフィードバック・AI警告フラグ: AIコメントが存在する記録を取得
+                ai_rows = db.query(
+                    RecordComment.record_type,
+                    RecordComment.record_id,
+                    RecordComment.ai_has_concern,
+                ).filter(
+                    RecordComment.baby_id == baby_id,
+                    RecordComment.is_ai_generated == True,
+                    RecordComment.is_deleted == False,
+                    or_(*conditions)
+                ).all()
+
+                for rt, rid, concern in ai_rows:
+                    ai_feedback_set.add((rt, rid))
+                    if concern:
+                        ai_concern_set.add((rt, rid))
             except Exception as e:
                 logger.warning("Failed to fetch comment counts for baby %s: %s", baby_id, e)
 
@@ -380,6 +401,8 @@ def get_records(
             timestamp=ts,
             details=details,
             comment_count=comment_counts.get((rec_type, rec_id), 0),
+            has_ai_feedback=(rec_type, rec_id) in ai_feedback_set,
+            has_ai_concern=(rec_type, rec_id) in ai_concern_set,
             recorded_by_display_name=user_map.get(user_id),
             updated_at=updated_at,
         )

--- a/frontend/components/dashboard/ActivityItem.tsx
+++ b/frontend/components/dashboard/ActivityItem.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { BabyRecord } from "@/types/record"
 import { formatElapsed } from "@/lib/ageUtils"
 import { formatDateTime } from "@/lib/dateUtils"
-import { MessageCircle, User, StickyNote } from "lucide-react"
+import { MessageCircle, User, StickyNote, Bot, TriangleAlert } from "lucide-react"
 import { RECORD_TYPE_LABELS, RECORD_TYPE_LUCIDE_ICONS, RECORD_TYPE_COLORS, RECORD_TYPE_BG_COLORS } from "@/constants/ui"
 import { AppIcons } from "@/constants/icons"
 import { Hexagon } from "@/components/ui/hexagon"
@@ -63,11 +63,26 @@ export const ActivityItem = React.memo(function ActivityItem({ record, onClick }
                                 {record.recorded_by_display_name}
                             </span>
                         ) : null}
+                        {record.has_ai_concern ? (
+                            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-950/50 border border-amber-300 dark:border-amber-700">
+                                <TriangleAlert className="w-3 h-3 text-amber-600 dark:text-amber-400" />
+                                <span className="text-[10px] font-semibold text-amber-700 dark:text-amber-400">
+                                    AI要確認
+                                </span>
+                            </span>
+                        ) : record.has_ai_feedback ? (
+                            <span className="inline-flex items-center gap-1">
+                                <Bot className="w-3 h-3 text-indigo-400" />
+                                <span className="text-[10px] font-medium text-indigo-500 dark:text-indigo-400">
+                                    AIフィードバック
+                                </span>
+                            </span>
+                        ) : null}
                         {record.comment_count > 0 ? (
                             <span className="inline-flex items-center gap-1">
                                 <MessageCircle className="w-3 h-3 text-orange-400" />
                                 <span className="text-[10px] font-medium text-orange-500">
-                                    {record.comment_count}件のメッセージ
+                                    {record.comment_count}件
                                 </span>
                             </span>
                         ) : null}

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3639,6 +3639,16 @@
             "title": "Details",
             "type": "object"
           },
+          "has_ai_concern": {
+            "default": false,
+            "title": "Has Ai Concern",
+            "type": "boolean"
+          },
+          "has_ai_feedback": {
+            "default": false,
+            "title": "Has Ai Feedback",
+            "type": "boolean"
+          },
           "id": {
             "title": "Id",
             "type": "integer"

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -2476,6 +2476,16 @@ export interface components {
             details: {
                 [key: string]: unknown;
             };
+            /**
+             * Has Ai Concern
+             * @default false
+             */
+            has_ai_concern: boolean;
+            /**
+             * Has Ai Feedback
+             * @default false
+             */
+            has_ai_feedback: boolean;
             /** Id */
             id: number;
             /** Recorded By Display Name */

--- a/frontend/types/record.ts
+++ b/frontend/types/record.ts
@@ -7,6 +7,8 @@ export interface BabyRecord {
         [key: string]: unknown;
     };
     comment_count: number;
+    has_ai_feedback?: boolean;
+    has_ai_concern?: boolean;
     recorded_by_display_name?: string | null;
     updated_at?: string;
 }

--- a/tests/test_records_ai_feedback_flags.py
+++ b/tests/test_records_ai_feedback_flags.py
@@ -1,0 +1,126 @@
+"""
+GET /api/babies/{baby_id}/records で返される
+has_ai_feedback / has_ai_concern フラグのテスト
+"""
+import pytest
+from datetime import datetime, timezone
+
+from app.main import app
+from app.dependencies import get_current_user
+from app.models.user import User
+from app.models.family import Family, FamilyUser, UserRole
+from app.models.baby import Baby
+from app.models.feeding import Feeding
+from app.models.comment import RecordComment
+from app.models.enums import FeedingType
+
+
+@pytest.fixture
+def setup(db):
+    user = User(username="testflags", hashed_password="pw")
+    db.add(user)
+    db.commit()
+
+    family = Family(name="FlagFamily", invite_code="FLAGCODE")
+    db.add(family)
+    db.commit()
+
+    fu = FamilyUser(family_id=family.id, user_id=user.id, role=UserRole.ADMIN)
+    db.add(fu)
+    baby = Baby(family_id=family.id, name="FlagBaby")
+    db.add(baby)
+    db.commit()
+
+    now = datetime.now(timezone.utc)
+    feeding = Feeding(
+        user_id=user.id,
+        baby_id=baby.id,
+        feeding_time=now,
+        feeding_type=FeedingType.BREAST,
+    )
+    db.add(feeding)
+    db.commit()
+
+    return {"user": user, "baby": baby, "feeding": feeding}
+
+
+def test_no_comments_no_flags(client, db, setup):
+    """コメントなしの記録はフラグが両方 False"""
+    app.dependency_overrides[get_current_user] = lambda: setup["user"]
+    resp = client.get(f"/api/babies/{setup['baby'].id}/records?limit=10")
+    assert resp.status_code == 200
+    records = resp.json()
+    feeding_record = next(r for r in records if r["type"] == "feeding")
+    assert feeding_record["has_ai_feedback"] is False
+    assert feeding_record["has_ai_concern"] is False
+
+
+def test_ai_feedback_no_concern(client, db, setup):
+    """AI フィードバックあり・警告なし → has_ai_feedback=True, has_ai_concern=False"""
+    feeding = setup["feeding"]
+    comment = RecordComment(
+        baby_id=setup["baby"].id,
+        record_type="feeding",
+        record_id=feeding.id,
+        content="問題ありません",
+        is_ai_generated=True,
+        ai_has_concern=False,
+    )
+    db.add(comment)
+    db.commit()
+
+    app.dependency_overrides[get_current_user] = lambda: setup["user"]
+    resp = client.get(f"/api/babies/{setup['baby'].id}/records?limit=10")
+    assert resp.status_code == 200
+    records = resp.json()
+    feeding_record = next(r for r in records if r["type"] == "feeding")
+    assert feeding_record["has_ai_feedback"] is True
+    assert feeding_record["has_ai_concern"] is False
+
+
+def test_ai_feedback_with_concern(client, db, setup):
+    """AI フィードバックあり・警告あり → has_ai_feedback=True, has_ai_concern=True"""
+    feeding = setup["feeding"]
+    comment = RecordComment(
+        baby_id=setup["baby"].id,
+        record_type="feeding",
+        record_id=feeding.id,
+        content="授乳間隔が長すぎます",
+        is_ai_generated=True,
+        ai_has_concern=True,
+    )
+    db.add(comment)
+    db.commit()
+
+    app.dependency_overrides[get_current_user] = lambda: setup["user"]
+    resp = client.get(f"/api/babies/{setup['baby'].id}/records?limit=10")
+    assert resp.status_code == 200
+    records = resp.json()
+    feeding_record = next(r for r in records if r["type"] == "feeding")
+    assert feeding_record["has_ai_feedback"] is True
+    assert feeding_record["has_ai_concern"] is True
+
+
+def test_user_comment_only_no_ai_flags(client, db, setup):
+    """ユーザーコメントのみ → フラグは両方 False、comment_count は 1"""
+    user = setup["user"]
+    feeding = setup["feeding"]
+    comment = RecordComment(
+        baby_id=setup["baby"].id,
+        record_type="feeding",
+        record_id=feeding.id,
+        user_id=user.id,
+        content="良い感じです",
+        is_ai_generated=False,
+    )
+    db.add(comment)
+    db.commit()
+
+    app.dependency_overrides[get_current_user] = lambda: setup["user"]
+    resp = client.get(f"/api/babies/{setup['baby'].id}/records?limit=10")
+    assert resp.status_code == 200
+    records = resp.json()
+    feeding_record = next(r for r in records if r["type"] == "feeding")
+    assert feeding_record["has_ai_feedback"] is False
+    assert feeding_record["has_ai_concern"] is False
+    assert feeding_record["comment_count"] == 1


### PR DESCRIPTION
## 概要

ダッシュボードの「最近の記録」フィードで、AIフィードバックの有無・警告の有無を視覚的に区別できるようにした。

## 変更内容

### バックエンド
- UnifiedRecord に has_ai_feedback / has_ai_concern フラグを追加
- コメントカウント取得と同一クエリでAIフラグを一括取得（追加DBクエリは1本のみ）

### フロントエンド
- BabyRecord 型に has_ai_feedback / has_ai_concern を追加
- ActivityItem のバッジ表示を3パターンに分岐:
  - has_ai_concern=true: 琥珀色「AI要確認」バッジ
  - has_ai_feedback=true: 藍色「AIフィードバック」バッジ
  - コメントあり: オレンジ「X件」バッジ（従来どおり）

### テスト
- tests/test_records_ai_feedback_flags.py を新規追加（4件）

## テスト計画
- [ ] ローカルでAIフィードバックを生成し、ダッシュボードに琥珀色バッジが表示されることを確認
- [ ] 警告なしAIフィードバックで藍色バッジが表示されることを確認
- [ ] ユーザーコメントのみの場合、AIバッジが表示されないことを確認