### PR TITLE
✍️ Scribe: UnifiedRecord スキーマと仕様書の同期 (AIフィードバックフラグ)

### DIFF
--- a/.specify/specs/infrastructure/system_design.md
+++ b/.specify/specs/infrastructure/system_design.md
@@ -100,6 +100,8 @@ baby-app/
 - **`timestamp`**: 記録の主たる日時
 - **`details`**: 種別ごとの詳細データ（`notes` など）を格納するオブジェクト
 - **`comment_count`**: 記録に対するコメント数
+- **`has_ai_feedback`**: AIからのフィードバックが存在するかどうか
+- **`has_ai_concern`**: AIからの懸念事項（受診勧奨など）が存在するかどうか
 - **`recorded_by_display_name`**: 記録者の表示名
 - **`updated_at`**: 記録の最終更新日時
 

--- a/.specify/specs/social/record_comments.md
+++ b/.specify/specs/social/record_comments.md
@@ -94,6 +94,8 @@ class UnifiedRecord(BaseModel):
     timestamp: datetime
     details: dict
     comment_count: int = 0  # 追加
+    has_ai_feedback: bool = False
+    has_ai_concern: bool = False
     recorded_by_display_name: Optional[str] = None
     updated_at: Optional[datetime] = None
 

--- a/.specify/specs/ui/dashboard.md
+++ b/.specify/specs/ui/dashboard.md
@@ -185,6 +185,8 @@ interface UnifiedRecord {
   type: "feeding" | "sleep" | "diaper" | "growth" | "note" | "contraction";
   timestamp: string; // ISO 8601 (JST)
   comment_count: number;
+  has_ai_feedback: boolean;
+  has_ai_concern: boolean;
   recorded_by_display_name: string | null;
   updated_at: string | null;
   details: RecordDetails; // 各タイプに応じた詳細情報


### PR DESCRIPTION
💡 何を
- `.specify/specs/infrastructure/system_design.md` の `UnifiedRecord` 説明リストに `has_ai_feedback` と `has_ai_concern` を追記。
- `.specify/specs/ui/dashboard.md` の `UnifiedRecord` インターフェース定義に `has_ai_feedback: boolean;` と `has_ai_concern: boolean;` を追記。
- `.specify/specs/social/record_comments.md` の `UnifiedRecord` クラス定義に `has_ai_feedback: bool = False` と `has_ai_concern: bool = False` を追記。

🔍 発見
- `app/routers/baby.py` や `frontend/types/record.ts` などの実装において、タイムライン等で返される `UnifiedRecord` モデルに AI フィードバック用のフラグ (`has_ai_feedback`, `has_ai_concern`) が追加されていましたが、関連する複数の仕様書でこれらのフィールドが欠落している（古いスキーマのままになっている）という仕様書のドリフトパターンを発見しました。

🎯 影響
- フロントエンド開発者が仕様書だけを読んで実装を進める際の、レスポンスフィールドの誤認（「AI フィードバック情報が UnifiedRecord には含まれていない」と勘違いし、余計な API コールを追加してしまう等の手戻り）を防ぐことができます。
- データ構造の「生きたドキュメント」としての正確性が回復しました。

---
*PR created automatically by Jules for task [4887334647474089192](https://jules.google.com/task/4887334647474089192) started by @eburairu*