### PR TITLE
feat: ダッシュボードのアニメーションを拡充（カウントアップ・浮遊・タップフィードバック）

### DIFF
--- a/frontend/components/dashboard/BabyProfileCard.tsx
+++ b/frontend/components/dashboard/BabyProfileCard.tsx
@@ -1,5 +1,6 @@
 "use client"
 import React, { useState, useId } from "react"
+import { motion } from "framer-motion"
 import { Sparkles, ChevronDown } from "lucide-react"
 import { calcAge } from "@/lib/ageUtils"
 import { getPrenatalLabel } from "@/lib/babyUtils"
@@ -31,15 +32,20 @@ export const BabyProfileCard = React.memo(function BabyProfileCard({ babies, sel
         <div className="rounded-2xl p-4 transition-colors bg-gradient-to-br from-pink-50 to-purple-50 dark:from-pink-950/20 dark:to-purple-950/20 shadow-sm border border-pink-100/50 dark:border-pink-900/20">
             <div className="flex flex-col gap-3">
                 <div className="flex items-center gap-4">
-                    <Hexagon 
-                        size={60} 
-                        color="var(--primary)" 
-                        className="text-white"
-                        borderColor="var(--primary)"
-                        borderWidth={2}
+                    <motion.div
+                        animate={{ y: [0, -6, 0] }}
+                        transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
                     >
-                        <span className="text-2xl font-bold">{initial}</span>
-                    </Hexagon>
+                        <Hexagon
+                            size={60}
+                            color="var(--primary)"
+                            className="text-white"
+                            borderColor="var(--primary)"
+                            borderWidth={2}
+                        >
+                            <span className="text-2xl font-bold">{initial}</span>
+                        </Hexagon>
+                    </motion.div>
                     <div>
                         <h1 className="text-2xl font-bold text-gray-900 dark:text-zinc-100">{selected?.name}</h1>
                         {age ? (

--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -10,6 +10,7 @@ import { calcProgress, isOverThreshold } from "@/lib/indicatorUtils"
 import Link from "next/link"
 import { useTick } from "@/hooks/useTick"
 import { AppIcons } from "@/constants/icons"
+import { AnimatedNumber } from "@/components/ui/animated-number"
 
 export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isError, isLoading, size, thresholdMinutes }: BaseWidgetProps) {
     const tick = useTick()
@@ -48,8 +49,8 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
                 <div className="flex flex-col items-center">
                     <span className="font-bold text-gray-800 dark:text-zinc-200">{lastElapsed}</span>
                     <div className="flex items-center gap-2 mt-0.5 text-[10px] text-gray-500 dark:text-zinc-500">
-                        <span className="flex items-center gap-0.5"><Droplets className="w-2.5 h-2.5" />{wetCount}</span>
-                        <span className="flex items-center gap-0.5"><Biohazard className="w-2.5 h-2.5" />{dirtyCount}</span>
+                        <span className="flex items-center gap-0.5"><Droplets className="w-2.5 h-2.5" /><AnimatedNumber value={wetCount} /></span>
+                        <span className="flex items-center gap-0.5"><Biohazard className="w-2.5 h-2.5" /><AnimatedNumber value={dirtyCount} /></span>
                     </div>
                 </div>
             </HexagonWidgetCard>

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -9,6 +9,7 @@ import { calcProgress, isOverThreshold } from "@/lib/indicatorUtils"
 import { AppIcons } from "@/constants/icons"
 import Link from "next/link"
 import { useTick } from "@/hooks/useTick"
+import { AnimatedNumber } from "@/components/ui/animated-number"
 
 export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isError, isLoading, size, thresholdMinutes }: BaseWidgetProps) {
     const tick = useTick()
@@ -44,7 +45,7 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
             >
                 <div className="flex flex-col items-center">
                     <span className="font-bold text-gray-800 dark:text-zinc-200">{lastElapsed}</span>
-                    <span className="text-[10px] text-gray-500 dark:text-zinc-500 mt-0.5">今日 {todayCount}回</span>
+                    <span className="text-[10px] text-gray-500 dark:text-zinc-500 mt-0.5">今日 <AnimatedNumber value={todayCount} />回</span>
                 </div>
             </HexagonWidgetCard>
         </Link>

--- a/frontend/components/dashboard/HexagonWidgetCard.tsx
+++ b/frontend/components/dashboard/HexagonWidgetCard.tsx
@@ -43,7 +43,7 @@ export const HexagonWidgetCard = ({
     return (
         <div className={cn(
             "relative transition-all duration-300",
-            !isSkeleton && "hover:-translate-y-1",
+            !isSkeleton && "hover:-translate-y-1 active:scale-[0.95]",
             className
         )}>
             <Hexagon 

--- a/frontend/components/dashboard/WidgetCard.tsx
+++ b/frontend/components/dashboard/WidgetCard.tsx
@@ -46,7 +46,7 @@ export function WidgetCard({
     }
 
     return (
-        <Card className="clay-card hover:-translate-y-1 transition-all duration-300">
+        <Card className="clay-card hover:-translate-y-1 active:scale-[0.97] transition-all duration-300">
             <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
                 <CardTitle className="text-sm font-medium flex items-center gap-1" data-sentry-unmask>
                     {title}

--- a/frontend/components/ui/animated-number.tsx
+++ b/frontend/components/ui/animated-number.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { motion, useMotionValue, useTransform, animate } from "framer-motion"
+import { useEffect } from "react"
+
+interface AnimatedNumberProps {
+    value: number
+    className?: string
+}
+
+/**
+ * 数値が変化したとき、前の値から新しい値へカウントアップ/ダウンするアニメーションコンポーネント
+ */
+export function AnimatedNumber({ value, className }: AnimatedNumberProps) {
+    const count = useMotionValue(value)
+    const rounded = useTransform(count, Math.round)
+
+    useEffect(() => {
+        const animation = animate(count, value, {
+            duration: 0.6,
+            ease: "easeOut",
+        })
+        return animation.stop
+    }, [value, count])
+
+    return <motion.span className={className}>{rounded}</motion.span>
+}


### PR DESCRIPTION
## 変更内容

- **AnimatedNumber コンポーネント追加**: framer-motion の `animate` を使い、数値が変化した際に前の値から新しい値へカウントアップ/ダウンするアニメーション
- **授乳・おむつウィジェット**: 今日の授乳回数・おしっこ/うんち回数に AnimatedNumber を適用
- **赤ちゃんアバター浮遊アニメーション**: BabyProfileCard の六角形アバターが 3秒周期でふわふわ上下する
- **タップフィードバック**: HexagonWidgetCard と WidgetCard にタップ時の scale-down（0.95/0.97）を追加

## 技術詳細

AnimatedNumber は useMotionValue + useTransform(count, Math.round) + animate() の framer-motion 標準パターン。duration 0.6s / ease-out。

## テスト計画

- [ ] ダッシュボード表示時にアバターが上下にふわふわ動くこと
- [ ] 記録を追加後、授乳/おむつの回数表示がカウントアップでなめらかに増えること
- [ ] ウィジェットをタップしたとき、軽く縮む感触があること
- [ ] ビルドが通ること（確認済み）