### PR TITLE
feat: UX改善4件（スライドイン・BottomSheet・DailyTip・SWRキャッシュ）

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -25,6 +25,7 @@ import dynamic from "next/dynamic"
 import { resolveThreshold } from '@/lib/thresholdUtils'
 import { calcAge } from '@/lib/ageUtils'
 import { motion, AnimatePresence } from "framer-motion"
+import { DailyTipCard } from "@/components/dashboard/DailyTipCard"
 
 const RecentActivityFeed = dynamic(() => import("@/components/dashboard/RecentActivityFeed").then(mod => mod.RecentActivityFeed), {
     loading: () => <Skeleton className="h-64 w-full rounded-2xl" />,
@@ -188,6 +189,8 @@ export default function DashboardPage() {
                             </motion.div>
                         )}
                     </AnimatePresence>
+
+                    {born && <DailyTipCard ageMonths={ageMonths} />}
 
                     <RecentActivityFeed
                         babyId={actualBabyId}

--- a/frontend/components/dashboard/DailyTipCard.tsx
+++ b/frontend/components/dashboard/DailyTipCard.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { memo } from "react"
+import { Lightbulb } from "lucide-react"
+import { getTodayTip } from "@/lib/daily-tips"
+
+interface Props {
+    ageMonths: number
+}
+
+export const DailyTipCard = memo(function DailyTipCard({ ageMonths }: Props) {
+    const tip = getTodayTip(ageMonths)
+
+    return (
+        <div className="rounded-2xl bg-amber-50 dark:bg-amber-950/20 border border-amber-100 dark:border-amber-900/30 px-4 py-3 flex items-start gap-3">
+            <div className="shrink-0 mt-0.5 w-7 h-7 rounded-full bg-amber-100 dark:bg-amber-900/40 flex items-center justify-center">
+                <Lightbulb className="w-4 h-4 text-amber-500 dark:text-amber-400" />
+            </div>
+            <div className="flex-1 min-w-0">
+                <p className="text-[10px] font-bold uppercase tracking-wider text-amber-500 dark:text-amber-400 mb-0.5">
+                    今日のヒント
+                </p>
+                <p className="text-sm text-gray-700 dark:text-zinc-300 leading-relaxed">
+                    <span className="mr-1.5">{tip.icon}</span>
+                    {tip.text}
+                </p>
+            </div>
+        </div>
+    )
+})

--- a/frontend/components/dashboard/RecentActivityFeed.tsx
+++ b/frontend/components/dashboard/RecentActivityFeed.tsx
@@ -1,5 +1,6 @@
 "use client"
 import React, { useState, useCallback } from "react"
+import { AnimatePresence, motion } from "framer-motion"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { BabyBottleLoading } from "@/components/ui/baby-bottle-loading"
 import { BabyRecord } from "@/types/record"
@@ -36,8 +37,6 @@ export const RecentActivityFeed = React.memo(function RecentActivityFeed({ recor
         threshold: 0.1
     })
 
-    // Handle record click to show detail dialog
-    // Optimized: Memoized to prevent re-rendering all ActivityItems when list grows
     const handleRecordClick = useCallback((record: BabyRecord) => {
         setSelectedRecord(record)
         setDialogOpen(true)
@@ -50,26 +49,38 @@ export const RecentActivityFeed = React.memo(function RecentActivityFeed({ recor
                     <CardTitle className="text-sm font-medium text-gray-700 dark:text-zinc-300">最近の記録</CardTitle>
                 </CardHeader>
                 <CardContent>
-                    {isLoading ? (
+                    {isLoading && recent.length === 0 ? (
                         <div className="flex justify-center py-8">
                             <BabyBottleLoading className="w-8 h-8 text-indigo-400" />
                         </div>
                     ) : recent.length > 0 ? (
                         <>
                             <ul className="space-y-3">
-                                {recent.map((record: BabyRecord, index: number) => (
-                                    <React.Fragment key={`${record.type}-${record.id}`}>
-                                        <ActivityItem
-                                            record={record}
-                                            onClick={handleRecordClick}
-                                        />
-                                        {(index + 1) % 10 === 0 && (
-                                            <li className="list-none">
-                                                <AdUnit slot={process.env.NEXT_PUBLIC_ADSENSE_SLOT_ID ?? ""} />
-                                            </li>
-                                        )}
-                                    </React.Fragment>
-                                ))}
+                                {/* initial={false}: マウント時の既存アイテムはアニメーションしない。新規追加分のみスライドイン */}
+                                <AnimatePresence initial={false} mode="popLayout">
+                                    {recent.map((record: BabyRecord, index: number) => (
+                                        <React.Fragment key={`${record.type}-${record.id}`}>
+                                            <motion.div
+                                                key={`motion-${record.type}-${record.id}`}
+                                                layout
+                                                initial={{ opacity: 0, y: -12 }}
+                                                animate={{ opacity: 1, y: 0 }}
+                                                exit={{ opacity: 0, height: 0, marginTop: 0 }}
+                                                transition={{ duration: 0.22, ease: "easeOut" }}
+                                            >
+                                                <ActivityItem
+                                                    record={record}
+                                                    onClick={handleRecordClick}
+                                                />
+                                            </motion.div>
+                                            {(index + 1) % 10 === 0 && (
+                                                <li className="list-none">
+                                                    <AdUnit slot={process.env.NEXT_PUBLIC_ADSENSE_SLOT_ID ?? ""} />
+                                                </li>
+                                            )}
+                                        </React.Fragment>
+                                    ))}
+                                </AnimatePresence>
                             </ul>
                             {hasMore ? (
                                 <div ref={sentinelRef} className="mt-3 flex justify-center py-1">

--- a/frontend/components/records/EditDialogBase.tsx
+++ b/frontend/components/records/EditDialogBase.tsx
@@ -1,12 +1,7 @@
 "use client"
 
 import { ReactNode } from "react"
-import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-} from "@/components/ui/dialog"
+import { ResponsiveModal } from "@/components/ui/responsive-modal"
 
 interface EditDialogBaseProps {
     open: boolean
@@ -20,20 +15,15 @@ interface EditDialogBaseProps {
 
 export function EditDialogBase({ open, onOpenChange, title, children, onOpenAutoFocus, contentClassName, dialogClassName }: EditDialogBaseProps) {
     return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent
-                className={`max-w-md p-0 overflow-hidden border-0 sm:border rounded-2xl dark:bg-zinc-900 dark:border-zinc-800 ${dialogClassName || ''}`}
-                onOpenAutoFocus={onOpenAutoFocus}
-            >
-                <DialogHeader className="p-4 border-b bg-slate-50 dark:bg-zinc-900/50">
-                    <DialogTitle className="text-lg font-bold flex items-center gap-2" data-sentry-unmask>
-                        {title}
-                    </DialogTitle>
-                </DialogHeader>
-                <div className={`p-4 max-h-[80vh] overflow-y-auto ${contentClassName || ''}`}>
-                    {children}
-                </div>
-            </DialogContent>
-        </Dialog>
+        <ResponsiveModal
+            open={open}
+            onOpenChange={onOpenChange}
+            title={title}
+            onOpenAutoFocus={onOpenAutoFocus}
+            contentClassName={contentClassName}
+            dialogClassName={dialogClassName}
+        >
+            {children}
+        </ResponsiveModal>
     )
 }

--- a/frontend/components/ui/responsive-modal.tsx
+++ b/frontend/components/ui/responsive-modal.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { ReactNode } from "react"
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog"
+import {
+    Drawer,
+    DrawerContent,
+    DrawerHeader,
+    DrawerTitle,
+} from "@/components/ui/drawer"
+import { useIsMobile } from "@/hooks/useIsMobile"
+
+interface ResponsiveModalProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    title: ReactNode
+    children: ReactNode
+    onOpenAutoFocus?: (e: Event) => void
+    contentClassName?: string
+    dialogClassName?: string
+}
+
+/**
+ * モバイルでは Drawer（ボトムシート）、デスクトップでは Dialog（センターモーダル）を使う
+ * レスポンシブモーダルコンポーネント
+ */
+export function ResponsiveModal({
+    open,
+    onOpenChange,
+    title,
+    children,
+    onOpenAutoFocus,
+    contentClassName,
+    dialogClassName,
+}: ResponsiveModalProps) {
+    const isMobile = useIsMobile()
+
+    if (isMobile) {
+        return (
+            <Drawer open={open} onOpenChange={onOpenChange}>
+                <DrawerContent className={`max-h-[92dvh] dark:bg-zinc-900 ${dialogClassName || ''}`}>
+                    <DrawerHeader className="border-b bg-slate-50 dark:bg-zinc-900/50 px-4 py-3 text-left">
+                        <DrawerTitle className="text-base font-bold flex items-center gap-2" data-sentry-unmask>
+                            {title}
+                        </DrawerTitle>
+                    </DrawerHeader>
+                    <div className={`p-4 overflow-y-auto ${contentClassName || ''}`}>
+                        {children}
+                    </div>
+                </DrawerContent>
+            </Drawer>
+        )
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent
+                className={`max-w-md p-0 overflow-hidden border-0 sm:border rounded-2xl dark:bg-zinc-900 dark:border-zinc-800 ${dialogClassName || ''}`}
+                onOpenAutoFocus={onOpenAutoFocus}
+            >
+                <DialogHeader className="p-4 border-b bg-slate-50 dark:bg-zinc-900/50">
+                    <DialogTitle className="text-lg font-bold flex items-center gap-2" data-sentry-unmask>
+                        {title}
+                    </DialogTitle>
+                </DialogHeader>
+                <div className={`p-4 max-h-[80vh] overflow-y-auto ${contentClassName || ''}`}>
+                    {children}
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/frontend/hooks/useRecords.ts
+++ b/frontend/hooks/useRecords.ts
@@ -1,4 +1,5 @@
 import useSWR from 'swr';
+import { useEffect, useMemo } from 'react';
 import { fetcher } from '@/lib/api';
 import { BabyRecord } from "@/types/record";
 import { SWR_REFRESH_INTERVAL_MS } from "@/constants";
@@ -7,12 +8,51 @@ import { SWR_REFRESH_INTERVAL_MS } from "@/constants";
 // デフォルト20件だと1日の記録数が多い場合に昨日以前が取得されない問題があった。
 const RECORDS_FETCH_LIMIT = 100
 
+function getCacheKey(babyId: string) {
+    return `records-cache-v1-${babyId}`
+}
+
+function readCache(babyId: string): BabyRecord[] | undefined {
+    try {
+        const raw = sessionStorage.getItem(getCacheKey(babyId))
+        return raw ? (JSON.parse(raw) as BabyRecord[]) : undefined
+    } catch {
+        return undefined
+    }
+}
+
+function writeCache(babyId: string, data: BabyRecord[]) {
+    try {
+        sessionStorage.setItem(getCacheKey(babyId), JSON.stringify(data))
+    } catch {
+        // sessionStorage quota 超過は無視
+    }
+}
+
 export function useRecords(babyId: string | null) {
+    // キャッシュをフォールバックデータとして渡すことで、初回ロード時もスケルトンをスキップできる
+    const fallbackData = useMemo(
+        () => (babyId ? readCache(babyId) : undefined),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [babyId]
+    )
+
     const { data, error, isLoading, mutate } = useSWR<BabyRecord[]>(
         babyId ? `/babies/${babyId}/records?limit=${RECORDS_FETCH_LIMIT}` : null,
         fetcher,
-        { keepPreviousData: true, refreshInterval: SWR_REFRESH_INTERVAL_MS, revalidateOnFocus: true }
+        {
+            keepPreviousData: true,
+            refreshInterval: SWR_REFRESH_INTERVAL_MS,
+            revalidateOnFocus: true,
+            fallbackData,
+        }
     );
+
+    // 新しいデータが届いたらキャッシュを更新
+    useEffect(() => {
+        if (data && babyId) writeCache(babyId, data)
+    }, [data, babyId])
+
     return {
         records: data,
         isLoading,

--- a/frontend/lib/daily-tips.ts
+++ b/frontend/lib/daily-tips.ts
@@ -1,0 +1,50 @@
+export interface DailyTip {
+    icon: string
+    text: string
+    /** 対象の月齢範囲（inclusive）。省略時は全月齢対象 */
+    minMonths?: number
+    maxMonths?: number
+}
+
+export const DAILY_TIPS: DailyTip[] = [
+    // 全月齢
+    { icon: "💧", text: "授乳後は縦抱きにして、背中をさすってゲップを促しましょう。" },
+    { icon: "🌙", text: "赤ちゃんは仰向けで寝かせると SIDS のリスクが下がります。" },
+    { icon: "🤲", text: "おむつ替えの前後は手をしっかり洗いましょう。" },
+    { icon: "🌡️", text: "室温は 20〜22℃ が快適な睡眠環境の目安です。" },
+    { icon: "📱", text: "記録の積み重ねが、かかりつけ医との相談をスムーズにします。" },
+    { icon: "👁️", text: "目線の高さで話しかけると、赤ちゃんは表情を学びやすくなります。" },
+    { icon: "🎵", text: "ゆっくりした歌声や音楽は、赤ちゃんを落ち着かせる効果があります。" },
+    { icon: "🍼", text: "ミルクの温度は手首の内側に垂らして確認しましょう（人肌が目安）。" },
+    // 新生児〜3ヶ月
+    { icon: "⏱️", text: "新生児の授乳間隔は 2〜3 時間が目安。泣く前のサイン（口をパクパクなど）を観察してみましょう。", maxMonths: 3 },
+    { icon: "🌿", text: "まだ免疫が弱い時期。面会者には手洗いをお願いしましょう。", maxMonths: 2 },
+    // 3〜6ヶ月
+    { icon: "🏋️", text: "うつぶせ遊び（タミータイム）は頸筋や体幹を育てます。目を離さずに短時間から始めて。", minMonths: 3, maxMonths: 6 },
+    { icon: "🙂", text: "この頃から「社会的スマイル」が始まります。たくさん笑いかけてあげましょう。", minMonths: 2, maxMonths: 5 },
+    // 6〜12ヶ月
+    { icon: "🥄", text: "離乳食は 1 種類ずつ始めると、アレルギー反応を確認しやすくなります。", minMonths: 5, maxMonths: 12 },
+    { icon: "🪑", text: "お座りが安定してきたら、床に座らせて手を使った遊びを増やしましょう。", minMonths: 6, maxMonths: 10 },
+    { icon: "🚶", text: "つかまり立ちが始まったら、家具の角にカバーを付けて安全対策を。", minMonths: 8, maxMonths: 14 },
+    // 1歳以降
+    { icon: "📚", text: "絵本の読み聞かせは語彙力と情緒の発達に効果的です。毎日の習慣にしましょう。", minMonths: 10 },
+    { icon: "🧩", text: "積み木やブロックは手先の発達と空間認識力を育てます。", minMonths: 9 },
+]
+
+/**
+ * 今日の日付と赤ちゃんの月齢から「今日のヒント」を1件返す
+ */
+export function getTodayTip(ageMonths: number): DailyTip {
+    const candidates = DAILY_TIPS.filter(tip => {
+        const okMin = tip.minMonths === undefined || ageMonths >= tip.minMonths
+        const okMax = tip.maxMonths === undefined || ageMonths <= tip.maxMonths
+        return okMin && okMax
+    })
+
+    // 日付ベースで毎日変わるよう dayOfYear で選択
+    const now = new Date()
+    const start = new Date(now.getFullYear(), 0, 0)
+    const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86_400_000)
+
+    return candidates[dayOfYear % candidates.length]
+}


### PR DESCRIPTION
## 変更内容

### B-2: 活動フィードの新着スライドイン
- RecentActivityFeed に framer-motion の AnimatePresence を追加
- 新しい記録が追加されると上からスライドインして表示
- initial={false} でマウント時の全件アニメーションを抑制（新着分のみ動く）

### B-3: BottomSheet形式のクイック記録
- ResponsiveModal コンポーネントを新規作成
- モバイル: vaul の Drawer（ボトムシート）、デスクトップ: Dialog（センターモーダル）
- EditDialogBase を ResponsiveModal に差し替えるだけで、授乳・おむつ・メモなど全フォームに適用

### C-2: 日替わりの育児Tips
- daily-tips.ts に月齢フィルタ付き17件のヒントデータを作成
- DailyTipCard コンポーネントを新規作成
- 日付ベース（dayOfYear % n）で毎日1件切り替わる
- ダッシュボードの活動フィードの上に表示（出生後のみ）

### D-1: ダッシュボードのStale-while-revalidate
- useRecords に sessionStorage キャッシュを追加
- SWR の fallbackData にキャッシュデータを渡し、ページ再訪時のスケルトン表示を排除
- 新しいデータが届いたら自動でキャッシュを更新（古いデータの蓄積なし）

## テスト計画

- [ ] 記録追加後、ActivityFeed の先頭に新しいアイテムがスライドインで追加される
- [ ] モバイル幅で授乳/おむつボタンを押すとBottomSheetが下から出る
- [ ] デスクトップ幅では従来通りセンターモーダルが表示される
- [ ] ダッシュボードに「今日のヒント」が表示される（生後以降のみ）
- [ ] ダッシュボードを一度訪問後、別ページへ移動してから戻るとスケルトンなしで即時表示される
- [ ] ビルドが通ること（確認済み）