### PR TITLE
fix: 無限スクロールが20件で止まるバグを修正

### DIFF
--- a/frontend/hooks/useInfiniteScroll.ts
+++ b/frontend/hooks/useInfiniteScroll.ts
@@ -34,7 +34,8 @@ export function useInfiniteScroll<T>(
 
         observer.observe(sentinel)
         return () => observer.disconnect()
-    }, [hasMore, visibleCount, step, threshold])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [hasMore, step, threshold])
 
     return {
         visibleItems,


### PR DESCRIPTION
## 概要

ダッシュボードの「最近の記録」で20件以上読み込まれない問題を修正。

## 原因

`useInfiniteScroll` の `useEffect` 依存配列に `visibleCount` が含まれていたため、件数が増えるたびにオブザーバーが再作成されていた。

再作成のタイミングで sentinel 要素が viewport 内に安定していないケースがあり、新しい `IntersectionObserver` が発火しないまま「読み込み中...」が表示され続ける状態になっていた。

## 修正内容

`visibleCount` を `useEffect` の依存配列から除外。

- オブザーバーは `hasMore` の変化時のみ再作成される
- sentinel が viewport に入るたびに確実に発火し続ける

## テスト手順

- [ ] 21件以上の記録がある赤ちゃんでダッシュボードを開く
- [ ] 「最近の記録」カードを下にスクロールして30件、40件と追加読み込みされることを確認
- [ ] 全件表示後に「すべての記録を表示しています」が表示されることを確認