### PR TITLE
fix: 記録ページからダッシュボードに戻ると別の赤ちゃんが選択されるバグを修正

### DIFF
--- a/frontend/hooks/useRecordPage.ts
+++ b/frontend/hooks/useRecordPage.ts
@@ -6,7 +6,7 @@ import { usePermissions } from "@/hooks/usePermissions"
 import { useBabyStore } from "@/stores/babyStore"
 import { useHydratedStore } from "@/hooks/useHydratedStore"
 import { useRecordFeedback } from "@/hooks/useRecordFeedback"
-import { useMemo } from "react"
+import { useMemo, useEffect } from "react"
 
 /**
  * 記録ページ共通のデータ解決および権限チェックフック
@@ -15,9 +15,18 @@ export function useRecordPage() {
     const searchParams = useSearchParams()
     const { babies, isLoading: babiesLoading } = useBabies()
     const selectedBabyId = useHydratedStore(useBabyStore, (s) => s.selectedBabyId, null)
+    const setSelectedBabyId = useBabyStore((s) => s.setSelectedBabyId)
     const { canWrite } = usePermissions()
 
     const paramBabyId = searchParams.get("baby_id")
+
+    // URLパラメータの baby_id をストアに同期する
+    // これにより記録ページからダッシュボードに戻っても選択状態が維持される
+    useEffect(() => {
+        if (paramBabyId) {
+            setSelectedBabyId(paramBabyId)
+        }
+    }, [paramBabyId, setSelectedBabyId])
     const commentRecordIdStr = searchParams.get("comment")
 
     // 赤ちゃんIDの解決ロジック:


### PR DESCRIPTION
## 原因

URLパラメータ `baby_id` でアクセスされた記録ページは、Zustandストア（`babyStore`）を更新しない設計になっていた。そのため「ウィジェットから記録ページへ移動 → ダッシュボードに戻る」の操作で、ストアが古い選択状態のままになり別の赤ちゃんが表示される。

## 修正内容

`useRecordPage.ts` に `useEffect` を追加し、`baby_id` パラメータが存在する場合はストアを同期するようにした。

## 影響範囲

全記録ページ（授乳・睡眠・おむつ・成長・ノート・日記・体温・ワクチン・マイルストーン）

## テスト

- [ ] Baby B のウィジェットから記録ページに移動し、ダッシュボードに戻って Baby B が選択されていることを確認
- [ ] Baby A が選択済みの状態でブラウザ直接 URL アクセス（/feeding?baby_id=B_id）し、戻っても Baby B のままであることを確認