### PR TITLE
fix: ESLint警告を全件解消

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,1 +1,0 @@
-public/worker-*.js

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useUser } from "@/hooks/useAuth"
 import { LandingContent } from "@/components/landing/LandingContent"

--- a/frontend/components/temperature/TemperatureChart.tsx
+++ b/frontend/components/temperature/TemperatureChart.tsx
@@ -16,7 +16,7 @@ import { Temperature, FEVER_THRESHOLD, HIGH_FEVER_THRESHOLD, getFeverStatus } fr
 import { useMemo, useState } from "react"
 import { useTheme } from "next-themes"
 import { getChartGridColor, getChartTextColor, getChartTooltipStyle } from "@/components/charts/ChartStyles"
-import { formatDateTime, formatTime, subtractDays } from "@/lib/dateUtils"
+import { formatDateTime, subtractDays } from "@/lib/dateUtils"
 
 interface Props {
     temperatures: Temperature[]

--- a/frontend/components/temperature/TemperatureStats.tsx
+++ b/frontend/components/temperature/TemperatureStats.tsx
@@ -1,5 +1,5 @@
 import { Thermometer } from "lucide-react"
-import { Temperature, getFeverStatus, HIGH_FEVER_THRESHOLD, FEVER_THRESHOLD } from "@/types/temperature"
+import { Temperature, getFeverStatus } from "@/types/temperature"
 import { StatsCard } from "@/components/ui/stats-card"
 import { StatsBlock } from "@/components/ui/stats-block"
 import { formatElapsed } from "@/lib/ageUtils"

--- a/frontend/components/ui/tips-card.tsx
+++ b/frontend/components/ui/tips-card.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useState, useEffect } from "react"
 import { ChevronDown, ChevronUp, Lightbulb } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "./collapsible"

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -12,6 +12,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Generated service worker files:
+    "public/workbox-*.js",
+    "public/worker-*.js",
   ]),
 ]);
 

--- a/frontend/hooks/useInfiniteScroll.ts
+++ b/frontend/hooks/useInfiniteScroll.ts
@@ -34,7 +34,6 @@ export function useInfiniteScroll<T>(
 
         observer.observe(sentinel)
         return () => observer.disconnect()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [hasMore, step, threshold])
 
     return {

--- a/frontend/hooks/useRecords.ts
+++ b/frontend/hooks/useRecords.ts
@@ -33,7 +33,6 @@ export function useRecords(babyId: string | null) {
     // キャッシュをフォールバックデータとして渡すことで、初回ロード時もスケルトンをスキップできる
     const fallbackData = useMemo(
         () => (babyId ? readCache(babyId) : undefined),
-        // eslint-disable-next-line react-hooks/exhaustive-deps
         [babyId]
     )
 


### PR DESCRIPTION
## Summary
- `eslint.config.mjs` に `public/workbox-*.js` / `public/worker-*.js` を ignores 追加（CI警告の大半を占めていた生成ファイル）
- `.eslintignore` を削除し `eslint.config.mjs` に統合（ESLintIgnoreWarning 解消）
- `app/page.tsx`: 未使用の `useState` を削除
- `TemperatureChart.tsx`: 未使用の `formatTime` を削除
- `TemperatureStats.tsx`: 未使用の `HIGH_FEVER_THRESHOLD` / `FEVER_THRESHOLD` を削除
- `tips-card.tsx`: 未使用の `useState` / `useEffect` を削除
- `useInfiniteScroll.ts` / `useRecords.ts`: 不要な `eslint-disable` コメントを削除

## Test plan
- [ ] `pnpm lint` が警告ゼロで通過することを確認