### PR TITLE
fix: ダークモード起動時の白フラッシュ（FOUC）を修正

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -67,6 +67,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('theme');if(t==='dark'||((!t||t==='system')&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${nunito.variable} antialiased`}
       >


### PR DESCRIPTION
## 問題

静的エクスポート（`output: 'export'`）環境では、`next-themes` のテーマ判定スクリプトが初回ペイントより後に実行されるため、ダークモード設定でも起動時に一瞬白い画面が表示される（FOUC: Flash of Unstyled Content）。

## 修正

`<head>` にブロッキングインラインスクリプトを追加。

- `localStorage.getItem('theme')` でユーザー設定を確認
- 未設定またはシステム設定の場合は `window.matchMedia('(prefers-color-scheme: dark)')` で確認
- どちらかがダークモードなら `document.documentElement.classList.add('dark')` を即時実行

このスクリプトは CSS レンダリング前に同期実行されるため、初回ペイント時から正しいテーマが適用される。

## テスト計画

- [ ] ダークモード設定デバイスでページリロード → 白フラッシュが発生しないことを確認
- [ ] ライトモード設定デバイスでページリロード → 正常にライトテーマで表示されることを確認
- [ ] テーマ切り替え（設定画面）→ 次回読み込みでも維持されることを確認