### PR TITLE
fix: PWA起動時の白フラッシュを根本修正（スプラッシュ画面・manifest）

### DIFF
--- a/frontend/components/ui/splash-screen.tsx
+++ b/frontend/components/ui/splash-screen.tsx
@@ -29,8 +29,6 @@ export function SplashScreen() {
         return () => clearTimeout(fallback)
     }, [])
 
-    if (!isMounted) return null
-
     return (
         <AnimatePresence>
             {isVisible && (

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -4,7 +4,7 @@
   "description": "家族で共有する育児記録アプリ",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
+  "background_color": "#1a182a",
   "theme_color": "#4F46E5",
   "icons": [
     {


### PR DESCRIPTION
## 問題

#1089 のマージ後に追加した変更が未マージのまま残っていたため、改めてPRを作成。

## 変更内容

### SplashScreen の `!isMounted` ガードを削除（`components/ui/splash-screen.tsx`）

静的エクスポートでは `!isMounted` 時に `null` を返すため、静的HTMLにスプラッシュ画面が含まれない。JSが起動してマウントされるまでの間、実際のページコンテンツが丸見えになっていた。

ガードを削除し `isVisible=true` の初期状態からスプラッシュ画面をレンダリングするよう修正。`isMounted` はフェードアウトのトリガー判定にのみ使用する。

### `manifest.json` の `background_color` を変更

`#ffffff`（白）→ `#1a182a`（ダークテーマ背景色相当）

PWA起動時にOSが描画するシステムスプラッシュの背景色が白になる問題を修正。

## テスト計画

- [ ] ダークモードのPWAを再起動 → OS起動時のシステムスプラッシュが白くならないことを確認
- [ ] JSロード前のページ露出（白フラッシュ）がなくなっていることを確認
- [ ] スプラッシュ画面が正常にフェードアウトすることを確認