### PR TITLE
fix: SQLAlchemyのQueuePoolをNullPoolに変更しNeonのauto-suspendを復元

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,5 +1,6 @@
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker, with_loader_criteria, Session as ORMSession
+from sqlalchemy.pool import NullPool
 from app.models.base import SoftDeleteMixin
 
 import os
@@ -12,8 +13,7 @@ if not SQLALCHEMY_DATABASE_URL:
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL,
     connect_args={"options": "-c timezone=Asia/Tokyo"},
-    pool_pre_ping=True,
-    pool_recycle=3600,
+    poolclass=NullPool,
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
## 原因

SQLAlchemyのデフォルト接続プール（`QueuePool`、接続数5）が常時Neonへの接続を維持し続けていた。
Neonのauto-suspendはアクティブな接続がゼロになって初めて動作するため、Renderにデプロイ中は一切スリープしない状態になっていた。

pooler client connectionが常時2以上になっていたのもこれが原因。

## 変更内容

`app/database.py`の`create_engine`を`NullPool`に変更。

- **Before**: `QueuePool`（デフォルト）+ `pool_pre_ping=True` + `pool_recycle=3600`
  → 常時5本の接続をNeonに維持
- **After**: `NullPool`
  → リクエスト処理中のみ接続し、終了後即座に閉じる

`NullPool`はNeon公式でもサーバーレス・auto-suspend用途に推奨されている構成。

## テスト計画

- [ ] デプロイ後、Neonダッシュボードでpooler client connectionが0になることを確認
- [ ] アイドル時にNeonがauto-suspendすることを確認（5分程度待機）
- [ ] アプリの動作（レコード記録・取得）が正常であることを確認