### PR TITLE
feat: #997 おむつ(Diaper)記録へのうんち詳細(色・状態・量)用構造化カラムの追加

### DIFF
--- a/alembic/versions/n1o2p3q4_add_poop_details_to_diapers.py
+++ b/alembic/versions/n1o2p3q4_add_poop_details_to_diapers.py
@@ -1,0 +1,28 @@
+"""Add poop detail columns to diapers table
+
+Revision ID: n1o2p3q4
+Revises: m1n2o3p4
+Create Date: 2026-03-22 06:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'n1o2p3q4'
+down_revision = '7d1f65e674b7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('diapers', sa.Column('poop_color', sa.String(), nullable=True))
+    op.add_column('diapers', sa.Column('poop_consistency', sa.String(), nullable=True))
+    op.add_column('diapers', sa.Column('poop_amount', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('diapers', 'poop_amount')
+    op.drop_column('diapers', 'poop_consistency')
+    op.drop_column('diapers', 'poop_color')

--- a/app/models/diaper.py
+++ b/app/models/diaper.py
@@ -12,6 +12,9 @@ class Diaper(Base, SoftDeleteMixin, TimestampMixin):
     diaper_type = Column(Enum(DiaperType, name="diapertype"), nullable=False)
     notes = Column(String, nullable=True)
     baby_id = Column(Integer, ForeignKey("babies.id"), nullable=False)
+    poop_color = Column(String, nullable=True)
+    poop_consistency = Column(String, nullable=True)
+    poop_amount = Column(String, nullable=True)
 
     __table_args__ = (
         Index("idx_diaper_baby_time", "baby_id", "change_time"),

--- a/app/routers/diaper.py
+++ b/app/routers/diaper.py
@@ -63,6 +63,9 @@ def create_diaper(
         change_time=diaper_in.change_time,
         diaper_type=diaper_in.diaper_type,
         notes=diaper_in.notes,
+        poop_color=diaper_in.poop_color,
+        poop_consistency=diaper_in.poop_consistency,
+        poop_amount=diaper_in.poop_amount,
     )
     db.add(new_diaper)
     db.flush()
@@ -131,6 +134,12 @@ def update_diaper(diaper_id: int, diaper_in: DiaperUpdate, db: Session = Depends
         diaper.diaper_type = diaper_in.diaper_type
     if diaper_in.notes is not None:
         diaper.notes = diaper_in.notes
+    if diaper_in.poop_color is not None:
+        diaper.poop_color = diaper_in.poop_color
+    if diaper_in.poop_consistency is not None:
+        diaper.poop_consistency = diaper_in.poop_consistency
+    if diaper_in.poop_amount is not None:
+        diaper.poop_amount = diaper_in.poop_amount
 
     db.commit()
     db.refresh(diaper)

--- a/app/schemas/diaper.py
+++ b/app/schemas/diaper.py
@@ -12,6 +12,9 @@ class DiaperCreate(BaseModel):
     change_time: datetime
     diaper_type: DiaperType
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
+    poop_color: Optional[str] = Field(None, max_length=50)
+    poop_consistency: Optional[str] = Field(None, max_length=50)
+    poop_amount: Optional[str] = Field(None, max_length=50)
 
     @field_validator('change_time', mode='before')
     @classmethod
@@ -23,6 +26,9 @@ class DiaperUpdate(BaseModel):
     change_time: Optional[datetime] = None
     diaper_type: Optional[DiaperType] = None
     notes: Optional[str] = Field(None, max_length=NOTE_MAX_LENGTH)
+    poop_color: Optional[str] = Field(None, max_length=50)
+    poop_consistency: Optional[str] = Field(None, max_length=50)
+    poop_amount: Optional[str] = Field(None, max_length=50)
 
     @field_validator('change_time', mode='before')
     @classmethod

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1268,6 +1268,42 @@
               }
             ],
             "title": "Notes"
+          },
+          "poop_amount": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poop Amount"
+          },
+          "poop_color": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poop Color"
+          },
+          "poop_consistency": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poop Consistency"
           }
         },
         "required": [
@@ -1312,6 +1348,42 @@
               }
             ],
             "title": "Notes"
+          },
+          "poop_amount": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poop Amount"
+          },
+          "poop_color": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poop Color"
+          },
+          "poop_consistency": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poop Consistency"
           },
           "recorded_by_display_name": {
             "anyOf": [
@@ -1392,6 +1464,42 @@
               }
             ],
             "title": "Notes"
+          },
+          "poop_amount": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poop Amount"
+          },
+          "poop_color": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poop Color"
+          },
+          "poop_consistency": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poop Consistency"
           }
         },
         "title": "DiaperUpdate",

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -1695,6 +1695,12 @@ export interface components {
             diaper_type: components["schemas"]["DiaperType"];
             /** Notes */
             notes?: string | null;
+            /** Poop Amount */
+            poop_amount?: string | null;
+            /** Poop Color */
+            poop_color?: string | null;
+            /** Poop Consistency */
+            poop_consistency?: string | null;
         };
         /** DiaperResponse */
         DiaperResponse: {
@@ -1715,6 +1721,12 @@ export interface components {
             id: number;
             /** Notes */
             notes?: string | null;
+            /** Poop Amount */
+            poop_amount?: string | null;
+            /** Poop Color */
+            poop_color?: string | null;
+            /** Poop Consistency */
+            poop_consistency?: string | null;
             /** Recorded By Display Name */
             recorded_by_display_name?: string | null;
             /**
@@ -1737,6 +1749,12 @@ export interface components {
             diaper_type?: components["schemas"]["DiaperType"] | null;
             /** Notes */
             notes?: string | null;
+            /** Poop Amount */
+            poop_amount?: string | null;
+            /** Poop Color */
+            poop_color?: string | null;
+            /** Poop Consistency */
+            poop_consistency?: string | null;
         };
         /** FamilyAdminResponse */
         FamilyAdminResponse: {

--- a/tests/test_diaper.py
+++ b/tests/test_diaper.py
@@ -138,6 +138,111 @@ def test_delete_diaper(client: TestClient, auth_client, db):
     assert record is not None
     assert record.is_deleted is True
 
+def test_create_diaper_with_poop_details(client: TestClient, auth_client):
+    """うんち詳細フィールド（色・状態・量）を持つDiaperの作成テスト"""
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    assert baby_res.status_code == 200
+    baby_id = baby_res.json()["id"]
+
+    resp = client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now(timezone.utc).isoformat(),
+            "diaper_type": "DIRTY",
+            "poop_color": "黄色",
+            "poop_consistency": "やわらかい",
+            "poop_amount": "普通",
+        }
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["poop_color"] == "黄色"
+    assert data["poop_consistency"] == "やわらかい"
+    assert data["poop_amount"] == "普通"
+
+
+def test_poop_details_null_for_wet(client: TestClient, auth_client):
+    """WETタイプのDiaperではpoop詳細がnullであることを確認"""
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    resp = client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now(timezone.utc).isoformat(),
+            "diaper_type": "WET",
+        }
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["poop_color"] is None
+    assert data["poop_consistency"] is None
+    assert data["poop_amount"] is None
+
+
+def test_update_diaper_poop_details(client: TestClient, auth_client):
+    """DiaperのPUT APIでpoop詳細フィールドを更新できることを確認"""
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    resp = client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now(timezone.utc).isoformat(),
+            "diaper_type": "DIRTY",
+        }
+    )
+    diaper_id = resp.json()["id"]
+
+    update_resp = client.put(
+        f"/api/diapers/{diaper_id}",
+        json={
+            "poop_color": "緑",
+            "poop_amount": "多量",
+            "poop_consistency": "水様",
+        }
+    )
+    assert update_resp.status_code == 200
+    data = update_resp.json()
+    assert data["poop_color"] == "緑"
+    assert data["poop_amount"] == "多量"
+    assert data["poop_consistency"] == "水様"
+
+
+def test_poop_details_in_list_response(client: TestClient, auth_client):
+    """GETのレスポンスにpoop詳細フィールドが含まれることを確認"""
+    client = auth_client()
+    baby_res = client.post("/api/babies/", json={"name": "テスト赤ちゃん", "gender": "boy"})
+    baby_id = baby_res.json()["id"]
+
+    client.post(
+        "/api/diapers/",
+        json={
+            "baby_id": baby_id,
+            "change_time": datetime.now(timezone.utc).isoformat(),
+            "diaper_type": "BOTH",
+            "poop_color": "茶色",
+            "poop_amount": "少量",
+        }
+    )
+
+    resp = client.get(f"/api/diapers/?baby_id={baby_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+    assert "poop_color" in data[0]
+    assert "poop_consistency" in data[0]
+    assert "poop_amount" in data[0]
+    assert data[0]["poop_color"] == "茶色"
+    assert data[0]["poop_amount"] == "少量"
+
+
 def test_diaper_access_control(client: TestClient, auth_client):
     # ユーザー1が赤ちゃんを登録
     client1 = auth_client(username="user1", family_name="Family1")


### PR DESCRIPTION
## 概要

Closes #997

## 変更内容

おむつ(Diaper)記録へのうんち詳細(色・状態・量)用構造化カラムの追加

## 実装方法

- Claude Codeによる実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認