### PR TITLE
fix: PWA起動時のFOUCを修正

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -73,10 +73,36 @@ export default function RootLayout({
             __html: `(function(){try{var t=localStorage.getItem('theme');if(t==='dark'||((!t||t==='system')&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})();`,
           }}
         />
+        <style dangerouslySetInnerHTML={{ __html: `
+          #initial-splash {
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: oklch(0.98 0.012 350);
+          }
+          .dark #initial-splash {
+            background-color: oklch(0.18 0.04 280);
+          }
+          #initial-splash-title {
+            font-size: 2rem;
+            font-weight: 800;
+            background: linear-gradient(to right, #f472b6, #fb7185, #e879f9);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+          }
+        `}} />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${nunito.variable} antialiased`}
       >
+        <div id="initial-splash" aria-hidden="true">
+          <span id="initial-splash-title">Botoro</span>
+        </div>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/frontend/components/ui/splash-screen.tsx
+++ b/frontend/components/ui/splash-screen.tsx
@@ -22,6 +22,12 @@ export function SplashScreen() {
     }, [isMounted, isLoading])
 
     useEffect(() => {
+        // Reactマウント後に静的スプラッシュ（#initial-splash）を削除してReactスプラッシュに引き継ぐ
+        const el = document.getElementById('initial-splash')
+        if (el) el.remove()
+    }, [])
+
+    useEffect(() => {
         // ネットワーク障害等でローディングが永久にハングした場合のフォールバック
         const fallback = setTimeout(() => {
             setIsVisible(false)


### PR DESCRIPTION
## 問題

PWA起動時にスプラッシュ画面より前にFOUC（Flash of Unstyled Content）が発生していた。

**原因：** `SplashScreen`コンポーネントはJavaScriptに依存するため、JSロードが完了してReactがハイドレートされるまでの間（JSダウンロード中）は画面に何も表示されず、その後コンテンツが一瞬見えてしまっていた。

## 修正内容

### `layout.tsx`
- `<head>`にインラインCSSを追加（`#initial-splash`のスタイル、ダークモード対応含む）
- `<body>`の先頭に`#initial-splash`要素を直接追加（JSなしで即時表示）
  - インラインCSSでスタイリングするためCSSファイルの読み込み完了を待たない
  - `z-index: 9999`でコンテンツを完全に覆う

### `splash-screen.tsx`
- Reactマウント後に`#initial-splash`を削除してReactスプラッシュに引き継ぐ`useEffect`を追加

## 動作フロー（修正後）

1. PWA起動 → 初期HTML読み込み → `#initial-splash`が即時表示（JSなし）
2. JSロード完了 → React初期化 → `SplashScreen`がマウント → `#initial-splash`を削除して引き継ぐ
3. ローディング完了 → `SplashScreen`がフェードアウト

## Test plan

- [ ] PWA（ホーム画面追加）を起動してFOUCが発生しないことを確認
- [ ] ダークモードでFOUCが発生しないことを確認
- [ ] 通常のブラウザアクセスでスプラッシュが正常に表示・消去されることを確認
- [ ] `sh scripts/verify_all.sh` が通ること