### PR TITLE
fix: framer-motionによるHydrationエラーをSSRオフの動的インポートで修正

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,10 +3,10 @@ import { Geist, Geist_Mono, Nunito } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
 import { ThemeProvider } from "@/components/theme-provider";
-import { SplashScreen } from "@/components/ui/splash-screen";
 import Script from "next/script";
 import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
 import { OfflineSyncIndicator } from "@/components/OfflineSyncIndicator";
+import { SplashScreenWrapper } from "@/components/ui/splash-screen-wrapper";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -119,7 +119,7 @@ export default function RootLayout({
           )}
           <ServiceWorkerRegister />
           <OfflineSyncIndicator />
-          <SplashScreen />
+          <SplashScreenWrapper />
           {children}
           <Toaster />
         </ThemeProvider>

--- a/frontend/components/ui/splash-screen-wrapper.tsx
+++ b/frontend/components/ui/splash-screen-wrapper.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+// framer-motion は SSG 時に Hydration mismatch を起こすため ssr: false で動的インポート
+// 静的スプラッシュ（#initial-splash）が JS ロード前のフラッシュを防ぐ
+const SplashScreen = dynamic(
+  () => import("./splash-screen").then((m) => ({ default: m.SplashScreen })),
+  { ssr: false }
+)
+
+export function SplashScreenWrapper() {
+  return <SplashScreen />
+}


### PR DESCRIPTION
## 問題

layout.tsxはServer Componentであるため、SplashScreenを直接importするとframer-motionのmotion.divがSSG出力に含まれ、クライアントサイドのHydration mismatch (Error #418) が発生し「Application error: a client-side exception has occurred」が表示されていた。

## 原因

- layout.tsxはServer Component → dynamic({ ssr: false }) が直接使えない制約がある
- SplashScreen内でuseState(true)によりSSG時にもDOMが出力される
- framer-motionはSSR環境で動作しないため、クライアントの状態と一致せずHydrationエラー

## 修正

SplashScreenWrapperという"use client"コンポーネントを作成し、その中でdynamic({ ssr: false })を使ってSplashScreenをラップ。layout.tsxからはこのWrapperを使用する。

## Test plan

- [ ] pnpm buildが正常完了することを確認
- [ ] 本番デプロイ後にブラウザコンソールにHydrationエラーが出ないことを確認
- [ ] スプラッシュ画面が正常に表示・フェードアウトすることを確認