### PR TITLE
fix: OfflineSyncIndicatorのHydrationミスマッチによるApplication errorを修正

### DIFF
--- a/frontend/hooks/useOfflineSync.ts
+++ b/frontend/hooks/useOfflineSync.ts
@@ -9,9 +9,10 @@ import { useHydratedStore } from '@/hooks/useHydratedStore'
  * アプリのルートに一度だけマウントすることを想定。
  */
 export function useOfflineSync() {
-    const [isOnline, setIsOnline] = useState(
-        typeof navigator !== 'undefined' ? navigator.onLine : true
-    )
+    // SSR安全: Node.js 21+ は navigator オブジェクトが存在するが navigator.onLine は undefined。
+    // サーバーで falsy になるとオフラインバナーがSSG HTMLに含まれてHydrationミスマッチが起きるため
+    // 初期値を true に固定し、マウント後のuseEffectで実際のオンライン状態を反映する。
+    const [isOnline, setIsOnline] = useState(true)
     const pendingOps = useHydratedStore(
         useOfflineSyncStore,
         (s) => s.pendingOps,
@@ -44,6 +45,9 @@ export function useOfflineSync() {
     }, [mutate])
 
     useEffect(() => {
+        // マウント直後に実際のオンライン状態を反映する（SSRとの差分を解消）
+        setIsOnline(navigator.onLine)
+
         const handleOnline = () => {
             setIsOnline(true)
             void flush()


### PR DESCRIPTION
## 原因

Node.js 21+ では `navigator` オブジェクトが存在するが `navigator.onLine` は `undefined`。

SSR（静的HTML生成）時に `useOfflineSync` の `useState(typeof navigator !== 'undefined' ? navigator.onLine : true)` が `undefined` (falsy) を初期値として受け取り、オフラインバナーが SSG HTML に含まれていた。

クライアントでは `navigator.onLine = true`（オンライン）のため、SSRとクライアントの出力が不一致となりHydrationエラーが発生。全ページで **Application error: a client-side exception has occurred** が表示される状態になっていた。

## 修正内容

- `useOfflineSync` の `useState` 初期値を `true`（SSR安全な固定値）に変更
- マウント後の `useEffect` で `setIsOnline(navigator.onLine)` を実行し実際のオンライン状態を反映

## 検証

- 修正前: SSG HTMLに `オフライン` バナーが含まれていた
- 修正後: SSG HTMLに `オフライン` バナーが含まれない（`pnpm build` + grep で確認済み）

## テスト計画

- [ ] 本番環境でApplication errorが解消されることを確認
- [ ] オフライン状態でバナーが正常に表示されることを確認
- [ ] オンライン→オフライン→オンラインの切り替えでバナーが正常に動作することを確認