### PR TITLE
fix: el.remove()をdisplay:noneに変更しSafariのDOMExceptionを修正

### DIFF
--- a/frontend/components/ui/splash-screen.tsx
+++ b/frontend/components/ui/splash-screen.tsx
@@ -22,9 +22,12 @@ export function SplashScreen() {
     }, [isMounted, isLoading])
 
     useEffect(() => {
-        // Reactマウント後に静的スプラッシュ（#initial-splash）を削除してReactスプラッシュに引き継ぐ
+        // Reactマウント後に静的スプラッシュ（#initial-splash）を非表示にしてReactスプラッシュに引き継ぐ。
+        // el.remove() はReact管理のDOMノードをfiberツリーの外から削除するため、
+        // 後続のinsertBefore呼び出し時にDOMExceptionを引き起こす。
+        // display:noneで非表示にすることでDOMに残したまま視覚的に隠す。
         const el = document.getElementById('initial-splash')
-        if (el) el.remove()
+        if (el) el.style.display = 'none'
     }, [])
 
     useEffect(() => {


### PR DESCRIPTION
## 問題

本番環境の全ページで `Application error: a client-side exception has occurred` が発生。

Safariのコンソールエラー:
```
DOMException { line: 21, column: 190815, sourceURL: ".../9218ff729b74ed89.js" }
r@webkit-masked-url://hidden/:27:166011
n@.../9218ff729b74ed89.js:7:4842
```

## 根本原因

`SplashScreen.useEffect` で `document.getElementById('initial-splash').remove()` を呼び出していた。

`#initial-splash` は `layout.tsx` のJSXに含まれるReact管理のDOMノード。  
`el.remove()` でDOMから直接削除するとReactのfiberツリーは当該ノードを参照し続け、  
後続のReact commitフェーズで `insertBefore(newNode, removedNode)` を呼び出した際に  
Safariが `NotFoundError` DOMExceptionをスローする。

このDOMExceptionはSentryのevent handlerラッパーを通じて再throwされ、  
Next.jsの全画面エラーページが表示される。

## 修正

`el.remove()` → `el.style.display = 'none'`

DOMノードを削除せず非表示にするのみ。これによりReactのfiberツリーとDOMの整合性が保たれる。

## テスト計画

- [ ] ローカルビルドで全ページが正常に表示されること
- [ ] Safariでの `Application error` が解消されること
- [ ] スプラッシュスクリーンのフェードアウト動作が正常なこと