### PR TITLE
fix: 瓶UIの4件の問題を修正

### DIFF
--- a/frontend/components/dashboard/JarCanvas.tsx
+++ b/frontend/components/dashboard/JarCanvas.tsx
@@ -1,24 +1,20 @@
 "use client"
 
-import { useEffect, useRef, useCallback } from "react"
+import { useEffect, useRef } from "react"
 import { BabyRecord } from "@/types/record"
-
-// Matter.js は dynamic import のみで使う（SSR 回避）
 import type { Engine, Runner, Body } from "matter-js"
 
 export const JAR_WIDTH = 220
 export const JAR_HEIGHT = 320
-// 瓶の内側の幅・壁の厚さ
 const WALL_THICK = 20
 const JAR_INNER_W = JAR_WIDTH - WALL_THICK * 2
-// 瓶口（上部の開口部）から少し内側を落下開始点に使う
 export const DROP_X_CENTER = JAR_WIDTH / 2
 export const DROP_Y_START = 10
 
-// 正六角形の外接円半径
+// Hexagon size=36 (pointy-top) の外接円半径。height/2 = 18
 const HEX_RADIUS = 18
 
-type BodyMap = Map<number, Body> // record.id → Body
+type BodyMap = Map<number, Body>
 
 export interface JarCanvasHandle {
     addRecord: (record: BabyRecord) => void
@@ -31,9 +27,9 @@ interface Props {
     onReady?: (handle: JarCanvasHandle) => void
 }
 
-function hexVertices(R: number) {
+function hexVertices(R: number): { x: number; y: number }[] {
     return Array.from({ length: 6 }, (_, i) => {
-        const angle = (Math.PI / 3) * i - Math.PI / 6
+        const angle = (Math.PI / 3) * i - Math.PI / 2
         return { x: R * Math.cos(angle), y: R * Math.sin(angle) }
     })
 }
@@ -43,17 +39,23 @@ export function JarCanvas({ records, onReady }: Props) {
     const engineRef = useRef<Engine | null>(null)
     const runnerRef = useRef<Runner | null>(null)
     const bodyMapRef = useRef<BodyMap>(new Map())
-    const handleRef = useRef<JarCanvasHandle | null>(null)
     const rafRef = useRef<number>(0)
+    // 最新の records を init 完了後に参照するため ref で保持
+    const recordsRef = useRef<BabyRecord[]>(records)
     const prevRecordIdsRef = useRef<Set<number>>(new Set())
 
-    const getBodyPositions = useCallback((): Map<number, { x: number; y: number; angle: number }> => {
+    // records が変わるたびに ref を更新
+    useEffect(() => {
+        recordsRef.current = records
+    })
+
+    const getBodyPositions = () => {
         const result = new Map<number, { x: number; y: number; angle: number }>()
         bodyMapRef.current.forEach((body, id) => {
             result.set(id, { x: body.position.x, y: body.position.y, angle: body.angle })
         })
         return result
-    }, [])
+    }
 
     // Matter.js の初期化（クライアントサイドのみ）
     useEffect(() => {
@@ -62,7 +64,6 @@ export function JarCanvas({ records, onReady }: Props) {
         async function init() {
             const Matter = await import("matter-js")
             const decomp = await import("poly-decomp")
-            // poly-decomp を Matter.js に登録
             Matter.Common.setDecomp(decomp.default ?? decomp)
 
             if (destroyed || !canvasRef.current) return
@@ -72,58 +73,55 @@ export function JarCanvas({ records, onReady }: Props) {
             engineRef.current = engine
             runnerRef.current = runner
 
-            // 瓶の壁（静的ボディ）
             const wallOpts = { isStatic: true, friction: 0.5, restitution: 0.05 }
-            const leftWall = Matter.Bodies.rectangle(
-                WALL_THICK / 2, JAR_HEIGHT / 2, WALL_THICK, JAR_HEIGHT, wallOpts
-            )
-            const rightWall = Matter.Bodies.rectangle(
-                JAR_WIDTH - WALL_THICK / 2, JAR_HEIGHT / 2, WALL_THICK, JAR_HEIGHT, wallOpts
-            )
-            const floor = Matter.Bodies.rectangle(
-                JAR_WIDTH / 2, JAR_HEIGHT - WALL_THICK / 2, JAR_WIDTH, WALL_THICK, wallOpts
-            )
-            Matter.World.add(engine.world, [leftWall, rightWall, floor])
+            Matter.World.add(engine.world, [
+                Matter.Bodies.rectangle(WALL_THICK / 2, JAR_HEIGHT / 2, WALL_THICK, JAR_HEIGHT, wallOpts),
+                Matter.Bodies.rectangle(JAR_WIDTH - WALL_THICK / 2, JAR_HEIGHT / 2, WALL_THICK, JAR_HEIGHT, wallOpts),
+                Matter.Bodies.rectangle(JAR_WIDTH / 2, JAR_HEIGHT - WALL_THICK / 2, JAR_WIDTH, WALL_THICK, wallOpts),
+            ])
 
             Matter.Runner.run(runner, engine)
 
+            const addRecord = (record: BabyRecord) => {
+                if (bodyMapRef.current.has(record.id)) return
+                const x = WALL_THICK + HEX_RADIUS + Math.random() * (JAR_INNER_W - HEX_RADIUS * 2)
+                const verts: Matter.Vector[] = hexVertices(HEX_RADIUS)
+                const body = Matter.Bodies.fromVertices(x, DROP_Y_START, [verts], {
+                    restitution: 0.12,
+                    friction: 0.6,
+                    density: 0.004,
+                    frictionAir: 0.01,
+                    label: String(record.id),
+                }, true)
+                Matter.Body.setPosition(body, { x, y: DROP_Y_START })
+                Matter.World.add(engine.world, body)
+                bodyMapRef.current.set(record.id, body)
+            }
+
             const handle: JarCanvasHandle = {
-                addRecord: (record: BabyRecord) => {
-                    if (bodyMapRef.current.has(record.id)) return
-                    // 瓶口の中央付近からランダムなX位置で落下
-                    const x = WALL_THICK + HEX_RADIUS + Math.random() * (JAR_INNER_W - HEX_RADIUS * 2)
-                    const verts: Matter.Vector[] = hexVertices(HEX_RADIUS)
-                    // fromVertices は Vector[][] を受け取る（複数の凸ポリゴン配列）
-                    const body = Matter.Bodies.fromVertices(x, DROP_Y_START, [verts], {
-                        restitution: 0.12,
-                        friction: 0.6,
-                        density: 0.004,
-                        frictionAir: 0.01,
-                        label: String(record.id),
-                    }, true)
-                    // fromVertices は重心を原点として生成するためオフセット調整
-                    Matter.Body.setPosition(body, { x, y: DROP_Y_START })
-                    Matter.World.add(engine.world, body)
-                    bodyMapRef.current.set(record.id, body)
-                },
+                addRecord,
                 clearAll: () => {
-                    bodyMapRef.current.forEach(body => {
-                        Matter.World.remove(engine.world, body)
-                    })
+                    bodyMapRef.current.forEach(body => Matter.World.remove(engine.world, body))
                     bodyMapRef.current.clear()
+                    prevRecordIdsRef.current = new Set()
                 },
                 getBodyPositions,
             }
-            handleRef.current = handle
+
             onReady?.(handle)
 
-            // Canvas への手動描画ループ
-            const ctx = canvasRef.current?.getContext("2d")
+            // init 完了時点の records を時系列順に落下（初期表示）
+            const initial = [...recordsRef.current].sort(
+                (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+            )
+            initial.forEach((r, i) => {
+                setTimeout(() => { if (!destroyed) addRecord(r) }, i * 80)
+            })
+            prevRecordIdsRef.current = new Set(recordsRef.current.map(r => r.id))
 
+            // Canvas は空のままにして DOM オーバーレイ側で描画
             function drawLoop() {
-                if (destroyed || !ctx || !canvasRef.current) return
-                ctx.clearRect(0, 0, JAR_WIDTH, JAR_HEIGHT)
-                // ボディは DOM オーバーレイ側で描画するため、Canvas は空のまま
+                if (destroyed) return
                 rafRef.current = requestAnimationFrame(drawLoop)
             }
             rafRef.current = requestAnimationFrame(drawLoop)
@@ -134,43 +132,55 @@ export function JarCanvas({ records, onReady }: Props) {
         return () => {
             destroyed = true
             cancelAnimationFrame(rafRef.current)
-            if (runnerRef.current) {
-                import("matter-js").then(Matter => {
-                    if (runnerRef.current) Matter.Runner.stop(runnerRef.current)
-                    if (engineRef.current) Matter.Engine.clear(engineRef.current)
-                })
-            }
+            import("matter-js").then(Matter => {
+                if (runnerRef.current) Matter.Runner.stop(runnerRef.current)
+                if (engineRef.current) Matter.Engine.clear(engineRef.current)
+            })
         }
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-    // records が変わったとき、追加分のみを落下させる
+    // records が変わったとき差分を適用（init 完了後のみ）
     useEffect(() => {
-        const handle = handleRef.current
-        if (!handle) return
+        const engine = engineRef.current
+        if (!engine) return
+
         const prevIds = prevRecordIdsRef.current
         const newIds = new Set(records.map(r => r.id))
 
-        // 削除された記録
+        // 削除
         prevIds.forEach(id => {
             if (!newIds.has(id)) {
                 const body = bodyMapRef.current.get(id)
                 if (body) {
-                    import("matter-js").then(Matter => {
-                        if (engineRef.current) Matter.World.remove(engineRef.current.world, body)
-                    })
+                    import("matter-js").then(Matter => Matter.World.remove(engine.world, body))
                     bodyMapRef.current.delete(id)
                 }
             }
         })
 
-        // 新規記録を時系列順に落下（古い順）
-        const sorted = [...records].sort(
-            (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-        )
-        sorted.forEach((r, i) => {
-            if (!prevIds.has(r.id)) {
-                setTimeout(() => handle.addRecord(r), i * 80)
-            }
+        // 追加（新規のみ、時系列順に落下）
+        const added = records
+            .filter(r => !prevIds.has(r.id))
+            .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+
+        added.forEach((r, i) => {
+            setTimeout(() => {
+                if (!engineRef.current) return
+                const x = WALL_THICK + HEX_RADIUS + Math.random() * (JAR_INNER_W - HEX_RADIUS * 2)
+                import("matter-js").then(Matter => {
+                    const verts: Matter.Vector[] = hexVertices(HEX_RADIUS)
+                    const body = Matter.Bodies.fromVertices(x, DROP_Y_START, [verts], {
+                        restitution: 0.12,
+                        friction: 0.6,
+                        density: 0.004,
+                        frictionAir: 0.01,
+                        label: String(r.id),
+                    }, true)
+                    Matter.Body.setPosition(body, { x, y: DROP_Y_START })
+                    Matter.World.add(engineRef.current!.world, body)
+                    bodyMapRef.current.set(r.id, body)
+                })
+            }, i * 80)
         })
 
         prevRecordIdsRef.current = newIds

--- a/frontend/components/dashboard/JarHexTokenOverlay.tsx
+++ b/frontend/components/dashboard/JarHexTokenOverlay.tsx
@@ -3,26 +3,13 @@
 import { useEffect, useRef, useState, useCallback } from "react"
 import { BabyRecord } from "@/types/record"
 import { JarCanvasHandle, JAR_WIDTH, JAR_HEIGHT } from "./JarCanvas"
+import { Hexagon } from "@/components/ui/hexagon"
+import { RECORD_TYPE_LUCIDE_ICONS, RECORD_TYPE_BG_COLORS, RECORD_TYPE_COLORS } from "@/constants/ui"
+import { StickyNote } from "lucide-react"
+import { cn } from "@/lib/utils"
 
-const RECORD_COLORS: Record<BabyRecord["type"], string> = {
-    feeding: "bg-indigo-400",
-    sleep: "bg-blue-400",
-    diaper: "bg-amber-400",
-    growth: "bg-green-400",
-    note: "bg-purple-400",
-    contraction: "bg-rose-400",
-}
-
-const RECORD_ICONS: Record<BabyRecord["type"], string> = {
-    feeding: "🍼",
-    sleep: "😴",
-    diaper: "👶",
-    growth: "📏",
-    note: "📝",
-    contraction: "⏱",
-}
-
-const HEX_DISPLAY_SIZE = 36 // px（DOM六角形のサイズ）
+// 既存の Hexagon と同じ size 値（pointy-top の高さ = HEX_RADIUS * 2 = 36）
+const HEX_SIZE = 36
 
 interface HexToken {
     id: number
@@ -43,14 +30,12 @@ export function JarHexTokenOverlay({ records, jarHandle, onSelect }: Props) {
     const rafRef = useRef<number>(0)
     const recordMapRef = useRef<Map<number, BabyRecord>>(new Map())
 
-    // record map を最新に保つ
     useEffect(() => {
         const map = new Map<number, BabyRecord>()
         records.forEach(r => map.set(r.id, r))
         recordMapRef.current = map
     }, [records])
 
-    // RAF で物理ボディ座標を追従
     const startTracking = useCallback(() => {
         if (!jarHandle) return
         function tick() {
@@ -91,38 +76,44 @@ export function JarHexTokenOverlay({ records, jarHandle, onSelect }: Props) {
 }
 
 function HexTokenItem({ token, onSelect }: { token: HexToken; onSelect: (r: BabyRecord) => void }) {
-    const colorClass = RECORD_COLORS[token.record.type] ?? "bg-gray-400"
-    const icon = RECORD_ICONS[token.record.type] ?? "●"
-    const half = HEX_DISPLAY_SIZE / 2
+    const type = token.record.type as keyof typeof RECORD_TYPE_LUCIDE_ICONS
+    const LucideIcon = RECORD_TYPE_LUCIDE_ICONS[type] ?? StickyNote
+    const bgClass = RECORD_TYPE_BG_COLORS[type] ?? "text-gray-100 dark:text-zinc-800"
+    const colorClass = RECORD_TYPE_COLORS[type] ?? "text-muted-foreground"
+
+    // Hexagon size=HEX_SIZE の pointy-top は: width = HEX_SIZE * √3/2, height = HEX_SIZE
+    const hexW = HEX_SIZE * Math.SQRT2 * 0.866 // ≈ HEX_SIZE * √3/2
+    const hexH = HEX_SIZE
 
     return (
         <button
             onClick={() => onSelect(token.record)}
-            onKeyDown={e => e.key === "Enter" && onSelect(token.record)}
             title={token.record.type}
             style={{
                 position: "absolute",
-                left: token.x - half,
-                top: token.y - half,
-                width: HEX_DISPLAY_SIZE,
-                height: HEX_DISPLAY_SIZE,
+                left: token.x - hexW / 2,
+                top: token.y - hexH / 2,
                 transform: `rotate(${token.angle}rad)`,
-                clipPath: "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)",
                 pointerEvents: "auto",
                 cursor: "pointer",
                 border: "none",
                 padding: 0,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontSize: 14,
-                lineHeight: 1,
+                background: "none",
             }}
-            className={`${colorClass} hover:brightness-110 active:brightness-125 transition-[filter]`}
+            className="hover:brightness-110 active:brightness-125 transition-[filter]"
         >
-            <span style={{ transform: `rotate(${-token.angle}rad)`, display: "block" }}>
-                {icon}
-            </span>
+            <Hexagon
+                size={HEX_SIZE}
+                cornerRadius={5}
+                pointy
+                className={cn("shrink-0", bgClass)}
+            >
+                <LucideIcon
+                    className={cn("h-3 w-3", colorClass)}
+                    style={{ transform: `rotate(${-token.angle}rad)` }}
+                    aria-hidden
+                />
+            </Hexagon>
         </button>
     )
 }

--- a/frontend/components/dashboard/JarPhysicsView.tsx
+++ b/frontend/components/dashboard/JarPhysicsView.tsx
@@ -61,7 +61,7 @@ export function JarPhysicsView({ records, isLoading, mutate }: Props) {
     }, [])
 
     return (
-        <div className="flex flex-col items-center">
+        <div className="flex flex-col items-center pb-24">
             <JarDateNav date={selectedDate} onChange={handleDateChange} />
 
             {isLoading && !records ? (


### PR DESCRIPTION
## 変更内容

前PR #1113（瓶+物理エンジン記録ビュー）の実装後に発覚した問題を修正。

- **正六角形でない**: clip-path+絵文字 → 既存の `Hexagon` コンポーネント + `RECORD_TYPE_LUCIDE_ICONS` に変更
- **初期表示されない**: `init()` の async 完了後に `recordsRef.current` を参照して初期投下。records変化追跡 effect は engine 準備後のみ実行
- **絵文字 → アイコン**: ActivityItem と同じアイコン・背景色・テキスト色の定数を使用
- **QuickAction と重なる**: `pb-24` を追加してスクロール可能に

## 確認事項

- [ ] ダッシュボードを開いた際に今日の記録が六角形で表示されることを確認
- [ ] 六角形が既存の Hexagon コンポーネントと同じ正六角形で表示されることを確認
- [ ] アイコンが絵文字ではなく lucide アイコンで表示されることを確認
- [ ] 瓶の下にスクロールできて QuickActionBar と重ならないことを確認