### PR TITLE
fix: 瓶ビューで7日以前のデータが表示されない問題を修正

### DIFF
--- a/app/routers/baby.py
+++ b/app/routers/baby.py
@@ -181,11 +181,21 @@ def delete_baby(baby_id: int, db: Session = Depends(get_db), current_user: User 
 def get_records(
     baby_id: int,
     limit: int = Query(DEFAULT_PAGINATION_LIMIT, ge=1, le=MAX_PAGINATION_LIMIT),
+    date: Optional[str] = Query(None, description="YYYY-MM-DD形式の日付フィルタ"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
     # "baby" レベルのアクセスチェック（record_type="baby" はデフォルトなので変更不要）
     verify_baby_access(db, baby_id, current_user.id)
+
+    # date パラメータが指定された場合は当日の UTC 範囲に変換（JST 基準）
+    date_start: Optional[datetime] = None
+    date_end: Optional[datetime] = None
+    if date:
+        from datetime import date as date_type, timedelta
+        parsed = date_type.fromisoformat(date)
+        date_start = datetime.combine(parsed, datetime.min.time()).replace(tzinfo=JST)
+        date_end = date_start + timedelta(days=1)
 
     family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
     is_admin = (family_user and family_user.role == UserRole.ADMIN) or current_user.is_superadmin
@@ -213,13 +223,16 @@ def get_records(
 
     if can_view_type("feeding"):
         # Select only necessary columns to avoid overhead of full ORM object creation
-        for feeding in db.query(
+        feeding_q = db.query(
             Feeding.id, Feeding.user_id, Feeding.feeding_time,
             Feeding.feeding_type, Feeding.amount_ml, Feeding.duration_minutes, Feeding.notes
         ).filter(
             Feeding.baby_id == baby_id,
             Feeding.is_deleted == False
-        ).order_by(Feeding.feeding_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
+        )
+        if date_start:
+            feeding_q = feeding_q.filter(Feeding.feeding_time >= date_start, Feeding.feeding_time < date_end)
+        for feeding in feeding_q.order_by(Feeding.feeding_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 feeding.id, "feeding", feeding.user_id, feeding.feeding_time,
                 {
@@ -233,12 +246,15 @@ def get_records(
             ))
 
     if can_view_type("sleep"):
-        for sleep in db.query(
+        sleep_q = db.query(
             Sleep.id, Sleep.user_id, Sleep.start_time, Sleep.end_time, Sleep.notes
         ).filter(
             Sleep.baby_id == baby_id,
             Sleep.is_deleted == False
-        ).order_by(Sleep.start_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
+        )
+        if date_start:
+            sleep_q = sleep_q.filter(Sleep.start_time >= date_start, Sleep.start_time < date_end)
+        for sleep in sleep_q.order_by(Sleep.start_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 sleep.id, "sleep", sleep.user_id, sleep.start_time,
                 {
@@ -250,12 +266,15 @@ def get_records(
             ))
 
     if can_view_type("diaper"):
-        for diaper in db.query(
+        diaper_q = db.query(
             Diaper.id, Diaper.user_id, Diaper.change_time, Diaper.diaper_type, Diaper.notes
         ).filter(
             Diaper.baby_id == baby_id,
             Diaper.is_deleted == False
-        ).order_by(Diaper.change_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
+        )
+        if date_start:
+            diaper_q = diaper_q.filter(Diaper.change_time >= date_start, Diaper.change_time < date_end)
+        for diaper in diaper_q.order_by(Diaper.change_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 diaper.id, "diaper", diaper.user_id, diaper.change_time,
                 {
@@ -267,13 +286,16 @@ def get_records(
             ))
 
     if can_view_type("growth"):
-        for growth in db.query(
+        growth_q = db.query(
             Growth.id, Growth.user_id, Growth.date,
             Growth.weight, Growth.height, Growth.head_circumference, Growth.notes
         ).filter(
             Growth.baby_id == baby_id,
             Growth.is_deleted == False
-        ).order_by(Growth.date.desc()).limit(MAX_PAGINATION_LIMIT).all():
+        )
+        if date_start and date_end:
+            growth_q = growth_q.filter(Growth.date >= date_start.date(), Growth.date < date_end.date())
+        for growth in growth_q.order_by(Growth.date.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 growth.id, "growth", growth.user_id,
                 datetime.combine(growth.date, datetime.min.time()),
@@ -288,12 +310,15 @@ def get_records(
             ))
 
     if can_view_type("note"):
-        for note in db.query(
+        note_q = db.query(
             Note.id, Note.user_id, Note.note_time, Note.content, Note.updated_at
         ).filter(
             Note.baby_id == baby_id,
             Note.is_deleted == False
-        ).order_by(Note.note_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
+        )
+        if date_start:
+            note_q = note_q.filter(Note.note_time >= date_start, Note.note_time < date_end)
+        for note in note_q.order_by(Note.note_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 note.id, "note", note.user_id, note.note_time,
                 {
@@ -304,13 +329,16 @@ def get_records(
             ))
 
     if can_view_type("contraction"):
-        for c in db.query(
+        contraction_q = db.query(
             Contraction.id, Contraction.user_id, Contraction.start_time,
             Contraction.end_time, Contraction.duration_seconds, Contraction.notes
         ).filter(
             Contraction.baby_id == baby_id,
             Contraction.is_deleted == False
-        ).order_by(Contraction.start_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
+        )
+        if date_start:
+            contraction_q = contraction_q.filter(Contraction.start_time >= date_start, Contraction.start_time < date_end)
+        for c in contraction_q.order_by(Contraction.start_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 c.id, "contraction", c.user_id, c.start_time,
                 {

--- a/frontend/components/dashboard/JarPhysicsView.tsx
+++ b/frontend/components/dashboard/JarPhysicsView.tsx
@@ -33,7 +33,7 @@ interface Props {
     mutate?: () => void
 }
 
-export function JarPhysicsView({ records, isLoading, mutate }: Props) {
+export function JarPhysicsView({ babyId, records, isLoading, mutate }: Props) {
     const today = new Date()
     today.setHours(0, 0, 0, 0)
 
@@ -42,7 +42,7 @@ export function JarPhysicsView({ records, isLoading, mutate }: Props) {
     const [dialogOpen, setDialogOpen] = useState(false)
     const [jarHandle, setJarHandle] = useState<JarCanvasHandle | null>(null)
 
-    const dayRecords = useRecordsByDate(records, selectedDate)
+    const { dayRecords, isLoading: dateLoading } = useRecordsByDate(records, babyId, selectedDate)
 
     const handleDateChange = useCallback((date: Date) => {
         date.setHours(0, 0, 0, 0)
@@ -64,7 +64,7 @@ export function JarPhysicsView({ records, isLoading, mutate }: Props) {
         <div className="flex flex-col items-center">
             <JarDateNav date={selectedDate} onChange={handleDateChange} />
 
-            {isLoading && !records ? (
+            {(isLoading && !records) || dateLoading ? (
                 <div style={{ width: JAR_WIDTH, height: JAR_HEIGHT }} className="flex items-center justify-center">
                     <BabyBottleLoading className="w-8 h-8 text-indigo-400" />
                 </div>
@@ -85,7 +85,7 @@ export function JarPhysicsView({ records, isLoading, mutate }: Props) {
                 </div>
             )}
 
-            {dayRecords.length === 0 && !isLoading && (
+            {dayRecords.length === 0 && !isLoading && !dateLoading && (
                 <p className="text-sm text-gray-400 dark:text-zinc-500 mt-3">この日の記録はありません</p>
             )}
 

--- a/frontend/hooks/useRecordsByDate.ts
+++ b/frontend/hooks/useRecordsByDate.ts
@@ -1,21 +1,50 @@
-import { useMemo } from "react"
+import useSWR from "swr"
+import { fetcher } from "@/lib/api"
 import { BabyRecord } from "@/types/record"
 
 /**
  * 指定した日付の記録を返す。
- * すでに取得済みの records（useRecords の結果）からクライアント側でフィルタする。
+ * - キャッシュ済み records（useRecords の結果）でカバーできる日付はクライアント側でフィルタ
+ * - キャッシュの最古レコードより前の日付は API から直接取得（date パラメータ使用）
  */
 export function useRecordsByDate(
     records: BabyRecord[] | undefined,
+    babyId: string | null,
     date: Date
-): BabyRecord[] {
-    const dateStr = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
-    return useMemo(() => {
-        if (!records) return []
-        const [y, m, d] = dateStr.split("-").map(Number)
-        return records.filter(r => {
-            const t = new Date(r.timestamp)
-            return t.getFullYear() === y && t.getMonth() === m && t.getDate() === d
-        })
-    }, [records, dateStr])
+): { dayRecords: BabyRecord[]; isLoading: boolean } {
+    const y = date.getFullYear()
+    const m = date.getMonth()       // 0-indexed
+    const d = date.getDate()
+    // YYYY-MM-DD（API パラメータ用）
+    const dateStr = `${y}-${String(m + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`
+
+    // キャッシュの最古タイムスタンプ（ms）
+    let oldestTs: number | null = null
+    if (records && records.length > 0) {
+        oldestTs = Math.min(...records.map(r => new Date(r.timestamp).getTime()))
+    }
+
+    // 選択日の開始時刻（JST 0時 = ローカル 0時）
+    const selStart = new Date(y, m, d).getTime()
+
+    // キャッシュでカバーできない = キャッシュが存在し、かつ選択日がキャッシュ最古より前
+    const needsFetch = records !== undefined && oldestTs !== null && selStart < oldestTs
+
+    const { data: fetchedRecords, isLoading } = useSWR<BabyRecord[]>(
+        needsFetch && babyId ? `/babies/${babyId}/records?date=${dateStr}&limit=100` : null,
+        fetcher,
+        { revalidateOnFocus: false }
+    )
+
+    if (needsFetch) {
+        return { dayRecords: fetchedRecords ?? [], isLoading }
+    }
+
+    // クライアント側フィルタ
+    const dayRecords = (records ?? []).filter(r => {
+        const t = new Date(r.timestamp)
+        return t.getFullYear() === y && t.getMonth() === m && t.getDate() === d
+    })
+
+    return { dayRecords, isLoading: false }
 }

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -6013,6 +6013,24 @@
               "title": "Limit",
               "type": "integer"
             }
+          },
+          {
+            "description": "YYYY-MM-DD形式の日付フィルタ",
+            "in": "query",
+            "name": "date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "YYYY-MM-DD形式の日付フィルタ",
+              "title": "Date"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## 原因

`useRecords` は直近100件しか取得しないため、7日以上前のデータはキャッシュに存在せず、クライアント側フィルタで空になっていた。

## 変更内容

**バックエンド** (`app/routers/baby.py`):
- `GET /babies/{baby_id}/records` に `date` クエリパラメータを追加（`YYYY-MM-DD` 形式）
- feeding / sleep / diaper / growth / note / contraction の各クエリに日付範囲フィルタを適用（JST基準）

**フロントエンド**:
- `useRecordsByDate`: キャッシュの最古レコードより前の日付が選択された場合のみ `?date=YYYY-MM-DD` 付きで API を呼び出すフォールバックを実装
- `JarPhysicsView`: `babyId` を `useRecordsByDate` に渡すよう修正、API フェッチ中はローディング表示

## 確認事項

- [ ] 今日・昨日など直近の日付で記録が表示されることを確認
- [ ] 7日以上前の日付に切り替えて記録が表示されることを確認（要: その日に記録があること）
- [ ] 記録がない日付では「この日の記録はありません」と表示されることを確認