### PR TITLE
feat: 棚サムネイルを物理エンジン計算に対応・7日以前データ表示を修正

### DIFF
--- a/app/core/constants.py
+++ b/app/core/constants.py
@@ -4,7 +4,7 @@ Core constants for the application.
 
 # Pagination
 DEFAULT_PAGINATION_LIMIT = 20
-MAX_PAGINATION_LIMIT = 100
+MAX_PAGINATION_LIMIT = 500
 
 # API
 API_TIMEOUT_MS = 30000

--- a/app/routers/baby.py
+++ b/app/routers/baby.py
@@ -181,14 +181,15 @@ def delete_baby(baby_id: int, db: Session = Depends(get_db), current_user: User 
 def get_records(
     baby_id: int,
     limit: int = Query(DEFAULT_PAGINATION_LIMIT, ge=1, le=MAX_PAGINATION_LIMIT),
-    date: Optional[str] = Query(None, description="YYYY-MM-DD形式の日付フィルタ"),
+    date: Optional[str] = Query(None, description="YYYY-MM-DD形式の日付フィルタ（1日分）"),
+    from_date: Optional[str] = Query(None, description="YYYY-MM-DD形式の開始日フィルタ（以降すべて）"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
     # "baby" レベルのアクセスチェック（record_type="baby" はデフォルトなので変更不要）
     verify_baby_access(db, baby_id, current_user.id)
 
-    # date パラメータが指定された場合は当日の UTC 範囲に変換（JST 基準）
+    # date / from_date パラメータを JST 基準で日時範囲に変換
     date_start: Optional[datetime] = None
     date_end: Optional[datetime] = None
     if date:
@@ -196,6 +197,11 @@ def get_records(
         parsed = date_type.fromisoformat(date)
         date_start = datetime.combine(parsed, datetime.min.time()).replace(tzinfo=JST)
         date_end = date_start + timedelta(days=1)
+    elif from_date:
+        from datetime import date as date_type
+        parsed = date_type.fromisoformat(from_date)
+        date_start = datetime.combine(parsed, datetime.min.time()).replace(tzinfo=JST)
+        # date_end は None のままにして上限なしフィルタにする
 
     family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
     is_admin = (family_user and family_user.role == UserRole.ADMIN) or current_user.is_superadmin
@@ -231,7 +237,9 @@ def get_records(
             Feeding.is_deleted == False
         )
         if date_start:
-            feeding_q = feeding_q.filter(Feeding.feeding_time >= date_start, Feeding.feeding_time < date_end)
+            feeding_q = feeding_q.filter(Feeding.feeding_time >= date_start)
+            if date_end:
+                feeding_q = feeding_q.filter(Feeding.feeding_time < date_end)
         for feeding in feeding_q.order_by(Feeding.feeding_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 feeding.id, "feeding", feeding.user_id, feeding.feeding_time,
@@ -253,7 +261,9 @@ def get_records(
             Sleep.is_deleted == False
         )
         if date_start:
-            sleep_q = sleep_q.filter(Sleep.start_time >= date_start, Sleep.start_time < date_end)
+            sleep_q = sleep_q.filter(Sleep.start_time >= date_start)
+            if date_end:
+                sleep_q = sleep_q.filter(Sleep.start_time < date_end)
         for sleep in sleep_q.order_by(Sleep.start_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 sleep.id, "sleep", sleep.user_id, sleep.start_time,
@@ -273,7 +283,9 @@ def get_records(
             Diaper.is_deleted == False
         )
         if date_start:
-            diaper_q = diaper_q.filter(Diaper.change_time >= date_start, Diaper.change_time < date_end)
+            diaper_q = diaper_q.filter(Diaper.change_time >= date_start)
+            if date_end:
+                diaper_q = diaper_q.filter(Diaper.change_time < date_end)
         for diaper in diaper_q.order_by(Diaper.change_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 diaper.id, "diaper", diaper.user_id, diaper.change_time,
@@ -293,8 +305,10 @@ def get_records(
             Growth.baby_id == baby_id,
             Growth.is_deleted == False
         )
-        if date_start and date_end:
-            growth_q = growth_q.filter(Growth.date >= date_start.date(), Growth.date < date_end.date())
+        if date_start:
+            growth_q = growth_q.filter(Growth.date >= date_start.date())
+            if date_end:
+                growth_q = growth_q.filter(Growth.date < date_end.date())
         for growth in growth_q.order_by(Growth.date.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 growth.id, "growth", growth.user_id,
@@ -317,7 +331,9 @@ def get_records(
             Note.is_deleted == False
         )
         if date_start:
-            note_q = note_q.filter(Note.note_time >= date_start, Note.note_time < date_end)
+            note_q = note_q.filter(Note.note_time >= date_start)
+            if date_end:
+                note_q = note_q.filter(Note.note_time < date_end)
         for note in note_q.order_by(Note.note_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 note.id, "note", note.user_id, note.note_time,
@@ -337,7 +353,9 @@ def get_records(
             Contraction.is_deleted == False
         )
         if date_start:
-            contraction_q = contraction_q.filter(Contraction.start_time >= date_start, Contraction.start_time < date_end)
+            contraction_q = contraction_q.filter(Contraction.start_time >= date_start)
+            if date_end:
+                contraction_q = contraction_q.filter(Contraction.start_time < date_end)
         for c in contraction_q.order_by(Contraction.start_time.desc()).limit(MAX_PAGINATION_LIMIT).all():
             raw_records.append((
                 c.id, "contraction", c.user_id, c.start_time,

--- a/frontend/components/dashboard/JarPhysicsView.tsx
+++ b/frontend/components/dashboard/JarPhysicsView.tsx
@@ -91,7 +91,7 @@ export function JarPhysicsView({ babyId, records, isLoading, mutate }: Props) {
             )}
 
             <JarShelf
-                records={records}
+                babyId={babyId}
                 selectedDate={selectedDate}
                 onDateChange={handleDateChange}
             />

--- a/frontend/components/dashboard/JarShelf.tsx
+++ b/frontend/components/dashboard/JarShelf.tsx
@@ -1,25 +1,43 @@
 "use client"
 
-import { useMemo } from "react"
+import { useMemo, useEffect, useState } from "react"
 import { BabyRecord } from "@/types/record"
+import { useShelfRecords } from "@/hooks/useShelfRecords"
 
-// ミニ瓶のサイズ定数
+// ミニ瓶の寸法定数（物理・描画共通）
 const MINI_W = 68
 const MINI_H = 96
 const MINI_WALL = 6
-const MINI_NECK_W = 22
 const MINI_NECK_H = 10
+const HEX_R = 5
+const DAYS_BACK = 13
 
-const TYPE_DOT_COLORS: Record<string, string> = {
-    feeding: "#f97316",   // orange-500
-    sleep: "#6366f1",     // indigo-500
-    diaper: "#f59e0b",    // amber-500
-    growth: "#22c55e",    // green-500
-    note: "#a855f7",      // purple-500
-    contraction: "#f43f5e", // rose-500
+const TYPE_COLORS: Record<string, string> = {
+    feeding:     "#f97316",
+    sleep:       "#6366f1",
+    diaper:      "#f59e0b",
+    growth:      "#22c55e",
+    note:        "#a855f7",
+    contraction: "#f43f5e",
 }
 
-// 線形合同法による再現性ある疑似乱数
+// --- 物理レイアウト計算 ---
+
+interface PhysicsToken {
+    id: number
+    type: BabyRecord["type"]
+    x: number
+    y: number
+    angle: number
+}
+
+function miniHexVertices(R: number) {
+    return Array.from({ length: 6 }, (_, i) => {
+        const a = (Math.PI / 3) * i - Math.PI / 2
+        return { x: R * Math.cos(a), y: R * Math.sin(a) }
+    })
+}
+
 function seededRng(seed: number) {
     let s = seed >>> 0
     return () => {
@@ -28,36 +46,94 @@ function seededRng(seed: number) {
     }
 }
 
-function calcDots(records: BabyRecord[]) {
+async function computePhysicsLayout(records: BabyRecord[]): Promise<PhysicsToken[]> {
+    if (records.length === 0) return []
+
+    const Matter = await import("matter-js")
+    const decomp = await import("poly-decomp")
+    Matter.Common.setDecomp(decomp.default ?? decomp)
+
+    const engine = Matter.Engine.create({ gravity: { y: 1.5 } })
+    const wallOpts = { isStatic: true, friction: 0.5, restitution: 0.05 }
+    const innerW = MINI_W - MINI_WALL * 2
+
+    Matter.Composite.add(engine.world, [
+        Matter.Bodies.rectangle(MINI_WALL / 2, MINI_H / 2, MINI_WALL, MINI_H, wallOpts),
+        Matter.Bodies.rectangle(MINI_W - MINI_WALL / 2, MINI_H / 2, MINI_WALL, MINI_H, wallOpts),
+        Matter.Bodies.rectangle(MINI_W / 2, MINI_H - MINI_WALL / 2, MINI_W, MINI_WALL, wallOpts),
+    ])
+
     const rng = seededRng(records.reduce((acc, r) => acc + r.id, 42))
-    const innerX = MINI_WALL + 2
-    const innerW = MINI_W - MINI_WALL * 2 - 4
-    const innerY = MINI_NECK_H + 2
-    const innerH = MINI_H - MINI_NECK_H - MINI_WALL - 4
-    return records.slice(0, 24).map(r => ({
-        x: innerX + rng() * innerW,
-        y: innerY + rng() * innerH,
-        color: TYPE_DOT_COLORS[r.type] ?? "#9ca3af",
-    }))
+    const hexVerts = miniHexVertices(HEX_R)
+    const bodyToRecord = new Map<number, BabyRecord>()
+
+    const sorted = [...records].sort(
+        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    )
+
+    for (const record of sorted) {
+        const x = MINI_WALL + HEX_R + rng() * (innerW - HEX_R * 2)
+        const y = MINI_NECK_H + HEX_R
+        const body = Matter.Bodies.fromVertices(x, y, [hexVerts], {
+            restitution: 0.08,
+            friction: 0.6,
+            density: 0.004,
+            frictionAir: 0.12,
+        }, true)
+        Matter.Body.setPosition(body, { x, y })
+        Matter.Composite.add(engine.world, body)
+        bodyToRecord.set(body.id, record)
+    }
+
+    const dt = 1000 / 60
+    for (let i = 0; i < 250; i++) {
+        Matter.Engine.update(engine, dt)
+    }
+
+    const result: PhysicsToken[] = []
+    for (const body of Matter.Composite.allBodies(engine.world)) {
+        if (body.isStatic) continue
+        const record = bodyToRecord.get(body.id)
+        if (record) {
+            result.push({
+                id: record.id,
+                type: record.type,
+                x: body.position.x,
+                y: body.position.y,
+                angle: body.angle,
+            })
+        }
+    }
+
+    Matter.Engine.clear(engine)
+    return result
 }
 
-interface MiniJarVisualProps {
-    selected: boolean
+// --- SVG 六角形ポリゴンのポイント計算 ---
+
+function hexPolygonPoints(cx: number, cy: number, r: number, angle: number): string {
+    return Array.from({ length: 6 }, (_, i) => {
+        const a = angle + (Math.PI / 3) * i - Math.PI / 2
+        return `${(cx + r * Math.cos(a)).toFixed(2)},${(cy + r * Math.sin(a)).toFixed(2)}`
+    }).join(" ")
 }
 
-function MiniJarVisual({ selected }: MiniJarVisualProps) {
+// --- ミニ瓶 SVG ビジュアル ---
+
+function MiniJarVisual({ selected }: { selected: boolean }) {
     const w = MINI_W
     const h = MINI_H
-    const neckX = (w - MINI_NECK_W) / 2
+    const neckW = 22
+    const neckX = (w - neckW) / 2
     const r = 4
 
     const path = [
         `M ${neckX} ${MINI_NECK_H}`,
         `L ${neckX} 2`,
         `Q ${neckX} 0 ${neckX + 2} 0`,
-        `L ${neckX + MINI_NECK_W - 2} 0`,
-        `Q ${neckX + MINI_NECK_W} 0 ${neckX + MINI_NECK_W} 2`,
-        `L ${neckX + MINI_NECK_W} ${MINI_NECK_H}`,
+        `L ${neckX + neckW - 2} 0`,
+        `Q ${neckX + neckW} 0 ${neckX + neckW} 2`,
+        `L ${neckX + neckW} ${MINI_NECK_H}`,
         `L ${w - r} ${MINI_NECK_H}`,
         `Q ${w} ${MINI_NECK_H} ${w} ${MINI_NECK_H + r}`,
         `L ${w} ${h - r}`,
@@ -70,12 +146,11 @@ function MiniJarVisual({ selected }: MiniJarVisualProps) {
     ].join(" ")
 
     const stroke = selected ? "rgba(99,102,241,0.85)" : "rgba(147,197,253,0.5)"
-    const fill = selected ? "rgba(199,210,254,0.18)" : "rgba(186,230,253,0.1)"
-    const strokeW = selected ? 1.5 : 1
+    const fill   = selected ? "rgba(199,210,254,0.18)" : "rgba(186,230,253,0.1)"
 
     return (
         <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} aria-hidden>
-            <path d={path} fill={fill} stroke={stroke} strokeWidth={strokeW} />
+            <path d={path} fill={fill} stroke={stroke} strokeWidth={selected ? 1.5 : 1} />
             <rect x={0} y={MINI_NECK_H} width={MINI_WALL} height={h - MINI_NECK_H} fill="rgba(186,230,253,0.08)" />
             <rect x={w - MINI_WALL} y={MINI_NECK_H} width={MINI_WALL} height={h - MINI_NECK_H} fill="rgba(186,230,253,0.08)" />
             <rect x={0} y={h - MINI_WALL} width={w} height={MINI_WALL} fill="rgba(186,230,253,0.08)" />
@@ -83,6 +158,8 @@ function MiniJarVisual({ selected }: MiniJarVisualProps) {
         </svg>
     )
 }
+
+// --- JarThumbnail ---
 
 interface JarThumbnailProps {
     date: Date
@@ -92,7 +169,18 @@ interface JarThumbnailProps {
 }
 
 function JarThumbnail({ date, records, selected, onClick }: JarThumbnailProps) {
-    const dots = useMemo(() => calcDots(records), [records])
+    const [tokens, setTokens] = useState<PhysicsToken[] | null>(null)
+
+    const recordKey = records.map(r => r.id).sort().join(",")
+
+    useEffect(() => {
+        let cancelled = false
+        computePhysicsLayout(records).then(result => {
+            if (!cancelled) setTokens(result)
+        })
+        return () => { cancelled = true }
+        // recordKey で変化を検知する
+    }, [recordKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
     const label = useMemo(() => {
         const today = new Date()
@@ -108,32 +196,47 @@ function JarThumbnail({ date, records, selected, onClick }: JarThumbnailProps) {
             onClick={onClick}
             className={[
                 "flex flex-col items-center gap-1 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded",
-                selected ? "scale-105" : "hover:scale-103 active:scale-95",
+                selected ? "scale-105" : "hover:scale-105 active:scale-95",
             ].join(" ")}
             aria-pressed={selected}
             title={`${date.getMonth() + 1}/${date.getDate()}の記録`}
         >
             <div style={{ position: "relative", width: MINI_W, height: MINI_H }}>
                 <MiniJarVisual selected={selected} />
+
                 <svg
                     width={MINI_W}
                     height={MINI_H}
                     style={{ position: "absolute", top: 0, left: 0, pointerEvents: "none" }}
                     aria-hidden
                 >
-                    {dots.map((dot, i) => (
-                        <circle key={i} cx={dot.x} cy={dot.y} r={2.5} fill={dot.color} fillOpacity={0.85} />
+                    {tokens?.map(token => (
+                        <polygon
+                            key={token.id}
+                            points={hexPolygonPoints(token.x, token.y, HEX_R, token.angle)}
+                            fill={TYPE_COLORS[token.type] ?? "#9ca3af"}
+                            fillOpacity={0.88}
+                        />
                     ))}
+                    {tokens === null && records.length > 0 && (
+                        <text x={MINI_W / 2} y={MINI_H / 2 + 4} textAnchor="middle" fontSize={9} fill="rgba(147,197,253,0.6)">…</text>
+                    )}
                 </svg>
+
                 {records.length === 0 && (
                     <div
-                        style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", paddingTop: MINI_NECK_H }}
+                        style={{
+                            position: "absolute", inset: 0,
+                            display: "flex", alignItems: "center", justifyContent: "center",
+                            paddingTop: MINI_NECK_H,
+                        }}
                         className="pointer-events-none"
                     >
                         <span className="text-[10px] text-gray-300 dark:text-zinc-600">空</span>
                     </div>
                 )}
             </div>
+
             <span className={`text-[10px] font-medium leading-none tabular-nums ${selected ? "text-indigo-500 dark:text-indigo-400" : "text-gray-400 dark:text-zinc-500"}`}>
                 {label}
             </span>
@@ -141,29 +244,29 @@ function JarThumbnail({ date, records, selected, onClick }: JarThumbnailProps) {
     )
 }
 
+// --- JarShelf ---
+
 interface JarShelfProps {
-    records: BabyRecord[] | undefined
+    babyId: string
     selectedDate: Date
     onDateChange: (date: Date) => void
-    daysBack?: number
 }
 
-export function JarShelf({ records, selectedDate, onDateChange, daysBack = 13 }: JarShelfProps) {
-    // 今日から daysBack 日前まで（新しい順: 今日が先頭）
+export function JarShelf({ babyId, selectedDate, onDateChange }: JarShelfProps) {
+    const { records } = useShelfRecords(babyId, DAYS_BACK)
+
     const dates = useMemo(() => {
         const today = new Date()
         today.setHours(0, 0, 0, 0)
-        return Array.from({ length: daysBack + 1 }, (_, i) => {
+        return Array.from({ length: DAYS_BACK + 1 }, (_, i) => {
             const d = new Date(today)
             d.setDate(today.getDate() - i)
             return d
         })
-    }, [daysBack])
+    }, [])
 
-    // records を日付キーでグループ化
     const recordsByKey = useMemo(() => {
         const map = new Map<string, BabyRecord[]>()
-        if (!records) return map
         for (const r of records) {
             const t = new Date(r.timestamp)
             const key = `${t.getFullYear()}-${t.getMonth()}-${t.getDate()}`
@@ -180,7 +283,7 @@ export function JarShelf({ records, selectedDate, onDateChange, daysBack = 13 }:
         <div className="w-full mt-3">
             <div
                 className="flex gap-2.5 overflow-x-auto pb-3 px-3"
-                style={{ scrollbarWidth: "none", WebkitOverflowScrolling: "touch" }}
+                style={{ scrollbarWidth: "none" } as React.CSSProperties}
             >
                 {dates.map(date => {
                     const key = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
@@ -197,7 +300,6 @@ export function JarShelf({ records, selectedDate, onDateChange, daysBack = 13 }:
                     )
                 })}
             </div>
-            {/* 棚板 */}
             <div className="h-[2px] mx-3 rounded-full bg-gradient-to-r from-transparent via-sky-300/40 dark:via-sky-700/30 to-transparent" />
         </div>
     )

--- a/frontend/hooks/useShelfRecords.ts
+++ b/frontend/hooks/useShelfRecords.ts
@@ -1,0 +1,31 @@
+import useSWR from "swr"
+import { fetcher } from "@/lib/api"
+import { BabyRecord } from "@/types/record"
+
+/**
+ * 棚ビュー用のデータ取得フック。
+ * from_date パラメータを使って過去 daysBack 日分のレコードをまとめて取得する。
+ * useRecords の 100件キャッシュとは独立して動作する。
+ */
+export function useShelfRecords(
+    babyId: string | null,
+    daysBack: number
+): { records: BabyRecord[]; isLoading: boolean } {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const fromDate = new Date(today)
+    fromDate.setDate(today.getDate() - daysBack)
+    const fromDateStr = [
+        fromDate.getFullYear(),
+        String(fromDate.getMonth() + 1).padStart(2, "0"),
+        String(fromDate.getDate()).padStart(2, "0"),
+    ].join("-")
+
+    const { data, isLoading } = useSWR<BabyRecord[]>(
+        babyId ? `/babies/${babyId}/records?from_date=${fromDateStr}&limit=500` : null,
+        fetcher,
+        { revalidateOnFocus: false }
+    )
+
+    return { records: data ?? [], isLoading }
+}

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4585,8 +4585,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
-              "maximum": 100,
+              "default": 500,
+              "maximum": 500,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
@@ -4797,8 +4797,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
-              "maximum": 100,
+              "default": 500,
+              "maximum": 500,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
@@ -6008,14 +6008,14 @@
             "required": false,
             "schema": {
               "default": 20,
-              "maximum": 100,
+              "maximum": 500,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
           },
           {
-            "description": "YYYY-MM-DD形式の日付フィルタ",
+            "description": "YYYY-MM-DD形式の日付フィルタ（1日分）",
             "in": "query",
             "name": "date",
             "required": false,
@@ -6028,8 +6028,26 @@
                   "type": "null"
                 }
               ],
-              "description": "YYYY-MM-DD形式の日付フィルタ",
+              "description": "YYYY-MM-DD形式の日付フィルタ（1日分）",
               "title": "Date"
+            }
+          },
+          {
+            "description": "YYYY-MM-DD形式の開始日フィルタ（以降すべて）",
+            "in": "query",
+            "name": "from_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "YYYY-MM-DD形式の開始日フィルタ（以降すべて）",
+              "title": "From Date"
             }
           }
         ],
@@ -6538,8 +6556,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
-              "maximum": 100,
+              "default": 500,
+              "maximum": 500,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
@@ -8371,8 +8389,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
-              "maximum": 100,
+              "default": 500,
+              "maximum": 500,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"


### PR DESCRIPTION
## Summary

- **バックエンド**: `GET /babies/{id}/records` に `from_date` クエリパラメータを追加（YYYY-MM-DD、指定日以降の全記録を返す）
- **バックエンド**: `MAX_PAGINATION_LIMIT` を 100→500 に拡大（棚ビュー用の広い日付範囲に対応）
- **`useShelfRecords` 新規**: `from_date=13日前&limit=500` で棚専用データを独立取得するフック
- **`JarShelf` 全面刷新**: `babyId` を受け取り `useShelfRecords` で自律データ取得。ランダムドットの代わりに Matter.js オフライン物理計算でトークン位置を決定（レンダリングなし、250ステップ演算で安定位置を算出）
- **`JarPhysicsView`**: `JarShelf` に `babyId` を渡すように変更

## Test plan

- [ ] 棚に今日から13日前までのサムネイルが表示される（7日以前も含む）
- [ ] サムネイル内のトークンが物理エンジンで積み重なったように配置される
- [ ] 記録の種類ごとに色が異なるトークンが表示される
- [ ] 記録なしの日は「空」と表示される
- [ ] サムネイルタップでメイン瓶の日付が切り替わる