### PR TITLE
fix: invite_code.isupper()を==upper()比較に修正

### DIFF
--- a/tests/test_auth_case_insensitive.py
+++ b/tests/test_auth_case_insensitive.py
@@ -10,7 +10,8 @@ def test_join_family_lowercase_fails(client):
     invite_code = res.json()["invite_code"]
 
     # Verify invite code is uppercase (as per previous fix)
-    assert invite_code.isupper()
+    # isupper() は letter を含まない文字列（全数字 hex など）で False を返すため == upper() で比較する
+    assert invite_code == invite_code.upper()
 
     # 2. Join family with lowercase invite code
     # This should fail if the backend does not normalize input


### PR DESCRIPTION
## 概要

`test_join_family_lowercase_fails` がフレーキーに失敗する問題を修正。

## 原因

`secrets.token_hex(8)` が生成する招待コードが全数字の hex（例: `9880895547199928`）の場合、`str.isupper()` は文字（letter）を含まない文字列に対して `False` を返す仕様のため、テストが誤って失敗していた。

## 修正

```python
# Before
assert invite_code.isupper()

# After
assert invite_code == invite_code.upper()
```

`== upper()` 比較は文字列が大文字かどうかを正しく検証し、全数字文字列でも期待通り `True` を返す。

## テスト計画
- [ ] CI で `test_join_family_lowercase_fails` が安定して通過することを確認