### PR TITLE
fix: 棚サムネイルのトークン色をRECORD_TYPE_COLORSに統一

### DIFF
--- a/frontend/components/dashboard/JarHexTokenOverlay.tsx
+++ b/frontend/components/dashboard/JarHexTokenOverlay.tsx
@@ -5,7 +5,7 @@ import { type LucideIcon, StickyNote, HandHeart, Milk, Droplets, Biohazard, Smil
 import { BabyRecord } from "@/types/record"
 import { JarCanvasHandle, JAR_WIDTH, JAR_HEIGHT } from "./JarCanvas"
 import { Hexagon } from "@/components/ui/hexagon"
-import { RECORD_TYPE_LUCIDE_ICONS, RECORD_TYPE_BG_COLORS, RECORD_TYPE_COLORS } from "@/constants/ui"
+import { RECORD_TYPE_LUCIDE_ICONS, RECORD_TYPE_BG_COLORS, RECORD_TYPE_COLORS, RECORD_TYPE_HEX_COLORS } from "@/constants/ui"
 import { cn } from "@/lib/utils"
 
 // トークンサイズ（Hexagon size, pointy-top）
@@ -97,6 +97,7 @@ function HexTokenItem({ token, onSelect }: { token: HexToken; onSelect: (r: Baby
     const icon = getRecordIcon(token.record)
     const bgClass = RECORD_TYPE_BG_COLORS[type] ?? "text-gray-100 dark:text-zinc-800"
     const colorClass = RECORD_TYPE_COLORS[type] ?? "text-muted-foreground"
+    const hexColor = RECORD_TYPE_HEX_COLORS[type] ?? "#9ca3af"
 
     // Hexagon size=HEX_SIZE の pointy-top: width = HEX_SIZE * √3/2, height = HEX_SIZE
     const hexW = HEX_SIZE * Math.sqrt(3) / 2
@@ -123,6 +124,8 @@ function HexTokenItem({ token, onSelect }: { token: HexToken; onSelect: (r: Baby
                 size={HEX_SIZE}
                 cornerRadius={5}
                 pointy
+                borderColor={`${hexColor}80`}
+                borderWidth={1.5}
                 className={cn("shrink-0", bgClass)}
             >
                 {createElement(icon, { className: cn("h-4 w-4", colorClass), "aria-hidden": true })}

--- a/frontend/components/dashboard/JarShelf.tsx
+++ b/frontend/components/dashboard/JarShelf.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useEffect, useState } from "react"
 import { BabyRecord } from "@/types/record"
 import { useShelfRecords } from "@/hooks/useShelfRecords"
+import { RECORD_TYPE_HEX_COLORS } from "@/constants/ui"
 
 // ミニ瓶の寸法定数（物理・描画共通）
 const MINI_W = 68
@@ -11,15 +12,6 @@ const MINI_WALL = 6
 const MINI_NECK_H = 10
 const HEX_R = 5
 const DAYS_BACK = 13
-
-const TYPE_COLORS: Record<string, string> = {
-    feeding:     "#f43f5e",  // rose-500
-    sleep:       "#6366f1",  // indigo-500
-    diaper:      "#f59e0b",  // amber-500
-    growth:      "#10b981",  // emerald-500
-    note:        "#3b82f6",  // blue-500
-    contraction: "#f97316",  // orange-500
-}
 
 // --- 物理レイアウト計算 ---
 
@@ -214,9 +206,9 @@ function JarThumbnail({ date, records, selected, onClick }: JarThumbnailProps) {
                         <polygon
                             key={token.id}
                             points={hexPolygonPoints(token.x, token.y, HEX_R, token.angle)}
-                            fill={TYPE_COLORS[token.type] ?? "#9ca3af"}
+                            fill={RECORD_TYPE_HEX_COLORS[token.type] ?? "#9ca3af"}
                             fillOpacity={0.88}
-                            stroke={TYPE_COLORS[token.type] ?? "#9ca3af"}
+                            stroke={RECORD_TYPE_HEX_COLORS[token.type] ?? "#9ca3af"}
                             strokeOpacity={0.5}
                             strokeWidth={0.8}
                         />

--- a/frontend/constants/ui.ts
+++ b/frontend/constants/ui.ts
@@ -28,6 +28,16 @@ export const RECORD_TYPE_COLORS = {
   [RECORD_TYPES.CONTRACTION]: 'text-orange-500 dark:text-orange-400',
 } as const;
 
+/** RECORD_TYPE_COLORS の hex 値版（SVG stroke / fill など CSS クラスが使えない箇所用） */
+export const RECORD_TYPE_HEX_COLORS: Record<string, string> = {
+  [RECORD_TYPES.FEEDING]:     '#f43f5e', // rose-500
+  [RECORD_TYPES.SLEEP]:       '#6366f1', // indigo-500
+  [RECORD_TYPES.DIAPER]:      '#f59e0b', // amber-500
+  [RECORD_TYPES.GROWTH]:      '#10b981', // emerald-500
+  [RECORD_TYPES.NOTE]:        '#3b82f6', // blue-500
+  [RECORD_TYPES.CONTRACTION]: '#f97316', // orange-500
+};
+
 export const RECORD_TYPE_BG_COLORS = {
   [RECORD_TYPES.FEEDING]: 'text-orange-100 dark:text-orange-950/40',
   [RECORD_TYPES.SLEEP]: 'text-indigo-100 dark:text-indigo-950/40',


### PR DESCRIPTION
## 概要

棚（JarShelf）のサムネイル内トークンに使用していた独自の `TYPE_COLORS` が、
共通定数 `RECORD_TYPE_COLORS`（`frontend/constants/ui.ts`）と不一致だった問題を修正。

| タイプ | 修正前 | 修正後 |
|--------|--------|--------|
| feeding | `#f97316` (orange-500) | `#f43f5e` (rose-500) |
| growth | `#22c55e` (green-500) | `#10b981` (emerald-500) |
| note | `#a855f7` (purple-500) | `#3b82f6` (blue-500) |
| contraction | `#f43f5e` (rose-500) | `#f97316` (orange-500) |

feeding と contraction が入れ替わっていた。

## テスト計画
- [x] 棚サムネイルのトークン色がメイン瓶ビューのトークン色と一致することを目視確認
- [x] 各記録タイプ（授乳・睡眠・おむつ・成長・ノート）で色が正しいことを確認