### PR TITLE
🎨 Palette: ダッシュボードの日付ナビゲーションボタンのアクセシビリティを改善

### DIFF
--- a/frontend/components/dashboard/JarDateNav.tsx
+++ b/frontend/components/dashboard/JarDateNav.tsx
@@ -39,13 +39,13 @@ export function JarDateNav({ date, onChange }: Props) {
 
     return (
         <div className="flex items-center justify-between px-1 mb-2">
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={prev}>
+            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={prev} aria-label="前日へ" title="前日へ">
                 <ChevronLeft className="h-4 w-4" />
             </Button>
             <span className="text-sm font-medium text-gray-600 dark:text-zinc-300 min-w-[4rem] text-center">
                 {formatDate(date)}
             </span>
-            <Button variant="ghost" size="icon" className="h-7 w-7" disabled={isToday} onClick={next}>
+            <Button variant="ghost" size="icon" className="h-7 w-7" disabled={isToday} onClick={next} aria-label="翌日へ" title="翌日へ">
                 <ChevronRight className="h-4 w-4" />
             </Button>
         </div>


### PR DESCRIPTION
💡 何を:
ダッシュボードの日付ナビゲーションコンポーネント (`JarDateNav.tsx`) にある「前へ」「次へ」のアイコンのみのボタンに、`aria-label` と `title` 属性（"前日へ", "翌日へ"）を追加しました。

🎯 なぜ:
これらのボタンはアイコン（ChevronLeft, ChevronRight）のみで構成されており、スクリーンリーダー等の支援技術を使用するユーザーにとって、ボタンの目的が不明確でした。また、一般のユーザーにとっても、マウスホバー時に何のボタンか説明が出ることでより直感的な操作が可能になります（マイクロUXの改善）。

📸 Before/After:
* **Before:** `<Button variant="ghost" size="icon" onClick={prev}> <ChevronLeft /> </Button>` (支援技術には単なるボタンとしか認識されない)
* **After:** `<Button variant="ghost" size="icon" onClick={prev} aria-label="前日へ" title="前日へ"> <ChevronLeft /> </Button>` (支援技術で「前日へ、ボタン」と読み上げられ、ホバーでツールチップが表示される)

♿ アクセシビリティ:
WCAGの「非テキストコンテンツ（アイコン）」に対する代替テキストの提供ガイドラインに準拠しました。キーボード操作可能な既存の `<Button>` コンポーネントを維持しつつ、セマンティクスを向上させています。

---
*PR created automatically by Jules for task [10208683453589559407](https://jules.google.com/task/10208683453589559407) started by @eburairu*