### PR TITLE
🧹 Tidy: RecordDetailDialogの削除ロジックをuseRecordDeleteに共通化

### DIFF
--- a/frontend/components/dashboard/RecordDetailDialog.tsx
+++ b/frontend/components/dashboard/RecordDetailDialog.tsx
@@ -14,7 +14,7 @@ import { CommentSection } from "@/components/records/CommentSection"
 import { EditDialogBase } from "@/components/records/EditDialogBase"
 import { api, isApiError } from "@/lib/api"
 import { formatJapaneseDateTime, formatDateLocal } from "@/lib/dateUtils"
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog"
+import { useRecordDelete } from "@/hooks/useRecordDelete"
 import { RECORD_TYPE_LABELS } from "@/constants/ui"
 
 interface Props {
@@ -98,34 +98,26 @@ export function RecordDetailDialog({ record, open, onOpenChange, onSuccess }: Pr
     )
   }
 
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
-
-  const handleDelete = async () => {
-    if (!record) return
-
-    await execute(
-      async () => {
-        let endpoint = ""
-        switch (record.type) {
-          case RECORD_TYPES.FEEDING: endpoint = `/feedings/${record.id}`; break
-          case RECORD_TYPES.SLEEP: endpoint = `/sleeps/${record.id}`; break
-          case RECORD_TYPES.DIAPER: endpoint = `/diapers/${record.id}`; break
-          case RECORD_TYPES.GROWTH: endpoint = `/growths/${record.id}`; break
-          case RECORD_TYPES.NOTE: endpoint = `/notes/${record.id}`; break
-          case RECORD_TYPES.CONTRACTION: endpoint = `/contractions/${record.id}`; break
-        }
-        await api.delete(endpoint)
-      },
-      {
-        onSuccess: () => {
-          setDeleteConfirmOpen(false)
-          onSuccess()
-          onOpenChange(false)
-        },
-        errorMessage: "削除に失敗しました"
+  const { setDeleteTargetId, ConfirmDeleteDialog, isDeleting } = useRecordDelete({
+    onDelete: async (id: number) => {
+      if (!record) return
+      let endpoint = ""
+      switch (record.type) {
+        case RECORD_TYPES.FEEDING: endpoint = `/feedings/${id}`; break
+        case RECORD_TYPES.SLEEP: endpoint = `/sleeps/${id}`; break
+        case RECORD_TYPES.DIAPER: endpoint = `/diapers/${id}`; break
+        case RECORD_TYPES.GROWTH: endpoint = `/growths/${id}`; break
+        case RECORD_TYPES.NOTE: endpoint = `/notes/${id}`; break
+        case RECORD_TYPES.CONTRACTION: endpoint = `/contractions/${id}`; break
       }
-    )
-  }
+      await api.delete(endpoint)
+    },
+    onSuccess: () => {
+      onSuccess()
+      onOpenChange(false)
+    },
+    resourceName: "記録",
+  })
 
   if (!record) return null
 
@@ -172,8 +164,8 @@ export function RecordDetailDialog({ record, open, onOpenChange, onSuccess }: Pr
                 <Button
                   type="button"
                   variant="ghost"
-                  onClick={() => setDeleteConfirmOpen(true)}
-                  disabled={loading}
+                  onClick={() => setDeleteTargetId(record.id)}
+                  disabled={loading || isDeleting}
                   className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 sm:mr-auto"
                 >
                   削除
@@ -211,22 +203,7 @@ export function RecordDetailDialog({ record, open, onOpenChange, onSuccess }: Pr
         </div>
       </EditDialogBase>
 
-      <AlertDialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle data-sentry-unmask>記録の削除</AlertDialogTitle>
-            <AlertDialogDescription data-sentry-unmask>
-              この記録を削除しますか？この操作は取り消せません。
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={loading} data-sentry-unmask>キャンセル</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete} data-sentry-unmask className="bg-red-600 hover:bg-red-700" loading={loading}>
-              削除
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDeleteDialog />
     </>
   )
 }


### PR DESCRIPTION
💡 何を
`RecordDetailDialog` コンポーネント内の削除確認ダイアログ（`<AlertDialog>`）と、その開閉状態（`deleteConfirmOpen`）を、既存のカスタムフック `useRecordDelete` を利用するようにリファクタリングしました。

🎯 なぜ
他の履歴コンポーネント（`GrowthHistoryList`、`NoteHistory`、`GenericRecordHistory`、`ContractionHistory`、`sleep-history`）ではすでに `useRecordDelete` を利用して削除ダイアログを共通化しています。しかし、`RecordDetailDialog` は独自で状態管理とコンポーネントの記述を行っており、コードの重複（ボイラープレート）が発生していました。これを統一することで、DRY原則に従い可読性と保守性を向上させます。

🛡️ 安全性
- `useRecordDelete` に渡す `onDelete` コールバック内に、既存の API 呼び出しロジックをそのまま移行しました。
- `pnpm test` を実行し、既存のテスト（`DiaryEditDialog.test.tsx`などを含む）がすべてパスすることを確認しました。
- `pnpm build` が正常に完了することを確認しました。
- 既存の `useRecordDelete` の実装（UIや振る舞い）に依存しており、新しい機能の追加やUIデザインの変更は行っていません。

---
*PR created automatically by Jules for task [1706257339685790000](https://jules.google.com/task/1706257339685790000) started by @eburairu*