### PR TITLE
✍️ Scribe: [仕様書同期] 通知センターのサービス関数の引数定義を最新実装に更新

### DIFF
--- a/.specify/specs/ui/notification_center.md
+++ b/.specify/specs/ui/notification_center.md
@@ -283,7 +283,7 @@ def notify_achievements_bg(
     baby_name: str,
     baby_id: int,
     unlocked: list[dict],
-):
+) -> None:
     """
     実績（アチーブメント）解除時に同ファミリーの全メンバーに通知を送信。
     """


### PR DESCRIPTION
💡 **何を (What)**
`.specify/specs/ui/notification_center.md` 内の `notify_achievements_bg` の引数リストに対して、現在の `app/utils/notifications.py` の実装と一致するよう、戻り値の型 `-> None` を追加しました。

🔍 **発見 (Discovery)**
`app/utils/notifications.py` に実装されている `notify_achievements_bg` 関数は戻り値の型 `-> None` を明示して定義されていますが、仕様書 (`notification_center.md`) の該当箇所にはその記述が漏れており、実装との間に微細な乖離が生じていました。

🎯 **影響 (Impact)**
仕様書上の型シグネチャが実際の実装と正確に一致することで、開発者がドキュメントを参照して実装する際の混乱を防ぎ、仕様書への信頼性が維持されます。

---
*PR created automatically by Jules for task [17753370535977222796](https://jules.google.com/task/17753370535977222796) started by @eburairu*