### PR TITLE
🎨 Palette: アイコンのみのボタンにARIAラベルを追加

### DIFF
--- a/frontend/components/dashboard/JarHexTokenOverlay.tsx
+++ b/frontend/components/dashboard/JarHexTokenOverlay.tsx
@@ -5,7 +5,7 @@ import { type LucideIcon, StickyNote, HandHeart, Milk, Droplets, Biohazard, Smil
 import { BabyRecord } from "@/types/record"
 import { JarCanvasHandle, JAR_WIDTH, JAR_HEIGHT } from "./JarCanvas"
 import { Hexagon } from "@/components/ui/hexagon"
-import { RECORD_TYPE_LUCIDE_ICONS, RECORD_TYPE_BG_COLORS, RECORD_TYPE_COLORS, RECORD_TYPE_HEX_COLORS } from "@/constants/ui"
+import { RECORD_TYPE_LUCIDE_ICONS, RECORD_TYPE_BG_COLORS, RECORD_TYPE_COLORS, RECORD_TYPE_HEX_COLORS, RECORD_TYPE_LABELS } from "@/constants/ui"
 import { cn } from "@/lib/utils"
 
 // トークンサイズ（Hexagon size, pointy-top）
@@ -107,6 +107,7 @@ function HexTokenItem({ token, onSelect }: { token: HexToken; onSelect: (r: Baby
         <button
             onClick={() => onSelect(token.record)}
             title={token.record.type}
+            aria-label={`${RECORD_TYPE_LABELS[token.record.type as keyof typeof RECORD_TYPE_LABELS] || token.record.type}の記録を見る`}
             style={{
                 position: "absolute",
                 left: token.x - hexW / 2,

--- a/frontend/components/family-tree/RelativeCard.tsx
+++ b/frontend/components/family-tree/RelativeCard.tsx
@@ -25,6 +25,7 @@ export function RelativeCard({
     return (
       <button
         onClick={onClick}
+        aria-label={`${label}を追加`}
         className="flex flex-col items-center gap-1 p-2 rounded-lg border border-dashed border-muted-foreground/30 hover:border-primary/50 hover:bg-accent/50 transition-colors min-w-[64px] text-muted-foreground/60 hover:text-muted-foreground"
       >
         <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-xs">+</div>
@@ -36,6 +37,7 @@ export function RelativeCard({
   return (
     <button
       onClick={onClick}
+      aria-label={`${relative.name} (${label}) の詳細を見る`}
       className={cn(
         "flex flex-col items-center gap-1 p-2 rounded-lg border bg-card hover:bg-accent/50 transition-colors min-w-[64px]",
         "border-border hover:border-primary/50"

--- a/frontend/components/notifications/NotificationBell.tsx
+++ b/frontend/components/notifications/NotificationBell.tsx
@@ -98,6 +98,7 @@ export function NotificationBell() {
                             <button
                                 onClick={handleReadAll}
                                 disabled={isMarkingAllAsRead}
+                                aria-label="すべての通知を既読にする"
                                 className={cn(
                                     "text-xs text-indigo-600 dark:text-indigo-400 hover:underline flex items-center gap-1",
                                     isMarkingAllAsRead && "opacity-70 cursor-wait"


### PR DESCRIPTION
💡 何を
以下のコンポーネント内にあるアイコンのみ、または視覚情報のみのボタンに対して `aria-label` を追加しました：
- `RelativeCard.tsx`: 親族追加ボタン、および親族詳細ボタン
- `JarHexTokenOverlay.tsx`: ダッシュボードの記録ヘキサゴントークンボタン
- `NotificationBell.tsx`: すべて既読にするボタン

🎯 なぜ
アイコンやレイアウトのみで機能が示されているボタンは、スクリーンリーダーを利用するユーザーにとって、何の機能を持っているか理解することが困難です。適切な `aria-label` を追加することで、スクリーンリーダーユーザーが各ボタンの目的を正確に把握でき、アクセシビリティが向上します。

📸 Before/After
視覚的な変更はありません（HTML属性の追加のみ）。

♿ アクセシビリティ
スクリーンリーダー対応として、視覚的文脈に依存しない代替テキスト（ARIAラベル）を追加しました。

---
*PR created automatically by Jules for task [11932205202535055879](https://jules.google.com/task/11932205202535055879) started by @eburairu*