### PR TITLE
🧹 Tidy: NotificationItemのformatRelativeTime関数をdateUtilsに共通化

### DIFF
--- a/frontend/components/notifications/NotificationItem.tsx
+++ b/frontend/components/notifications/NotificationItem.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils"
 import type { AppNotification } from "@/hooks/useNotifications"
 import { markAsRead } from "@/hooks/useNotifications"
 import { Hexagon } from "@/components/ui/hexagon"
+import { formatRelativeTime } from "@/lib/dateUtils"
 
 const TYPE_ICON: Record<AppNotification["type"], React.ReactNode> = {
     family_record: <Baby className="h-4 w-4 text-rose-500" />,
@@ -15,18 +16,6 @@ const TYPE_ICON: Record<AppNotification["type"], React.ReactNode> = {
     diaper_reminder: <Clock className="h-4 w-4 text-orange-500" />,
     system: <Bell className="h-4 w-4 text-gray-400" />,
     achievement: <Trophy className="h-4 w-4 text-amber-500" />,
-}
-
-function formatRelativeTime(isoString: string): string {
-    const diff = Date.now() - new Date(isoString).getTime()
-    const minutes = Math.floor(diff / 60000)
-    if (minutes < 1) return "たった今"
-    if (minutes < 60) return `${minutes}分前`
-    const hours = Math.floor(minutes / 60)
-    if (hours < 24) return `${hours}時間前`
-    const days = Math.floor(hours / 24)
-    if (days === 1) return "昨日"
-    return `${days}日前`
 }
 
 type Props = {

--- a/frontend/lib/dateUtils.ts
+++ b/frontend/lib/dateUtils.ts
@@ -162,3 +162,18 @@ export function formatMonthDaySlash(date: Date | string | number): string {
   const d = typeof date === "string" || typeof date === "number" ? new Date(date) : date;
   return format(d, "M/d", { locale: ja });
 }
+
+/**
+ * 短い相対時間の文字列を返します（例："たった今"、"5分前"、"昨日"、"2日前"）。
+ */
+export function formatRelativeTime(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "たった今";
+  if (minutes < 60) return `${minutes}分前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}時間前`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return "昨日";
+  return `${days}日前`;
+}


### PR DESCRIPTION
💡 何を
- `frontend/components/notifications/NotificationItem.tsx` に直接定義されていた相対時間のフォーマット関数 `formatRelativeTime` を `frontend/lib/dateUtils.ts` に移動しました。
- `NotificationItem.tsx` では `dateUtils.ts` から当該関数をインポートして利用するように修正しました。

🎯 なぜ
- **DRY原則（重複排除）**: 日付や時間のフォーマット処理を一箇所（`dateUtils.ts`）に集約することで、将来的に他のコンポーネントでも同様の「たった今」「〇分前」といった相対時間表記が必要になった際に再利用できるようにするためです。
- **関心の分離**: UIコンポーネント（`NotificationItem.tsx`）からロジックを分離することで、コンポーネントの可読性と保守性を向上させます。

🛡️ 安全性
- 関数のロジック自体には一切変更を加えていません。
- `pnpm lint`、`pnpm test --run` を実行し、既存のテストや型チェックに影響がないことを確認しました。
- `pnpm build` が正常に通過することを確認しました。

---
*PR created automatically by Jules for task [14028111788756468600](https://jules.google.com/task/14028111788756468600) started by @eburairu*