### PR TITLE
fix: コンフリクトPR群の変更を一括適用

### DIFF
--- a/frontend/components/dashboard/DiaperWidget.tsx
+++ b/frontend/components/dashboard/DiaperWidget.tsx
@@ -17,8 +17,7 @@ export const DiaperWidget = memo(function DiaperWidget({ babyId, records, isErro
 
     const { wetCount, dirtyCount, lastElapsed, lastDiaperTime } = useMemo(() => {
         // tick に依存させることで1分ごとの更新を保証する
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        tick;
+        void tick;
         const diaperRecords = records
             ?.map(normalizeDiaperFromRecord)
             .filter((d): d is NormalizedDiaper => d !== null) ?? []

--- a/frontend/components/dashboard/FeedingWidget.tsx
+++ b/frontend/components/dashboard/FeedingWidget.tsx
@@ -16,8 +16,7 @@ export const FeedingWidget = memo(function FeedingWidget({ babyId, records, isEr
 
     const { todayCount, lastElapsed, lastFeedingTime } = useMemo(() => {
         // tick に依存させることで1分ごとの更新を保証する
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        tick;
+        void tick;
         const feedingRecords = records
             ?.map(normalizeFeedingFromRecord)
             .filter((f): f is NormalizedFeeding => f !== null) ?? []

--- a/frontend/components/dashboard/JarCanvas.tsx
+++ b/frontend/components/dashboard/JarCanvas.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react"
 import { BabyRecord } from "@/types/record"
 import type { Engine, Runner, Body } from "matter-js"
+import { hexVertices } from "@/lib/hexagonUtils"
 
 export const JAR_WIDTH = 220
 export const JAR_HEIGHT = 320
@@ -27,12 +28,6 @@ interface Props {
     onReady?: (handle: JarCanvasHandle) => void
 }
 
-function hexVertices(R: number): { x: number; y: number }[] {
-    return Array.from({ length: 6 }, (_, i) => {
-        const angle = (Math.PI / 3) * i - Math.PI / 2
-        return { x: R * Math.cos(angle), y: R * Math.sin(angle) }
-    })
-}
 
 export function JarCanvas({ records, onReady }: Props) {
     const canvasRef = useRef<HTMLCanvasElement>(null)

--- a/frontend/components/dashboard/JarHexTokenOverlay.tsx
+++ b/frontend/components/dashboard/JarHexTokenOverlay.tsx
@@ -109,7 +109,7 @@ function HexTokenItem({ token, onSelect }: { token: HexToken; onSelect: (r: Baby
         <button
             onClick={() => onSelect(token.record)}
             aria-label={`${recordLabel}の詳細を表示`}
-            title={token.record.type}
+            title={`${recordLabel}の記録`}
             style={{
                 position: "absolute",
                 left: token.x - hexW / 2,

--- a/frontend/components/dashboard/JarShelf.tsx
+++ b/frontend/components/dashboard/JarShelf.tsx
@@ -4,6 +4,7 @@ import { useMemo, useEffect, useState } from "react"
 import { BabyRecord } from "@/types/record"
 import { useShelfRecords } from "@/hooks/useShelfRecords"
 import { RECORD_TYPE_HEX_COLORS } from "@/constants/ui"
+import { hexVertices, hexPolygonPoints } from "@/lib/hexagonUtils"
 
 // ミニ瓶の寸法定数（物理・描画共通）
 const MINI_W = 68
@@ -21,13 +22,6 @@ interface PhysicsToken {
     x: number
     y: number
     angle: number
-}
-
-function miniHexVertices(R: number) {
-    return Array.from({ length: 6 }, (_, i) => {
-        const a = (Math.PI / 3) * i - Math.PI / 2
-        return { x: R * Math.cos(a), y: R * Math.sin(a) }
-    })
 }
 
 function seededRng(seed: number) {
@@ -56,7 +50,7 @@ async function computePhysicsLayout(records: BabyRecord[]): Promise<PhysicsToken
     ])
 
     const rng = seededRng(records.reduce((acc, r) => acc + r.id, 42))
-    const hexVerts = miniHexVertices(HEX_R)
+    const hexVerts = hexVertices(HEX_R)
     const bodyToRecord = new Map<number, BabyRecord>()
 
     const sorted = [...records].sort(
@@ -101,14 +95,6 @@ async function computePhysicsLayout(records: BabyRecord[]): Promise<PhysicsToken
     return result
 }
 
-// --- SVG 六角形ポリゴンのポイント計算 ---
-
-function hexPolygonPoints(cx: number, cy: number, r: number, angle: number): string {
-    return Array.from({ length: 6 }, (_, i) => {
-        const a = angle + (Math.PI / 3) * i - Math.PI / 2
-        return `${(cx + r * Math.cos(a)).toFixed(2)},${(cy + r * Math.sin(a)).toFixed(2)}`
-    }).join(" ")
-}
 
 // --- ミニ瓶 SVG ビジュアル ---
 

--- a/frontend/components/dashboard/RecordDetailDialog.tsx
+++ b/frontend/components/dashboard/RecordDetailDialog.tsx
@@ -15,6 +15,7 @@ import { EditDialogBase } from "@/components/records/EditDialogBase"
 import { api, isApiError } from "@/lib/api"
 import { formatJapaneseDateTime, formatDateLocal } from "@/lib/dateUtils"
 import { useRecordDelete } from "@/hooks/useRecordDelete"
+import { getRecordEndpoint } from "@/lib/recordUtils"
 import { RECORD_TYPE_LABELS } from "@/constants/ui"
 
 interface Props {
@@ -101,16 +102,7 @@ export function RecordDetailDialog({ record, open, onOpenChange, onSuccess }: Pr
   const { setDeleteTargetId, ConfirmDeleteDialog, isDeleting } = useRecordDelete({
     onDelete: async (id: number) => {
       if (!record) return
-      let endpoint = ""
-      switch (record.type) {
-        case RECORD_TYPES.FEEDING: endpoint = `/feedings/${id}`; break
-        case RECORD_TYPES.SLEEP: endpoint = `/sleeps/${id}`; break
-        case RECORD_TYPES.DIAPER: endpoint = `/diapers/${id}`; break
-        case RECORD_TYPES.GROWTH: endpoint = `/growths/${id}`; break
-        case RECORD_TYPES.NOTE: endpoint = `/notes/${id}`; break
-        case RECORD_TYPES.CONTRACTION: endpoint = `/contractions/${id}`; break
-      }
-      await api.delete(endpoint)
+      await api.delete(getRecordEndpoint(record.type, id))
     },
     onSuccess: () => {
       onSuccess()

--- a/frontend/components/dashboard/SleepWidget.tsx
+++ b/frontend/components/dashboard/SleepWidget.tsx
@@ -15,8 +15,7 @@ export const SleepWidget = memo(function SleepWidget({ babyId, records, isError,
 
     const { isSleeping, todayTotal, elapsed, lastElapsed } = useMemo(() => {
         // tick に依存させることで1分ごとの更新を保 証する
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        tick;
+        void tick;
         return calculateSleepStats(records)
     }, [records, tick])
 

--- a/frontend/components/family-tree/RelativeCard.tsx
+++ b/frontend/components/family-tree/RelativeCard.tsx
@@ -25,6 +25,7 @@ export function RelativeCard({
     return (
       <button
         onClick={onClick}
+        aria-label={`${label}を追加`}
         className="flex flex-col items-center gap-1 p-2 rounded-lg border border-dashed border-muted-foreground/30 hover:border-primary/50 hover:bg-accent/50 transition-colors min-w-[64px] text-muted-foreground/60 hover:text-muted-foreground"
       >
         <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-xs">+</div>
@@ -36,6 +37,7 @@ export function RelativeCard({
   return (
     <button
       onClick={onClick}
+      aria-label={`${relative.name} (${label}) の詳細を見る`}
       className={cn(
         "flex flex-col items-center gap-1 p-2 rounded-lg border bg-card hover:bg-accent/50 transition-colors min-w-[64px]",
         "border-border hover:border-primary/50"

--- a/frontend/components/family-tree/RelativeFormDialog.tsx
+++ b/frontend/components/family-tree/RelativeFormDialog.tsx
@@ -158,7 +158,7 @@ function RelativeForm({
             variant="destructive"
             size="sm"
             onClick={handleDelete}
-            disabled={isSubmitting}
+            loading={isSubmitting}
             className="mr-auto"
           >
             削除
@@ -167,7 +167,7 @@ function RelativeForm({
         <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
           キャンセル
         </Button>
-        <Button onClick={handleSubmit} disabled={isSubmitting}>
+        <Button onClick={handleSubmit} loading={isSubmitting}>
           {isEdit ? "保存" : "追加"}
         </Button>
       </DialogFooter>

--- a/frontend/components/notifications/NotificationBell.tsx
+++ b/frontend/components/notifications/NotificationBell.tsx
@@ -98,6 +98,7 @@ export function NotificationBell() {
                             <button
                                 onClick={handleReadAll}
                                 disabled={isMarkingAllAsRead}
+                                aria-label="すべての通知を既読にする"
                                 className={cn(
                                     "text-xs text-indigo-600 dark:text-indigo-400 hover:underline flex items-center gap-1",
                                     isMarkingAllAsRead && "opacity-70 cursor-wait"

--- a/frontend/lib/hexagonUtils.ts
+++ b/frontend/lib/hexagonUtils.ts
@@ -1,0 +1,15 @@
+/** 六角形（pointy-top）の頂点座標を返す */
+export function hexVertices(R: number): { x: number; y: number }[] {
+    return Array.from({ length: 6 }, (_, i) => {
+        const angle = (Math.PI / 3) * i - Math.PI / 2
+        return { x: R * Math.cos(angle), y: R * Math.sin(angle) }
+    })
+}
+
+/** SVG polygon 用の六角形ポイント文字列を返す */
+export function hexPolygonPoints(cx: number, cy: number, r: number, angle: number): string {
+    return Array.from({ length: 6 }, (_, i) => {
+        const a = angle + (Math.PI / 3) * i - Math.PI / 2
+        return `${(cx + r * Math.cos(a)).toFixed(2)},${(cy + r * Math.sin(a)).toFixed(2)}`
+    }).join(" ")
+}

--- a/frontend/lib/recordUtils.ts
+++ b/frontend/lib/recordUtils.ts
@@ -1,0 +1,14 @@
+import { RECORD_TYPES } from "@/types/enums"
+
+export function getRecordEndpoint(type: string, id: number): string {
+    switch (type) {
+        case RECORD_TYPES.FEEDING: return `/feedings/${id}`
+        case RECORD_TYPES.SLEEP: return `/sleeps/${id}`
+        case RECORD_TYPES.DIAPER: return `/diapers/${id}`
+        case RECORD_TYPES.GROWTH: return `/growths/${id}`
+        case RECORD_TYPES.NOTE: return `/notes/${id}`
+        case RECORD_TYPES.CONTRACTION: return `/contractions/${id}`
+        case RECORD_TYPES.TEMPERATURE: return `/temperatures/${id}`
+        default: throw new Error(`Unknown record type: ${type}`)
+    }
+}


### PR DESCRIPTION
## 概要

コンフリクトにより単独マージできなかった5件のPRの変更を手動適用。

## 適用内容

- **#1143** 六角形計算ロジックを `hexagonUtils.ts` に共通化（JarCanvas / JarShelf のインライン関数を削除）
- **#1151** `getRecordEndpoint` を `recordUtils.ts` に抽出（RecordDetailDialog の削除ロジック簡略化）
- **#1152 / #1164** `JarHexTokenOverlay` の title を日本語化、`RelativeCard` / `NotificationBell` に aria-label 追加
- **#1154** Widget の `eslint-disable` コメントを `void tick` に置換
- **#1163** RelativeFormDialog のボタンを `disabled` → `loading` 状態に変更

## クローズされるPR

Closes #1143, #1151, #1152, #1154, #1163, #1164