### PR TITLE
✍️ Scribe: ダッシュボード仕様書の統合レコードスキーマ実装同期

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -5,3 +5,7 @@
 ## 2024-03-20 - 通知サービスの仕様書と実装のズレ修正
 **学び:** `notification_center.md` において、将来実装予定の `notification_service.py` (`async def`) の仕様が記載されていたが、実際の実装は `app/utils/notifications.py` に同期的な `BackgroundTasks` を使って (`notify_family_members_bg` 等) 実装されていた。また、実績解除(`achievement`)等のトリガーに関するメソッド(`notify_achievements_bg`)の記載も漏れていたため、仕様と実装の間で不整合が発生していた。
 **アクション:** 将来の実装や設計ドキュメントが、実際の実装（今回はFastAPIのBackgroundTasksを用いた通知ユーティリティ）と乖離しがちであることを念頭に、各種ドキュメントに記載された関数シグネチャと実際のコードとの一致を注視する。
+
+## 2026-03-25 - ダッシュボード仕様書の統合レコードスキーマ実装同期
+**学び:** `app/routers/baby.py` の `UnifiedRecord` (統合APIのレスポンススキーマ) と、フロントエンドの `BabyRecord` の型定義において、必須/任意の制約の乖離がありました。具体的には、API仕様書では `has_ai_feedback`, `has_ai_concern` 等が必須 (boolean) で定義されていましたが、フロントエンドではオプショナル (`boolean | undefined`) として扱われていました。バックエンドはデフォルト値を持って必須で返却していましたが、型としての堅牢性をフロントエンドの実装側に合わせる形で仕様書を修正しました。
+**アクション:** 仕様書のレスポンススキーマのインターフェース名も `UnifiedRecord` からフロントエンド側の実装である `BabyRecord` に統一しました。今後もAPI仕様とフロントエンドの型定義（特にOptionalの扱い）のズレに注意して仕様書を同期します。

--- a/.specify/specs/ui/dashboard.md
+++ b/.specify/specs/ui/dashboard.md
@@ -179,22 +179,22 @@ interface RecordCreate {
 }
 ```
 
-**レスポンススキーマ (`UnifiedRecord`)**
+**レスポンススキーマ (`BabyRecord`)**
 
 ```typescript
-interface UnifiedRecord {
+interface BabyRecord {
   id: number;
-  type: "feeding" | "sleep" | "diaper" | "growth" | "note" | "contraction";
+  type: 'feeding' | 'sleep' | 'diaper' | 'growth' | 'contraction' | 'note';
   timestamp: string; // ISO 8601 (JST)
-  comment_count: number;
-  has_ai_feedback: boolean;
-  has_ai_concern: boolean;
-  recorded_by_display_name: string | null;
-  updated_at: string | null;
   details: RecordDetails; // 各タイプに応じた詳細情報
+  comment_count: number;
+  has_ai_feedback?: boolean;
+  has_ai_concern?: boolean;
+  recorded_by_display_name?: string | null;
+  updated_at?: string; // ISO 8601 (JST)
 }
 
-// details の構造は type により異なる
+// details の構造は type により異なる (フロント側では [key: string]: unknown として扱われるが実態は以下)
 type RecordDetails =
   | { feeding_type: string; amount_ml: number | null; duration_minutes: number | null; notes: string | null } // feeding
   | { end_time: string | null; notes: string | null } // sleep
@@ -351,3 +351,4 @@ type RecordDetails =
 | 1.11 | 2026-03-02 | 実装との乖離を修正（広告表示の追記、出生前表示の現状反映、陣痛タイマーの Future Work 移動）。 |
 | 1.12 | 2026-03-04 | F3「クイックアクション」授乳ボタン（ミルク・母乳）の動作を即時記録からモーダル表示（`FeedingQuickAddModal`）に変更。モーダル仕様を追記。 |
 | 1.13 | 2026-03-24 | API仕様の統合タイムライン (`GET /api/babies/{id}/records`) に `date`, `from_date` クエリパラメータを追記。 |
+| 1.14 | 2026-03-25 | 統合APIのレスポンススキーマ (`UnifiedRecord`) をフロントエンドの実装 (`BabyRecord`) に合わせて修正。 |

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7408,8 +7408,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
-              "maximum": 100,
+              "default": 500,
+              "maximum": 500,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
@@ -8615,8 +8615,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
-              "maximum": 100,
+              "default": 500,
+              "maximum": 500,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7408,8 +7408,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 500,
-              "maximum": 500,
+              "default": 100,
+              "maximum": 100,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
@@ -8615,8 +8615,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 500,
-              "maximum": 500,
+              "default": 100,
+              "maximum": 100,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -4758,6 +4758,8 @@ export interface operations {
         parameters: {
             query: {
                 baby_id: number;
+                skip?: number;
+                limit?: number;
             };
             header?: never;
             path?: never;
@@ -5652,6 +5654,8 @@ export interface operations {
         parameters: {
             query: {
                 baby_id: number;
+                skip?: number;
+                limit?: number;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
💡 何を: 
`.specify/specs/ui/dashboard.md` 内のダッシュボードの統合API(`GET /api/babies/{id}/records`)のレスポンススキーマを修正しました。
API仕様書のインターフェース名を `UnifiedRecord` から、フロントエンドの実装で使用されている `BabyRecord` に変更し、`has_ai_feedback`, `has_ai_concern`, `recorded_by_display_name`, `updated_at` プロパティをオプショナル(`?:`)扱いに更新しました。また、`details` オブジェクトの実態としての `RecordDetails` 型定義を保持しつつ、フロントエンドでは `[key: string]: unknown` として扱われる旨のコメントを追記しました。

🔍 発見: 
バックエンド(`app/routers/baby.py`)は `UnifiedRecord` スキーマにおいて `has_ai_feedback: bool = False` のように必須フィールド（デフォルト値付き）として定義していましたが、フロントエンド(`frontend/types/record.ts`)の `BabyRecord` では、これらがオプショナル(`?: boolean`)として定義・運用されていました。この型制約の乖離（バックエンドは必須で返すが、フロントエンドはより緩いオプショナルとして扱う）により、フロントエンド側から見ると仕様書が厳格すぎる状態になっていました。

🎯 影響: 
フロントエンドの開発者が仕様書(`dashboard.md`)を参照した際に、実際の実装(`BabyRecord` インターフェース)との間で型の不一致による混乱が生じるのを防ぎます。これにより、統合タイムラインやクイックアクションの実装時における、不要な型のキャストやエラーハンドリングの追加実装といった手戻りを削減できます。

---
*PR created automatically by Jules for task [13295863725959620769](https://jules.google.com/task/13295863725959620769) started by @eburairu*