### PR TITLE
feat: #1149 Web Push購読(PushSubscription)時のSSRF攻撃を防ぐエンドポイント検証の実装

### DIFF
--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -1,8 +1,16 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional, List
 from datetime import datetime, time
 from enum import Enum
+from urllib.parse import urlparse
 from app.models.enums import NotificationType
+
+# Web Push サービスの許可ドメイン（完全ホスト名一致）
+ALLOWED_PUSH_ENDPOINT_HOSTS = {
+    "fcm.googleapis.com",
+    "push.services.mozilla.com",
+    "web.push.apple.com",
+}
 
 
 class AppNotificationResponse(BaseModel):
@@ -28,6 +36,20 @@ class PushSubscriptionCreate(BaseModel):
     p256dh: str
     auth: str
     user_agent: Optional[str] = None
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint(cls, v: str) -> str:
+        parsed = urlparse(v)
+        if parsed.scheme != "https":
+            raise ValueError("endpoint must use HTTPS")
+        host = parsed.hostname or ""
+        if host not in ALLOWED_PUSH_ENDPOINT_HOSTS:
+            raise ValueError(
+                f"endpoint host '{host}' is not an allowed push service. "
+                f"Allowed: {sorted(ALLOWED_PUSH_ENDPOINT_HOSTS)}"
+            )
+        return v
 
 
 class PushSubscriptionResponse(BaseModel):

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7408,8 +7408,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
-              "maximum": 100,
+              "default": 500,
+              "maximum": 500,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
@@ -8615,8 +8615,8 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
-              "maximum": 100,
+              "default": 500,
+              "maximum": 500,
               "minimum": 1,
               "title": "Limit",
               "type": "integer"

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -4758,6 +4758,8 @@ export interface operations {
         parameters: {
             query: {
                 baby_id: number;
+                skip?: number;
+                limit?: number;
             };
             header?: never;
             path?: never;
@@ -5652,6 +5654,8 @@ export interface operations {
         parameters: {
             query: {
                 baby_id: number;
+                skip?: number;
+                limit?: number;
             };
             header?: never;
             path?: never;

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -80,7 +80,7 @@ def test_logout_with_endpoint_deletes_push_subscription(client, db):
     assert res.status_code == 200
 
     # PushSubscription を登録
-    endpoint = "https://push.example.com/test-endpoint"
+    endpoint = "https://fcm.googleapis.com/fcm/send/test-endpoint"
     sub_res = client.post(
         "/api/notifications/subscribe",
         json={

--- a/tests/test_push_subscription_validation.py
+++ b/tests/test_push_subscription_validation.py
@@ -1,0 +1,111 @@
+import pytest
+from pydantic import ValidationError
+from app.schemas.notification import PushSubscriptionCreate
+
+
+VALID_P256DH = "dummy_p256dh_key_for_testing"
+VALID_AUTH = "dummy_auth_for_testing"
+
+
+def make_sub(endpoint: str) -> PushSubscriptionCreate:
+    return PushSubscriptionCreate(
+        endpoint=endpoint,
+        p256dh=VALID_P256DH,
+        auth=VALID_AUTH,
+    )
+
+
+# ---- 正常系 ----
+
+def test_valid_fcm_endpoint():
+    sub = make_sub("https://fcm.googleapis.com/fcm/send/xxx")
+    assert sub.endpoint.startswith("https://fcm.googleapis.com")
+
+
+def test_valid_mozilla_endpoint():
+    sub = make_sub("https://push.services.mozilla.com/push/xxx")
+    assert sub.endpoint.startswith("https://push.services.mozilla.com")
+
+
+def test_valid_apple_endpoint():
+    sub = make_sub("https://web.push.apple.com/xxx")
+    assert sub.endpoint.startswith("https://web.push.apple.com")
+
+
+# ---- 異常系: スキーム ----
+
+def test_reject_non_https_endpoint():
+    with pytest.raises(ValidationError):
+        make_sub("http://fcm.googleapis.com/fcm/send/xxx")
+
+
+# ---- 異常系: プライベートIPアドレス ----
+
+def test_reject_private_ip_endpoint():
+    with pytest.raises(ValidationError):
+        make_sub("http://192.168.1.1/push")
+
+
+def test_reject_localhost_endpoint():
+    with pytest.raises(ValidationError):
+        make_sub("http://localhost/push")
+
+
+# ---- 異常系: 未知のホスト ----
+
+def test_reject_internal_hostname_endpoint():
+    with pytest.raises(ValidationError):
+        make_sub("http://internal-service/push")
+
+
+def test_reject_unknown_public_domain():
+    with pytest.raises(ValidationError):
+        make_sub("https://evil.example.com/push")
+
+
+# ---- 異常系: サブドメイン詐称 ----
+
+def test_reject_subdomain_bypass():
+    with pytest.raises(ValidationError):
+        make_sub("https://fcm.googleapis.com.evil.com/push")
+
+
+# ---- ルーターレベル結合テスト ----
+
+def test_subscribe_valid_endpoint_returns_200(auth_client):
+    client = auth_client()
+    response = client.post(
+        "/api/notifications/subscribe",
+        json={
+            "endpoint": "https://fcm.googleapis.com/fcm/send/test-token",
+            "p256dh": VALID_P256DH,
+            "auth": VALID_AUTH,
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_subscribe_invalid_endpoint_returns_422(auth_client):
+    client = auth_client(username="testuser2", family_name="Family2")
+    response = client.post(
+        "/api/notifications/subscribe",
+        json={
+            "endpoint": "https://evil.example.com/push",
+            "p256dh": VALID_P256DH,
+            "auth": VALID_AUTH,
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_subscribe_localhost_returns_422(auth_client):
+    client = auth_client(username="testuser3", family_name="Family3")
+    response = client.post(
+        "/api/notifications/subscribe",
+        json={
+            "endpoint": "http://localhost:8080/push",
+            "p256dh": VALID_P256DH,
+            "auth": VALID_AUTH,
+        },
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## 概要

Closes #1149

## 変更内容

Web Push購読(PushSubscription)時のSSRF攻撃を防ぐエンドポイント検証の実装

## 実装方法

- Claude Codeによる実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認