### PR TITLE
✍️ Scribe: 通知処理フローと論理削除モデルの実装との同期

### DIFF
--- a/.specify/specs/infrastructure/soft_delete.md
+++ b/.specify/specs/infrastructure/soft_delete.md
@@ -19,8 +19,11 @@
 
 以下の主要なモデルに `is_deleted` を導入します。
 
-- **`Family`** (家族)
-- **`Baby`** (赤ちゃん)
+- **ユーザー・家族系モデル**:
+  - `User` (ユーザー)
+  - `Family` (家族)
+  - `Baby` (赤ちゃん)
+  - `Relative` (親戚)
 - **育児記録系モデル**:
   - `Feeding` (授乳)
   - `Sleep` (睡眠)
@@ -33,9 +36,10 @@
   - `Vaccination` (予防接種)
   - `Temperature` (体温)
 - **関連モデル**:
-  - `Comment` (記録へのコメント)
-  - `AISummary` (AIサマリー)
-  - `NotificationSubscription` (通知購読)
+  - `RecordComment` (記録へのコメント)
+  - `DailySummary` (AIサマリー)
+  - `AppNotification` (アプリ内通知)
+  - `PushSubscription` (プッシュ通知購読)
 
 ## 実装方針
 

--- a/.specify/specs/ui/notification_center.md
+++ b/.specify/specs/ui/notification_center.md
@@ -246,21 +246,20 @@ self.addEventListener('push', (event) => {
 FastAPI の `BackgroundTasks` を利用し、レスポンスをブロックせずに同期関数としてアプリ内通知の INSERT と PWA プッシュ送信（将来予定）を行う。
 
 ```python
-def notify_family_members_bg(
-    background_tasks: BackgroundTasks,
-    family_id: int,
-    exclude_user_id: int,
+def notify_user(
+    db: Session,
+    user_id: int,
     title: str,
     body: str,
     url: str = "/",
-    category: str = "family_record"
+    category: str = "system"
 ):
     """
-    1. バックグラウンドタスクとして実行
-    2. 同ファミリーの記録者以外のメンバーを取得
-    3. 各メンバーの notification_settings を確認
-    4. category (例: family_record_enabled) = True のメンバーのみ app_notifications に INSERT
-    5. （PWA 実装後）push_subscriptions を参照してプッシュ通知を送信
+    特定のユーザー（例: リマインダーなら対象ユーザー）に通知を送信。
+
+    1. notification_settings でカテゴリの ON/OFF を確認
+    2. app_notifications テーブルに INSERT（おやすみモードに関係なく常時）
+    3. おやすみモード中でなければ push_subscriptions を参照して PWA プッシュ通知も送信
     """
     ...
 
@@ -274,20 +273,21 @@ def notify_family_members(
     category: str = "family_record"
 ):
     """
-    同ファミリーの記録者以外のメンバーに通知を送信する（同期処理用）。
+    同ファミリーの記録者以外のメンバーを取得し、各メンバーに対して notify_user を呼び出す（同期処理用）。
     """
     ...
 
-def notify_user(
-    db: Session,
-    user_id: int,
+def notify_family_members_bg(
+    background_tasks: BackgroundTasks,
+    family_id: int,
+    exclude_user_id: int,
     title: str,
     body: str,
     url: str = "/",
-    category: str = "system"
+    category: str = "family_record"
 ):
     """
-    特定のユーザー（例: リマインダーなら対象ユーザー）に通知を送信。
+    notify_family_members をバックグラウンドタスクとして実行するラッパー関数。
     """
     ...
 
@@ -299,7 +299,7 @@ def notify_achievements_bg(
     unlocked: list[dict],
 ) -> None:
     """
-    実績（アチーブメント）解除時に同ファミリーの全メンバーに通知を送信。
+    実績（アチーブメント）解除時に同ファミリーの全メンバーに通知を送信（バックグラウンドタスク）。
     """
     ...
 ```


### PR DESCRIPTION
💡 何を (What):
- `notification_center.md` における通知生成関数の仕様（`notify_family_members_bg` 等）を、現在の `app/utils/notifications.py` の実装に合わせて修正しました。
- `soft_delete.md` の対象モデル一覧を更新し、実際に `SoftDeleteMixin` を継承しているモデル（`User`, `Relative`, `DailySummary`, `AppNotification`, `PushSubscription` など）を正確にリストアップしました。

🔍 発見 (Discovery):
- 以前の通知仕様書では `notify_family_members_bg` などの責務が混同されており、実装と乖離していました。現在は `notify_user` が中心的な処理を担う構造になっています。
- 論理削除の仕様書にあるモデル名（`AISummary` や `NotificationSubscription` など）が古く、実際のモデル名と一致していませんでした。

🎯 影響 (Impact):
- 今後機能拡張を行う開発者が、正しいモデル名や通知フローを把握しやすくなり、手戻りやバグの発生を防ぐことができます。

---
*PR created automatically by Jules for task [3776234819210008016](https://jules.google.com/task/3776234819210008016) started by @eburairu*