### PR TITLE
✍️ Scribe: ダッシュボード仕様書のAPIパラメータ `limit` 上限値の実装との同期

### DIFF
--- a/.specify/specs/ui/dashboard.md
+++ b/.specify/specs/ui/dashboard.md
@@ -160,7 +160,7 @@ Botoro のメイン画面（ホーム）となるダッシュボードの仕様�
 
 - **GET /api/babies/{baby_id}/records**
     - **Query Params**:
-        - `limit`: 取得件数 (default: 20, min: 1, max: 100)
+        - `limit`: 取得件数 (default: 20, min: 1, max: 500)
         - `date`: YYYY-MM-DD形式の日付フィルタ（指定した1日分）
         - `from_date`: YYYY-MM-DD形式の開始日フィルタ（以降すべて）
     - **Response**: `List[UnifiedRecord]`


### PR DESCRIPTION
💡 何を: ダッシュボード仕様書の `GET /api/babies/{baby_id}/records` APIにおける `limit` パラメータの最大値を100から500に修正しました。
      🔍 発見: 実際のコード実装（`app/core/constants.py` の `MAX_PAGINATION_LIMIT = 500`）では上限が500となっていますが、仕様書上では `max: 100` となっており乖離がありました。
      🎯 影響: 仕様書に基づくフロントエンド実装時に、誤って取得件数の上限を100件に制限してしまう不具合や誤解を防ぐことができます。

---
*PR created automatically by Jules for task [1010013361811151197](https://jules.google.com/task/1010013361811151197) started by @eburairu*