### PR TITLE
✍️ Scribe: ダッシュボード仕様書のAPI統合タイムライン取得件数上限の実装との同期

### DIFF
--- a/.specify/specs/ui/dashboard.md
+++ b/.specify/specs/ui/dashboard.md
@@ -160,7 +160,7 @@ Botoro のメイン画面（ホーム）となるダッシュボードの仕様�
 
 - **GET /api/babies/{baby_id}/records**
     - **Query Params**:
-        - `limit`: 取得件数 (default: 20, min: 1, max: 100)
+        - `limit`: 取得件数 (default: 20, min: 1, max: 500)
         - `date`: YYYY-MM-DD形式の日付フィルタ（指定した1日分）
         - `from_date`: YYYY-MM-DD形式の開始日フィルタ（以降すべて）
     - **Response**: `List[UnifiedRecord]`
@@ -351,3 +351,4 @@ type RecordDetails =
 | 1.11 | 2026-03-02 | 実装との乖離を修正（広告表示の追記、出生前表示の現状反映、陣痛タイマーの Future Work 移動）。 |
 | 1.12 | 2026-03-04 | F3「クイックアクション」授乳ボタン（ミルク・母乳）の動作を即時記録からモーダル表示（`FeedingQuickAddModal`）に変更。モーダル仕様を追記。 |
 | 1.13 | 2026-03-24 | API仕様の統合タイムライン (`GET /api/babies/{id}/records`) に `date`, `from_date` クエリパラメータを追記。 |
+| 1.14 | 2026-03-27 | API仕様の統合タイムライン (`GET /api/babies/{id}/records`) の `limit` パラメータの最大値を実装に合わせて `500` に修正。 |


### PR DESCRIPTION
💡 何を (What):
- `GET /api/babies/{id}/records` エンドポイントの `limit` パラメータの最大値を `100` から `500` に修正。
- 仕様書の改訂履歴に今回の修正を追記。

🔍 発見 (Discovery):
- 仕様書上は `limit` の最大値が `100` と記載されていましたが、バックエンドの実装 (`app/routers/baby.py` と `app/core/constants.py`) では `MAX_PAGINATION_LIMIT = 500` であり、実装と仕様書の間に乖離がありました。

🎯 影響 (Impact):
- 仕様書の制約が厳しすぎるために生じる不要なページネーションのバグ報告や、フロントエンドでの誤った制限を事前に防ぐことができます。


---
*PR created automatically by Jules for task [995490271959260714](https://jules.google.com/task/995490271959260714) started by @eburairu*