### PR TITLE
🎨 Palette: 家族ツリーカードのアクセシビリティ向上

### DIFF
--- a/frontend/components/family-tree/RelativeCard.tsx
+++ b/frontend/components/family-tree/RelativeCard.tsx
@@ -26,6 +26,8 @@ export function RelativeCard({
       <button
         onClick={onClick}
         className="flex flex-col items-center gap-1 p-2 rounded-lg border border-dashed border-muted-foreground/30 hover:border-primary/50 hover:bg-accent/50 transition-colors min-w-[64px] text-muted-foreground/60 hover:text-muted-foreground"
+        aria-label={`${label}を追加`}
+        title={`${label}を追加`}
       >
         <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-xs">+</div>
         <span className="text-[10px] leading-tight">{label}</span>
@@ -40,6 +42,8 @@ export function RelativeCard({
         "flex flex-col items-center gap-1 p-2 rounded-lg border bg-card hover:bg-accent/50 transition-colors min-w-[64px]",
         "border-border hover:border-primary/50"
       )}
+      aria-label={`${relative.name}（${label}）の詳細・編集`}
+      title={`${relative.name}（${label}）の詳細・編集`}
     >
       <div className="relative">
         <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">


### PR DESCRIPTION
💡 何を
家族ツリー（`RelativeCard`）のカード要素（追加ボタン・詳細表示ボタン）に `aria-label` および `title` 属性を追加しました。

🎯 なぜ
ボタンはアイコンや短いテキストのみで構成されており、スクリーンリーダーのユーザーにとってボタンの役割（誰を追加するのか、誰の詳細を表示するのか）が不明確だったためです。また、`title` 属性により視覚的なツールチップも表示されるようになり、すべてのユーザーの使いやすさが向上します。

📸 Before/After
（視覚的なデザインの変更はありませんが、ホバー時にブラウザ標準のツールチップが表示されます）

♿ アクセシビリティ
- 未登録の家族追加ボタンに `aria-label="〇〇を追加"` を追加
- 登録済みの家族カードボタンに `aria-label="名前（〇〇）の詳細・編集"` を追加
- 両方に `title` 属性を追加し、マウスユーザーへのフィードバックを提供

---
*PR created automatically by Jules for task [5060391051449719481](https://jules.google.com/task/5060391051449719481) started by @eburairu*