### PR TITLE
chore: PyrightのvenvPath設定を追加してimport解決エラーを修正

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.10",
+  "include": ["app", "tests", "scripts"],
+  "exclude": ["worktrees", "frontend", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- `pyrightconfig.json` を追加し、`.venv` を venvPath として設定
- Pyright が FastAPI/app モジュールを解決できず出ていた `reportMissingImports` 警告を修正
- `worktrees/`・`frontend/`・`node_modules/` は解析対象外に設定

## Test plan
- [ ] IDE で `app/` 配下ファイルを開き、import エラーが消えていることを確認