### PR TITLE
✍️ Scribe: [スーパー管理者の監査ログAPI仕様を実装と同期]

### DIFF
--- a/.specify/specs/auth/superadmin.md
+++ b/.specify/specs/auth/superadmin.md
@@ -91,7 +91,7 @@ def get_current_superadmin(
 - `GET /api/admin/families/{family_id}`: 家族の詳細情報（メンバー、赤ちゃん一覧）を取得
 - `GET /api/admin/users?skip={skip}&limit={limit}`: ユーザー一覧を取得（ページネーション対応。デフォルト: skip=0, limit=500）
 - `PATCH /api/admin/users/{user_id}/superadmin`: SuperAdmin 権限を切り替え
-- `GET /api/admin/audit-logs?skip={skip}&limit={limit}`: システム全体の監査ログを取得（ページネーション対応。デフォルト: skip=0, limit=500）
+- `GET /api/admin/audit-logs?skip={skip}&limit={limit}`: システム全体の監査ログを取得（ページネーション対応。デフォルト: skip=0, limit=100）
 
 ---
 


### PR DESCRIPTION
💡 何を:
`GET /api/admin/audit-logs` エンドポイントの `limit` のデフォルト値および最大値を 500 から 100 に修正しました。

🔍 発見:
仕様書 `.specify/specs/auth/superadmin.md` では監査ログAPIの `limit` パラメータが `limit=500` と記載されていました。しかし、実際のバックエンドの実装 (`app/routers/admin.py` の 299行目 `limit: int = Query(100, ge=1, le=100)`) では 100 にハードコードされており、1回のリクエストで最大100件までしか取得できない状態となっていました（他の admin 向け API は `MAX_PAGINATION_LIMIT` の 500 に対応しています）。

🎯 影響:
この更新によって、仕様書が現在の正しい実装状態（100件制限）を反映するようになり、フロントエンド開発者などが一度に500件取得できると誤解してバグを生むのを防ぎ、開発者体験が向上します。

---
*PR created automatically by Jules for task [7551065049182721074](https://jules.google.com/task/7551065049182721074) started by @eburairu*