### PR TITLE
🎨 Palette: 設定画面の戻るボタンにARIAラベルを追加

### DIFF
--- a/frontend/components/settings/SettingsHeader.tsx
+++ b/frontend/components/settings/SettingsHeader.tsx
@@ -18,6 +18,7 @@ export function SettingsHeader({
         <header className="sticky top-0 z-40 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center px-4 gap-3">
             <Link
                 href="/settings"
+                aria-label="設定メニューに戻る"
                 className="p-1 -ml-1 text-gray-500 dark:text-zinc-400 hover:text-gray-800 dark:hover:text-zinc-100 transition-colors"
             >
                 <ChevronLeft className="h-5 w-5" />


### PR DESCRIPTION
💡 何を: `<SettingsHeader>` コンポーネント内の戻るリンク（`<ChevronLeft />` のみを含む `<Link>`）に `aria-label="設定メニューに戻る"` を追加しました。
🎯 なぜ: アイコンのみのリンクであったため、スクリーンリーダーを利用するユーザーにとってリンクの目的（どこに戻るのか）が不明確でした。これを明確にし、ナビゲーションのアクセシビリティを向上させるためです。
📸 Before/After: （視覚的な変更はありません）
♿ アクセシビリティ: スクリーンリーダーによる音声読み上げに対応し、リンクのコンテキストを提供しました。

---
*PR created automatically by Jules for task [17816465610674991506](https://jules.google.com/task/17816465610674991506) started by @eburairu*