### PR TITLE
✍️ Scribe: 体温記録API仕様書の実装との同期

### DIFF
--- a/.specify/specs/tracking/temperature_tracker.md
+++ b/.specify/specs/tracking/temperature_tracker.md
@@ -160,6 +160,7 @@ interface TemperatureResponse extends TemperatureCreate {
   user_id: number
   recorded_by_display_name: string | null
   comment_count: number
+  unlocked_achievements: UnlockedAchievementInfo[]
 }
 ```
 


### PR DESCRIPTION
💡 何を
- `.specify/specs/tracking/temperature_tracker.md` の `TemperatureResponse` インターフェース定義に `unlocked_achievements` プロパティを追加しました。

🔍 発見
- 実際のバックエンドコード（`app/schemas/temperature.py`）では、体温記録のレスポンススキーマ（`TemperatureResponse`）に `unlocked_achievements: List[UnlockedAchievementInfo] = []` が含まれています。
- さらにフロントエンド（`frontend/hooks/useBaseRecord.ts` や `openapi.json`）も実績のアンロック処理のためにこのフィールドに依存しています。
- しかし、体温記録の仕様書では `TemperatureResponse` にこのフィールドが記載されておらず、乖離が生じていました。

🎯 影響
- ドキュメントと実際のAPI実装のズレを解消することで、フロントエンド開発者が実績解除（Achievement）のレスポンスフィールドについて混乱するのを防ぎます。
- ドキュメントの信頼性が向上し、今後の拡張でも正確な型情報を参照できるようになります。

---
*PR created automatically by Jules for task [12567286749863392157](https://jules.google.com/task/12567286749863392157) started by @eburairu*