### PR TITLE
🧹 Tidy: [DRY] 日付フォーマット処理を `dateUtils.ts` の共通関数にリファクタリング

### DIFF
--- a/frontend/app/(dashboard)/diary/page.tsx
+++ b/frontend/app/(dashboard)/diary/page.tsx
@@ -27,17 +27,7 @@ import { diaryTips } from "@/lib/tips-data"
 import { DailySummary } from "@/types/dailySummary"
 import { getErrorMessage } from "@/lib/api"
 import { RecordPageLayout } from "@/components/ui/record-page-layout"
-
-function getTodayJST(): string {
-    return new Intl.DateTimeFormat("ja-JP", {
-        timeZone: "Asia/Tokyo",
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-    })
-        .format(new Date())
-        .replace(/\//g, "-")
-}
+import { formatDateLocal } from "@/lib/dateUtils"
 
 export default function DiaryPage() {
     const { babies, isLoading: babiesLoading } = useBabies()
@@ -50,7 +40,7 @@ export default function DiaryPage() {
 
     const { summaries, isLoading: summariesLoading, error: summariesError, mutate } = useDailySummaries(babyId)
 
-    const todayStr = getTodayJST()
+    const todayStr = formatDateLocal(new Date())
     const [selectedDate, setSelectedDate] = useState<string>(todayStr)
     const [isGenerating, setIsGenerating] = useState(false)
     const [generateError, setGenerateError] = useState<string | null>(null)


### PR DESCRIPTION
**💡 何を (What):**
`frontend/app/(dashboard)/diary/page.tsx` に直書きされていた `getTodayJST` 関数を削除し、代わりに `frontend/lib/dateUtils.ts` から `formatDateLocal` 関数をインポートして使用するようにリファクタリングしました。

**🎯 なぜ (Why):**
特定の日付フォーマット（`YYYY-MM-DD`）を生成する処理が個別のページコンポーネント内に定義されており、DRY原則に違反していました。既存の共通ユーティリティ関数（`formatDateLocal`）を使用することで、コードの重複を排除し、保守性と可読性を高めるためです。

**🛡️ 安全性 (Safety):**
変更対象は日付文字列を取得する箇所のみであり、機能自体に変更はありません。また、リファクタリング後に以下のコマンドを実行し、エラーが発生しないことを確認しています。
*   `pnpm lint`: 警告なし
*   `pnpm test --run`: すべてのテストがパス（231件）
*   `pnpm build`: 正常にビルドが完了

---
*PR created automatically by Jules for task [3800396235593685121](https://jules.google.com/task/3800396235593685121) started by @eburairu*