### PR TITLE
🛡️ Sentinel: [HIGH] Enforce SuperAdmin access via Dependency Injection in ai_settings

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-31 - Enforce SuperAdmin access via Dependency Injection in ai_settings
+**脆弱性:** `ai_settings`ルーターのエンドポイントで、認証は `Depends(get_current_user)` で行いつつ、実際の認可（SuperAdmin判定）を各関数の内部で `verify_admin_access()` を手動で呼び出して行っていました。
+**学び:** 開発者が新しいエンドポイントを追加する際に、手動での `verify_admin_access()` 呼び出しを忘れると、一般ユーザーでも管理機能にアクセスできてしまう認可バイパスの脆弱性が容易に発生し得る構造になっていました。
+**予防:** 認可チェックは必ずFastAPIの依存関係インジェクション（`Depends(get_current_superadmin)`）を利用してルート定義レベルで行うことで、フェイルセキュアな設計（明示的に許可されない限り拒否される）を徹底します。

--- a/app/routers/ai_settings.py
+++ b/app/routers/ai_settings.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any
 
-from app.dependencies import get_db, get_current_user
+from app.dependencies import get_db, get_current_superadmin
 from app.models.user import User
 from app.models.system_settings import SystemSetting
 from app.utils.rate_limit import RateLimiter
@@ -32,28 +32,14 @@ ai_settings_limiter = RateLimiter(
     error_message="Too many requests to AI settings. Please try again later."
 )
 
-def verify_admin_access(db: Session, user: User):
-    """
-    ユーザーが SuperAdmin であるか検証する。
-    """
-    if not user.is_superadmin:
-        logger.warning("Unauthorized superadmin access attempt by user %s", user.id)
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="SuperAdmin access required"
-        )
-    return True
-
-
 @router.get("/settings", response_model=AISettingsSummary, dependencies=[Depends(ai_settings_limiter)])
 def get_ai_settings(
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    admin: User = Depends(get_current_superadmin)
 ):
     """
     現在の AI 設定と利用可能なモデルリストを取得する。
     """
-    verify_admin_access(db, current_user)
     
     config = get_ai_config(db)
     models = get_available_llm_models()
@@ -68,12 +54,11 @@ def get_ai_settings(
 def update_ai_settings(
     payload: AISettingsPatch,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    admin: User = Depends(get_current_superadmin)
 ):
     """
     AI 設定を更新する。
     """
-    verify_admin_access(db, current_user)
     
     # 許可リストにないキーは拒否
     unknown_keys = set(payload.settings.keys()) - ALLOWED_AI_SETTING_KEYS
@@ -102,10 +87,9 @@ def update_ai_settings(
 @router.get("/available-models", response_model=List[AIModel], dependencies=[Depends(ai_settings_limiter)])
 def list_available_models(
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    admin: User = Depends(get_current_superadmin)
 ):
     """
     利用可能な LLM モデルを外部 API から取得する。
     """
-    verify_admin_access(db, current_user)
     return get_available_llm_models()


### PR DESCRIPTION
🚨 深刻度: HIGH

💡 脆弱性: 
`app/routers/ai_settings.py` のすべてのエンドポイントは `Depends(get_current_user)` を依存関係として定義しており、関数内で手動で `verify_admin_access()` を呼び出すことでアクセス制御を行っていました。これは、開発者が新しいルートを追加する際に手動チェックを忘れると、あらゆる認証済みユーザーがアクセスできてしまうリスクがあり、依存関係インジェクションによる「デフォルト拒否（fail securely）」の原則に反しています。

🎯 影響:
SuperAdmin用のエンドポイントに誤って一般ユーザーがアクセスできてしまうことによる権限昇格の脆弱性を防ぎます。

🔧 修正:
すべてのエンドポイントを `Depends(get_current_superadmin)` に変更し、手動での `verify_admin_access()` 呼び出しを削除しました。これにより、FastAPIがルート処理を実行する前に必ず権限チェックが行われるようになります。

✅ 検証:
`tests/test_ai_settings_access.py` のテストを実行し、テストが通ることを確認しました。

---
*PR created automatically by Jules for task [15953900339715819171](https://jules.google.com/task/15953900339715819171) started by @eburairu*