### PR TITLE
fix: #1225 コメントAPIのmodel_mapにtemperatureが未登録で体温記録へのコメントが400エラー

### DIFF
--- a/app/routers/comments.py
+++ b/app/routers/comments.py
@@ -14,6 +14,7 @@ from app.models.growth import Growth
 from app.models.contraction import Contraction
 from app.models.schedule import Schedule
 from app.models.note import Note
+from app.models.temperature import TemperatureRecord
 from app.schemas.comment import CommentCreate, CommentResponse
 from app.utils.notifications import notify_family_members
 from app.models.baby import Baby
@@ -40,6 +41,7 @@ def get_record_baby_id(db: Session, record_type: str, record_id: int) -> int:
         "contraction": Contraction,
         "schedule": Schedule,
         "note": Note,
+        "temperature": TemperatureRecord,
     }
     model = model_map.get(record_type)
     if not model:

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,6 +1,37 @@
 import pytest
 from app.models.family import UserRole
 
+
+def test_comment_on_temperature_record(auth_client, db):
+    """体温記録に対してコメントの取得・投稿ができること（#1225）"""
+    client = auth_client()
+
+    # 赤ちゃん作成
+    res = client.post("/api/babies/", json={"name": "Baby Temp"})
+    assert res.status_code == 200
+    baby_id = res.json()["id"]
+
+    # 体温記録作成
+    res = client.post("/api/temperatures/", json={
+        "baby_id": baby_id,
+        "measured_at": "2024-03-20T10:00:00Z",
+        "temperature": 36.5,
+        "method": "AXILLARY",
+    })
+    assert res.status_code == 200
+    record_id = res.json()["id"]
+
+    # コメント投稿 → 400 ではなく 200 であること
+    res = client.post(f"/api/records/temperature/{record_id}/comments", json={"content": "正常な体温です"})
+    assert res.status_code == 200
+    assert res.json()["content"] == "正常な体温です"
+
+    # コメント取得 → 400 ではなく 200 であること
+    res = client.get(f"/api/records/temperature/{record_id}/comments")
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+    assert res.json()[0]["content"] == "正常な体温です"
+
 def test_viewer_can_comment(client, auth_client, db):
     # 1. Admin が家族を作成
     admin_client = auth_client(username="admin_user", family_name="Happy Family")


### PR DESCRIPTION
## 概要

Closes #1225

## 変更内容

コメントAPIのmodel_mapにtemperatureが未登録で体温記録へのコメントが400エラー

## 実装方法

- Claude Codeによる実装
- TDDで実装（テストを先に作成）
- `verify_all.sh` 通過済み

## チェックリスト

- [x] テスト追加済み
- [x] verify_all.sh 通過
- [ ] 動作確認