### PR TITLE
🎨 Palette: おむつ種類選択ボタンのアクセシビリティ改善

### DIFF
--- a/frontend/components/diaper/DiaperForm.tsx
+++ b/frontend/components/diaper/DiaperForm.tsx
@@ -49,6 +49,7 @@ function DiaperTypeButton({ type, selectedType, onClick, icon, label }: DiaperTy
             type="button"
             onClick={onClick}
             aria-pressed={selectedType === type}
+            aria-label={`おむつの種類: ${label}`}
             className={cn(
                 "h-20 w-full flex flex-col items-center justify-center gap-1 rounded-xl border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 selectedType === type


### PR DESCRIPTION
💡 何を: おむつ記録フォームの種類選択ボタン（おしっこ/うんち）に `aria-label` を追加しました。
🎯 なぜ: スクリーンリーダーを使用するユーザーが、各ボタンの意味（どのおむつの種類を選択するか）をより正確に理解できるようにするためです。
📸 Before/After: （視覚的な変更なし）
♿ アクセシビリティ: アイコンとテキストが併記されているボタンですが、`aria-label`を明示的に指定することで、より確実な読み上げをサポートします。

---
*PR created automatically by Jules for task [5134139227579666053](https://jules.google.com/task/5134139227579666053) started by @eburairu*