### PR TITLE
✍️ Scribe: [SuperAdmin] 家族削除と監査ログクリーンアップAPIの仕様書追加

### DIFF
--- a/.specify/specs/auth/superadmin.md
+++ b/.specify/specs/auth/superadmin.md
@@ -89,9 +89,11 @@ def get_current_superadmin(
 - `GET /api/admin/families?skip={skip}&limit={limit}&search={search}`: 家族一覧を取得（ページネーション、検索対応。デフォルト: skip=0, limit=500）
 - `POST /api/admin/families`: 管理者による家族の新規作成
 - `GET /api/admin/families/{family_id}`: 家族の詳細情報（メンバー、赤ちゃん一覧）を取得
+- `DELETE /api/admin/families/{family_id}`: 管理者による家族の削除
 - `GET /api/admin/users?skip={skip}&limit={limit}`: ユーザー一覧を取得（ページネーション対応。デフォルト: skip=0, limit=500）
 - `PATCH /api/admin/users/{user_id}/superadmin`: SuperAdmin 権限を切り替え
 - `GET /api/admin/audit-logs?skip={skip}&limit={limit}`: システム全体の監査ログを取得（ページネーション対応。デフォルト: skip=0, limit=100）
+- `POST /api/admin/audit-logs/cleanup`: 古い監査ログの削除（daysパラメータで指定した日数より前のログを削除）
 
 ---
 


### PR DESCRIPTION
💡 何を:
`app/routers/admin.py` に実装されているが仕様書に記載されていなかった以下の2つのエンドポイントを `.specify/specs/auth/superadmin.md` に追加しました。
- `DELETE /api/admin/families/{family_id}`
- `POST /api/admin/audit-logs/cleanup`

🔍 発見:
バックエンドの実装 (`app/routers/admin.py`) を調査したところ、`delete_admin_family` (`DELETE /families/{family_id}`) と `trigger_audit_log_cleanup` (`POST /audit-logs/cleanup`) の実装が存在していましたが、これらが SuperAdmin の仕様書に反映されていませんでした。

🎯 影響:
管理者向けの破壊的・重要な機能である「家族の削除」や「古い監査ログのクリーンアップ」が仕様書に明記されることで、フロントエンド開発者や他のメンバーがこれらの API の存在と用途を正しく理解し、安全に利用できるようになります。

---
*PR created automatically by Jules for task [335587245098627282](https://jules.google.com/task/335587245098627282) started by @eburairu*