### PR TITLE
🧹 Tidy: SettingsHeaderコンポーネントの再利用によるDRY化

### DIFF
--- a/frontend/app/(dashboard)/settings/page.tsx
+++ b/frontend/app/(dashboard)/settings/page.tsx
@@ -9,6 +9,7 @@ import { useState } from "react"
 import { AppInfoDialog } from "@/components/settings/AppInfoDialog"
 import { SettingItem } from "@/components/settings/SettingItem"
 import { useAppVersion } from "@/hooks/useAppVersion"
+import { SettingsHeader } from "@/components/settings/SettingsHeader"
 import {
     AlertDialog,
     AlertDialogAction,
@@ -112,9 +113,7 @@ export default function SettingsPage() {
 
     return (
         <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 transition-colors">
-            <header className="sticky top-0 z-40 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center justify-center px-4">
-                <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100">設定</h1>
-            </header>
+            <SettingsHeader title="設定" showBackButton={false} />
 
             <div className="max-w-5xl mx-auto p-4 space-y-3 pb-20">
                 {user?.is_superadmin && (

--- a/frontend/components/settings/SettingsHeader.tsx
+++ b/frontend/components/settings/SettingsHeader.tsx
@@ -7,23 +7,27 @@ interface SettingsHeaderProps {
     title: string;
     icon?: LucideIcon;
     children?: React.ReactNode;
+    showBackButton?: boolean;
 }
 
 export function SettingsHeader({
     title,
     icon: Icon,
     children,
+    showBackButton = true,
 }: SettingsHeaderProps) {
     return (
-        <header className="sticky top-0 z-40 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center px-4 gap-3">
-            <Link
-                href="/settings"
-                aria-label="設定メニューに戻る"
-                className="p-1 -ml-1 text-gray-500 dark:text-zinc-400 hover:text-gray-800 dark:hover:text-zinc-100 transition-colors"
-            >
-                <ChevronLeft className="h-5 w-5" />
-            </Link>
-            <div className="flex items-center gap-2 flex-1">
+        <header className={`sticky top-0 z-40 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md shadow-sm border-b border-gray-100 dark:border-zinc-800 h-14 flex items-center px-4 ${showBackButton ? "gap-3" : "justify-center"}`}>
+            {showBackButton && (
+                <Link
+                    href="/settings"
+                    aria-label="設定メニューに戻る"
+                    className="p-1 -ml-1 text-gray-500 dark:text-zinc-400 hover:text-gray-800 dark:hover:text-zinc-100 transition-colors"
+                >
+                    <ChevronLeft className="h-5 w-5" />
+                </Link>
+            )}
+            <div className={`flex items-center gap-2 ${showBackButton ? "flex-1" : ""}`}>
                 {Icon && <Icon className="h-4 w-4 text-violet-600" />}
                 <h1 className="text-base font-semibold text-gray-900 dark:text-zinc-100" data-sentry-unmask>
                     {title}


### PR DESCRIPTION
💡 何を:
- `SettingsHeader`コンポーネントに `showBackButton` プロパティを追加
- `frontend/app/(dashboard)/settings/page.tsx` の直書きされていた `<header>` を `<SettingsHeader>` に置き換え

🎯 なぜ:
設定のトップページ（`settings/page.tsx`）のみ固有の `<header>` 定義を持っており、設定系のサブページ（`settings/profile/page.tsx`など）で利用されている `SettingsHeader` とのコードの重複が発生していました。同じ見た目のヘッダーを一元管理し、DRY原則に則ることで保守性を高めました。

🛡️ 安全性:
- `SettingsHeader` を `showBackButton={false}` で呼び出すことで、従来のUI（戻るボタンなし、タイトル中央揃え）を維持しています。
- ビルド (`pnpm build`) およびLint (`pnpm lint`) が通ることを確認しました。
- UIの見た目やユーザー操作への影響はありません。

---
*PR created automatically by Jules for task [8157710714640980582](https://jules.google.com/task/8157710714640980582) started by @eburairu*