### PR TITLE
🧹 Tidy: 監査ログの日時フォーマット処理を共通ユーティリティに抽出

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -13,6 +13,7 @@ import {
   Clock
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { formatJapaneseDateTimeWithSeconds } from "@/lib/dateUtils";
 import { 
   Table, 
   TableBody, 
@@ -211,13 +212,7 @@ export default function AdminDashboard() {
                               <TableCell className="font-medium text-xs md:text-sm text-muted-foreground whitespace-nowrap">
                                 <div className="flex items-center gap-1.5">
                                   <Clock className="h-3 w-3" />
-                                  {new Date(log.created_at).toLocaleString("ja-JP", {
-                                    month: "short",
-                                    day: "numeric",
-                                    hour: "2-digit",
-                                    minute: "2-digit",
-                                    second: "2-digit"
-                                  })}
+                                  {formatJapaneseDateTimeWithSeconds(log.created_at)}
                                 </div>
                               </TableCell>
                               <TableCell className="text-xs md:text-sm font-semibold">

--- a/frontend/lib/dateUtils.ts
+++ b/frontend/lib/dateUtils.ts
@@ -42,6 +42,14 @@ export function formatJapaneseDateTime(date: Date | string | number): string {
 }
 
 /**
+ * Formats a date to "M月d日 HH:mm:ss" (e.g., 1月23日 14:30:45).
+ */
+export function formatJapaneseDateTimeWithSeconds(date: Date | string | number): string {
+  const d = typeof date === "string" || typeof date === "number" ? new Date(date) : date;
+  return format(d, "M月d日 HH:mm:ss", { locale: ja });
+}
+
+/**
  * Formats a date to "yyyy年M月d日" (e.g., 2024年1月23日).
  */
 export function formatJapaneseDate(date: Date | string | number): string {


### PR DESCRIPTION
💡 何を:
`frontend/app/admin/page.tsx` 内で直接記述されていた `new Date(...).toLocaleString("ja-JP", ...)` の処理を、`frontend/lib/dateUtils.ts` に新設した `formatJapaneseDateTimeWithSeconds` に抽出・置換しました。

🎯 なぜ:
コンポーネント内に複雑な日時フォーマットのロジックが混在しており、DRY原則に反していました。共通のユーティリティ関数に切り出すことで、コードの可読性を向上させ、将来的な日付フォーマットの変更や保守を容易にするためです。

🛡️ 安全性:
表示形式は `M月d日 HH:mm:ss` で元の `toLocaleString` と同じ出力形式を維持しています（例: `1月23日 14:30:45`）。また、既存のユニットテスト・静的解析 (lint, typecheck) をパスすることを確認しました。

---
*PR created automatically by Jules for task [13061564154138808684](https://jules.google.com/task/13061564154138808684) started by @eburairu*