### PR TITLE
🧹 Tidy: コメントダイアログの共通レスポンシブモーダル化

### DIFF
--- a/frontend/components/records/RecordCommentDialog.tsx
+++ b/frontend/components/records/RecordCommentDialog.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { ResponsiveModal } from "@/components/ui/responsive-modal";
 import { CommentSection } from "./CommentSection";
 
 interface RecordCommentDialogProps {
@@ -24,41 +22,18 @@ export function RecordCommentDialog({
   currentUserId,
   onCommentChange,
 }: RecordCommentDialogProps) {
-  const isMobile = useIsMobile();
-
-  if (isMobile) {
-    return (
-      <Drawer open={open} onOpenChange={onOpenChange}>
-        <DrawerContent>
-          <DrawerHeader>
-            <DrawerTitle>{title}</DrawerTitle>
-          </DrawerHeader>
-          <div className="overflow-y-auto px-4 pb-6">
-            <CommentSection
-              recordType={recordType}
-              recordId={recordId}
-              currentUserId={currentUserId}
-              onCommentChange={onCommentChange}
-            />
-          </div>
-        </DrawerContent>
-      </Drawer>
-    );
-  }
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md dark:bg-zinc-900 dark:border-zinc-800 max-h-[85dvh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="text-base">{title}</DialogTitle>
-        </DialogHeader>
-        <CommentSection
-          recordType={recordType}
-          recordId={recordId}
-          currentUserId={currentUserId}
-          onCommentChange={onCommentChange}
-        />
-      </DialogContent>
-    </Dialog>
+    <ResponsiveModal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+    >
+      <CommentSection
+        recordType={recordType}
+        recordId={recordId}
+        currentUserId={currentUserId}
+        onCommentChange={onCommentChange}
+      />
+    </ResponsiveModal>
   );
 }


### PR DESCRIPTION
💡 何を:
`RecordCommentDialog.tsx` に独自に実装されていたモバイル・PCの出し分け処理（`Drawer`・`Dialog` の分岐と `useIsMobile` の使用）を削除し、共通コンポーネントである `ResponsiveModal` を使用するようにリファクタリングしました。

🎯 なぜ:
他のダイアログコンポーネント（`EditDialogBase` 等）は既に `ResponsiveModal` を使用しており、DRY原則に基づきUIの共通化とコード行数の削減を行うためです。コンポーネントがスッキリし、可読性と保守性が向上します。

🛡️ 安全性:
- 既存の表示項目・機能に変更はありません。
- `pnpm test`, `pnpm lint`, `pnpm build` が全て成功することを確認しました。

---
*PR created automatically by Jules for task [10767750602400522405](https://jules.google.com/task/10767750602400522405) started by @eburairu*