### PR TITLE
🧹 Tidy: 汎用的な確認ダイアログコンポーネント(ConfirmAlertDialog)の抽出

### DIFF
--- a/frontend/components/diary/DiaryDeleteDialog.tsx
+++ b/frontend/components/diary/DiaryDeleteDialog.tsx
@@ -1,15 +1,6 @@
 "use client"
 
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
+import { ConfirmAlertDialog } from "@/components/ui/confirm-alert-dialog"
 import { DailySummary } from "@/types/dailySummary"
 
 interface DiaryDeleteDialogProps {
@@ -35,24 +26,14 @@ export function DiaryDeleteDialog({ summary, open, onOpenChange, onConfirm }: Di
     }
 
     return (
-        <AlertDialog open={open} onOpenChange={onOpenChange}>
-            <AlertDialogContent>
-                <AlertDialogHeader>
-                    <AlertDialogTitle>育児日誌を削除しますか？</AlertDialogTitle>
-                    <AlertDialogDescription>
-                        {dateLabel} の育児日誌を削除します。この操作は元に戻せません。
-                    </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                    <AlertDialogCancel>キャンセル</AlertDialogCancel>
-                    <AlertDialogAction
-                        onClick={handleConfirm}
-                        className="bg-red-500 hover:bg-red-600"
-                    >
-                        削除
-                    </AlertDialogAction>
-                </AlertDialogFooter>
-            </AlertDialogContent>
-        </AlertDialog>
+        <ConfirmAlertDialog
+            open={open}
+            onOpenChange={onOpenChange}
+            title="育児日誌を削除しますか？"
+            description={`${dateLabel} の育児日誌を削除します。この操作は元に戻せません。`}
+            confirmText="削除"
+            onConfirm={handleConfirm}
+            confirmButtonClass="bg-red-500 hover:bg-red-600"
+        />
     )
 }

--- a/frontend/components/settings/MemberList.tsx
+++ b/frontend/components/settings/MemberList.tsx
@@ -2,16 +2,7 @@
 import { useState } from "react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
+import { ConfirmAlertDialog } from "@/components/ui/confirm-alert-dialog"
 import { MemberRoleDialog } from "./MemberRoleDialog"
 import { MemberPasswordResetDialog } from "./MemberPasswordResetDialog"
 import { api } from "@/lib/api"
@@ -130,26 +121,16 @@ export function MemberList({ members, currentUserId, isAdmin, onUpdated }: Props
             />
 
             {/* 削除確認ダイアログ */}
-            <AlertDialog open={!!deleteTarget} onOpenChange={(v) => { if (!v) setDeleteTarget(null) }}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>{deleteTarget ? getDisplayName(deleteTarget) : ""} を削除しますか？</AlertDialogTitle>
-                        <AlertDialogDescription>
-                            このメンバーを家族グループから削除します。この操作は元に戻せません。
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>キャンセル</AlertDialogCancel>
-                        <AlertDialogAction
-                            onClick={handleDelete}
-                            disabled={deleting}
-                            className="bg-red-500 hover:bg-red-600"
-                        >
-                            削除する
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+            <ConfirmAlertDialog
+                open={!!deleteTarget}
+                onOpenChange={(v) => { if (!v) setDeleteTarget(null) }}
+                title={`${deleteTarget ? getDisplayName(deleteTarget) : ""} を削除しますか？`}
+                description="このメンバーを家族グループから削除します。この操作は元に戻せません。"
+                confirmText="削除する"
+                onConfirm={handleDelete}
+                loading={deleting}
+                confirmButtonClass="bg-red-500 hover:bg-red-600"
+            />
         </SettingsCard>
     )
 }

--- a/frontend/components/settings/MemberPasswordResetDialog.tsx
+++ b/frontend/components/settings/MemberPasswordResetDialog.tsx
@@ -1,16 +1,7 @@
 "use client"
 import { useState } from "react"
 import { Copy, Check } from "lucide-react"
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
+import { ConfirmAlertDialog } from "@/components/ui/confirm-alert-dialog"
 import { DialogFooter } from "@/components/ui/dialog"
 import { EditDialogBase } from "@/components/records/EditDialogBase"
 import { Button } from "@/components/ui/button"
@@ -111,27 +102,24 @@ export function MemberPasswordResetDialog({ member, open, onClose }: Props) {
     }
 
     return (
-        <AlertDialog open={open} onOpenChange={(v) => { if (!v) handleClose() }}>
-            <AlertDialogContent>
-                <AlertDialogHeader>
-                    <AlertDialogTitle>{displayName} のパスワードを再発行しますか？</AlertDialogTitle>
-                    <AlertDialogDescription>
-                        現在のパスワードは無効になり、新しい仮パスワードが発行されます。
+        <>
+            <ConfirmAlertDialog
+                open={open}
+                onOpenChange={(v) => { if (!v) handleClose() }}
+                title={`${displayName} のパスワードを再発行しますか？`}
+                description={
+                    <>
+                        現在のパスワードは無効になり、新しい仮パスワードが発行されます。<br />
                         発行された仮パスワードを本人に伝えてください。
-                    </AlertDialogDescription>
-                </AlertDialogHeader>
-                {error && <p className="text-red-500 text-sm px-1">{error}</p>}
-                <AlertDialogFooter>
-                    <AlertDialogCancel onClick={handleClose}>キャンセル</AlertDialogCancel>
-                    <AlertDialogAction
-                        onClick={handleReset}
-                        loading={resetting}
-                        className="bg-indigo-600 hover:bg-indigo-700"
-                    >
-                        再発行する
-                    </AlertDialogAction>
-                </AlertDialogFooter>
-            </AlertDialogContent>
-        </AlertDialog>
+                        {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
+                    </>
+                }
+                confirmText="再発行する"
+                onConfirm={handleReset}
+                loading={resetting}
+                confirmButtonClass="bg-indigo-600 hover:bg-indigo-700"
+                cancelText="キャンセル"
+            />
+        </>
     )
 }

--- a/frontend/components/ui/confirm-alert-dialog.tsx
+++ b/frontend/components/ui/confirm-alert-dialog.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { ReactNode } from "react"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+export interface ConfirmAlertDialogProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    title: ReactNode
+    description?: ReactNode
+    cancelText?: string
+    confirmText?: string
+    onConfirm: () => void
+    confirmButtonClass?: string
+    loading?: boolean
+    cancelButtonProps?: React.ComponentProps<typeof AlertDialogCancel>
+    confirmButtonProps?: React.ComponentProps<typeof AlertDialogAction>
+}
+
+export function ConfirmAlertDialog({
+    open,
+    onOpenChange,
+    title,
+    description,
+    cancelText = "キャンセル",
+    confirmText = "確認",
+    onConfirm,
+    confirmButtonClass,
+    loading = false,
+    cancelButtonProps,
+    confirmButtonProps,
+}: ConfirmAlertDialogProps) {
+    return (
+        <AlertDialog open={open} onOpenChange={onOpenChange}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{title}</AlertDialogTitle>
+                    {description && (
+                        <AlertDialogDescription asChild>
+                            <div>{description}</div>
+                        </AlertDialogDescription>
+                    )}
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel disabled={loading} {...cancelButtonProps}>
+                        {cancelText}
+                    </AlertDialogCancel>
+                    <AlertDialogAction
+                        onClick={onConfirm}
+                        className={confirmButtonClass}
+                        loading={loading}
+                        {...confirmButtonProps}
+                    >
+                        {confirmText}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    )
+}

--- a/frontend/hooks/useRecordDelete.tsx
+++ b/frontend/hooks/useRecordDelete.tsx
@@ -2,16 +2,7 @@
 
 import { useState } from "react"
 import { toast } from "sonner"
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
+import { ConfirmAlertDialog } from "@/components/ui/confirm-alert-dialog"
 
 interface UseRecordDeleteProps {
     onDelete: (id: number) => Promise<void>
@@ -40,22 +31,18 @@ export function useRecordDelete({ onDelete, onSuccess, resourceName }: UseRecord
     }
 
     const ConfirmDeleteDialog = () => (
-        <AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => { if (!open) setDeleteTargetId(null) }}>
-            <AlertDialogContent>
-                <AlertDialogHeader>
-                    <AlertDialogTitle data-sentry-unmask>記録の削除</AlertDialogTitle>
-                    <AlertDialogDescription data-sentry-unmask>
-                        この{resourceName}を削除しますか？この操作は取り消せません。
-                    </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                    <AlertDialogCancel disabled={isDeleting} data-sentry-unmask>キャンセル</AlertDialogCancel>
-                    <AlertDialogAction onClick={handleDelete} data-sentry-unmask className="bg-red-600 hover:bg-red-700" loading={isDeleting}>
-                        削除
-                    </AlertDialogAction>
-                </AlertDialogFooter>
-            </AlertDialogContent>
-        </AlertDialog>
+        <ConfirmAlertDialog
+            open={deleteTargetId !== null}
+            onOpenChange={(open) => { if (!open) setDeleteTargetId(null) }}
+            title={<span data-sentry-unmask>記録の削除</span>}
+            description={<span data-sentry-unmask>この{resourceName}を削除しますか？この操作は取り消せません。</span>}
+            confirmText="削除"
+            onConfirm={handleDelete}
+            loading={isDeleting}
+            confirmButtonClass="bg-red-600 hover:bg-red-700"
+            cancelButtonProps={{ "data-sentry-unmask": true } as React.ComponentProps<"button">}
+            confirmButtonProps={{ "data-sentry-unmask": true } as React.ComponentProps<"button">}
+        />
     )
 
     return {


### PR DESCRIPTION
💡 何を:
各コンポーネント内に散在していた `AlertDialog` を用いた確認ダイアログのボイラープレートを、共通の `ConfirmAlertDialog` コンポーネントに抽出しました。`MemberList`、`DiaryDeleteDialog`、`MemberPasswordResetDialog`、および `useRecordDelete` フックをリファクタリングして新しい共通コンポーネントを利用するようにしました。

🎯 なぜ:
冗長なUI記述（`AlertDialogContent` や `AlertDialogHeader` など）を減らし、コードベース全体の可読性と保守性を向上させるためです（DRY原則の適用）。

🛡️ 安全性:
機能やUIの見た目、操作時の挙動は変更せず、`pnpm lint`、`pnpm test --run`、`pnpm build`を実行して既存機能が壊れていないことを確認しました。

---
*PR created automatically by Jules for task [3679506934808467961](https://jules.google.com/task/3679506934808467961) started by @eburairu*