### PR TITLE
🧹 Tidy: メンバー一覧のバッジスタイル判定を定数化

### DIFF
--- a/frontend/components/settings/MemberList.tsx
+++ b/frontend/components/settings/MemberList.tsx
@@ -23,6 +23,12 @@ import { useAsyncAction } from "@/hooks/useAsyncAction"
 import { SettingsCard } from "./SettingsCard"
 import { ROLE_LABELS } from "@/constants/ui"
 
+const ROLE_BADGE_CLASSES: Record<string, string> = {
+    [UserRole.ADMIN]: "bg-violet-100 dark:bg-violet-950/40 text-violet-700 dark:text-violet-300",
+    [UserRole.VIEWER]: "bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300",
+    default: "bg-gray-100 dark:bg-zinc-800 text-gray-600 dark:text-zinc-400"
+}
+
 interface Props {
     members: FamilyMember[]
     currentUserId: number
@@ -68,11 +74,7 @@ export function MemberList({ members, currentUserId, isAdmin, onUpdated }: Props
                                     <span className="font-medium text-gray-900 dark:text-zinc-100">{getDisplayName(member)}</span>
                                     <Badge
                                         variant="secondary"
-                                        className={member.role === UserRole.ADMIN
-                                            ? "bg-violet-100 dark:bg-violet-950/40 text-violet-700 dark:text-violet-300"
-                                            : member.role === UserRole.VIEWER
-                                                ? "bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300"
-                                                : "bg-gray-100 dark:bg-zinc-800 text-gray-600 dark:text-zinc-400"}
+                                        className={ROLE_BADGE_CLASSES[member.role] || ROLE_BADGE_CLASSES.default}
                                     >
                                         {ROLE_LABELS[member.role] ?? member.role}
                                     </Badge>


### PR DESCRIPTION
💡 何を: `components/settings/MemberList.tsx` 内の `UserRole` に対するインラインの三項演算子によるバッジクラス判定を、`ROLE_BADGE_CLASSES` 定数マップに抽出しました。
🎯 なぜ: コンポーネント内のレンダリングロジックを簡潔にし、新しいロールが追加された際の保守性や可読性を高めるため。
🛡️ 安全性: `pnpm test`, `pnpm lint`, `pnpm build` が全て通ることを確認しています。見た目や機能は一切変更していません。

---
*PR created automatically by Jules for task [197631100000363996](https://jules.google.com/task/197631100000363996) started by @eburairu*