### PR TITLE
⚡ Bolt: useRecordsByDateでのdayRecordsのメモ化による不要な再レンダリング防止

### DIFF
--- a/frontend/hooks/useRecordsByDate.ts
+++ b/frontend/hooks/useRecordsByDate.ts
@@ -1,4 +1,5 @@
 import useSWR from "swr"
+import { useMemo } from "react"
 import { fetcher } from "@/lib/api"
 import { BabyRecord } from "@/types/record"
 
@@ -36,15 +37,17 @@ export function useRecordsByDate(
         { revalidateOnFocus: false }
     )
 
+    // クライアント側フィルタ
+    const filteredRecords = useMemo(() => {
+        return (records ?? []).filter(r => {
+            const t = new Date(r.timestamp)
+            return t.getFullYear() === y && t.getMonth() === m && t.getDate() === d
+        })
+    }, [records, y, m, d])
+
     if (needsFetch) {
         return { dayRecords: fetchedRecords ?? [], isLoading }
     }
 
-    // クライアント側フィルタ
-    const dayRecords = (records ?? []).filter(r => {
-        const t = new Date(r.timestamp)
-        return t.getFullYear() === y && t.getMonth() === m && t.getDate() === d
-    })
-
-    return { dayRecords, isLoading: false }
+    return { dayRecords: filteredRecords, isLoading: false }
 }


### PR DESCRIPTION
💡 何を: `useRecordsByDate` フック内で、キャッシュからレコードをフィルタリングする処理 (`dayRecords`) を `useMemo` でメモ化し、フック呼び出しのたびに新しい配列の参照が生成されるのを防ぎました。

🎯 なぜ: 以前は毎レンダリング時に `.filter()` によって新しい配列インスタンスが返されていたため、このフックを利用する `JarPhysicsView` などのコンポーネントが不要な再レンダリングを引き起こす可能性がありました。

📊 影響: `JarPhysicsView` 等における不要な再レンダリングを削減し、CPUとメモリのオーバーヘッドを微小ながら改善します。

🔬 測定: React DevToolsのProfilerを使用して、日付変更時の `JarPhysicsView` および子コンポーネント（特に `JarCanvas` や `JarHexTokenOverlay`）の再レンダリング回数と描画時間が短縮されていることを確認できます。

---
*PR created automatically by Jules for task [12665409862128116928](https://jules.google.com/task/12665409862128116928) started by @eburairu*