### PR TITLE
🎨 Palette: キーボードナビゲーション用に視認できるフォーカススタイルを追加

### DIFF
--- a/frontend/components/records/RecordActionButtons.tsx
+++ b/frontend/components/records/RecordActionButtons.tsx
@@ -23,7 +23,7 @@ export function RecordActionButtons({
             <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-transparent"
+                className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-transparent focus-visible:ring-2 focus-visible:ring-indigo-500 dark:focus-visible:ring-indigo-400 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-zinc-900"
                 onClick={onEdit}
                 aria-label={editLabel}
                 title={editLabel}
@@ -33,7 +33,7 @@ export function RecordActionButtons({
             <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-transparent"
+                className="h-8 w-8 text-gray-400 dark:text-zinc-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-transparent focus-visible:ring-2 focus-visible:ring-red-500 dark:focus-visible:ring-red-400 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-zinc-900"
                 onClick={onDelete}
                 aria-label={deleteLabel}
                 title={deleteLabel}


### PR DESCRIPTION
💡 何を:
記録アイテムの「編集」および「削除」アクションボタン（アイコンのみ）に対して、キーボードナビゲーション時に視認しやすくするためのフォーカススタイル（`focus-visible:ring-2` など）を追加しました。

🎯 なぜ:
アイコンのみのボタンは、Tabキーでフォーカスを移動した際に、現在どこにフォーカスが当たっているのか視覚的に分かりにくいため、アクセシビリティ（キーボードナビゲーション）の向上のために改善しました。

📸 Before/After:
フォーカス時にインディゴ色（編集）と赤色（削除）のリングが表示されるようになりました。

♿ アクセシビリティ:
キーボードユーザーが現在のフォーカス位置を明確に認識できるよう、`focus-visible` クラスを使用してアウトラインを明示しました。

---
*PR created automatically by Jules for task [6806087686803952482](https://jules.google.com/task/6806087686803952482) started by @eburairu*