### PR TITLE
🎨 Palette: 授乳記録比較チャートのタブにaria-labelを追加

### DIFF
--- a/frontend/components/feeding/FeedingChart.tsx
+++ b/frontend/components/feeding/FeedingChart.tsx
@@ -119,6 +119,7 @@ export function FeedingChart({ feedings }: FeedingChartProps) {
                                 key={key}
                                 onClick={() => setCompareMetric(key)}
                                 aria-pressed={compareMetric === key}
+                                aria-label={`比較指標: ${label}`}
                                 className={[
                                     "rounded-md px-2.5 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-zinc-900",
                                     compareMetric === key


### PR DESCRIPTION
💡 何を
授乳記録のチャートにおいて、比較指標（回数・ミルク量・授乳時間）を切り替えるタブボタンに `aria-label` を追加しました。

🎯 なぜ
テキストによるラベルが表示されているものの、これらのボタンは複数の情報を切り替えるためのインタラクティブな要素であるため、スクリーンリーダーを利用するユーザーが各タブの目的（比較指標の切り替えであること）を正確に理解できるように、コンテキストを補足する `aria-label` を付与することが望ましいためです。

📸 Before/After
視覚的な変更はありません。

♿ アクセシビリティ
比較指標を切り替える `<button>` 要素に対して `aria-label={\`比較指標: \${label}\`}` を追加し、スクリーンリーダーでの読み上げを改善しました。

---
*PR created automatically by Jules for task [15846481436493087039](https://jules.google.com/task/15846481436493087039) started by @eburairu*