### PR TITLE
🎨 Palette: 非同期処理中のダイアログのキャンセル防止とローディング表示

### DIFF
--- a/frontend/components/records/CommentItem.tsx
+++ b/frontend/components/records/CommentItem.tsx
@@ -122,9 +122,10 @@ export function CommentItem({ comment, currentUserId, onDelete, isDeleting }: Co
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>キャンセル</AlertDialogCancel>
+              <AlertDialogCancel disabled={isDeleting}>キャンセル</AlertDialogCancel>
               <AlertDialogAction
                 onClick={() => onDelete(comment.id)}
+                loading={isDeleting}
                 className="bg-red-500 hover:bg-red-600 focus-visible:ring-red-600"
               >
                 削除する

--- a/frontend/components/settings/InviteCodeCard.tsx
+++ b/frontend/components/settings/InviteCodeCard.tsx
@@ -82,9 +82,10 @@ export function InviteCodeCard({ inviteCode, isAdmin, onRegenerated }: Props) {
                             </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
-                            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                            <AlertDialogCancel disabled={regenerating}>キャンセル</AlertDialogCancel>
                             <AlertDialogAction
                                 onClick={handleRegenerate}
+                                loading={regenerating}
                                 className="bg-indigo-600 hover:bg-indigo-700"
                             >
                                 再生成する

--- a/frontend/components/settings/MemberList.tsx
+++ b/frontend/components/settings/MemberList.tsx
@@ -139,10 +139,10 @@ export function MemberList({ members, currentUserId, isAdmin, onUpdated }: Props
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                        <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                        <AlertDialogCancel disabled={deleting}>キャンセル</AlertDialogCancel>
                         <AlertDialogAction
                             onClick={handleDelete}
-                            disabled={deleting}
+                            loading={deleting}
                             className="bg-red-500 hover:bg-red-600"
                         >
                             削除する

--- a/frontend/components/settings/MemberPasswordResetDialog.tsx
+++ b/frontend/components/settings/MemberPasswordResetDialog.tsx
@@ -122,7 +122,7 @@ export function MemberPasswordResetDialog({ member, open, onClose }: Props) {
                 </AlertDialogHeader>
                 {error && <p className="text-red-500 text-sm px-1">{error}</p>}
                 <AlertDialogFooter>
-                    <AlertDialogCancel onClick={handleClose}>キャンセル</AlertDialogCancel>
+                    <AlertDialogCancel onClick={handleClose} disabled={resetting}>キャンセル</AlertDialogCancel>
                     <AlertDialogAction
                         onClick={handleReset}
                         loading={resetting}


### PR DESCRIPTION
💡 何を: パスワード再発行、メンバー削除、招待コード再生成、コメント削除のダイアログにおいて、非同期処理中のキャンセル防止（`disabled`）とローディング表示（`loading`）を追加。
🎯 なぜ: 処理中に誤ってダイアログを閉じてしまうのを防ぎ、システム状態の不整合やユーザーの混乱を避けるため。また、処理中であることを明示し、安心感を提供するため。
📸 Before/After: （該当なし）
♿ アクセシビリティ: 処理中にキャンセルボタンが操作不可能になることで、キーボードやスクリーンリーダー利用者が誤って操作するのを防ぎます。

---
*PR created automatically by Jules for task [9812830430696475352](https://jules.google.com/task/9812830430696475352) started by @eburairu*