### PR TITLE
🎨 Palette: おむつタイプ選択ボタンのアクセシビリティ改善

### DIFF
--- a/frontend/components/diaper/DiaperForm.tsx
+++ b/frontend/components/diaper/DiaperForm.tsx
@@ -49,6 +49,7 @@ function DiaperTypeButton({ type, selectedType, onClick, icon, label }: DiaperTy
             type="button"
             onClick={onClick}
             aria-pressed={selectedType === type}
+            aria-label={`おむつの種類: ${label}`}
             className={cn(
                 "h-20 w-full flex flex-col items-center justify-center gap-1 rounded-xl border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 selectedType === type


### PR DESCRIPTION
💡 何を: DiaperForm のおむつタイプ選択ボタンに aria-label を追加
🎯 なぜ: スクリーンリーダーユーザーがボタンの役割（おむつの種類選択）を明確に理解できるようにするため
📸 Before/After: （視覚的な変更はなし）
♿ アクセシビリティ: aria-label によって操作の文脈を明示し、支援技術での読み上げを改善しました

---
*PR created automatically by Jules for task [8319975387611038297](https://jules.google.com/task/8319975387611038297) started by @eburairu*