### PR TITLE
🎨 Palette: 非同期操作時のダイアログキャンセルボタン無効化・ローディング表示追加

### DIFF
--- a/frontend/components/diary/DiaryDeleteDialog.tsx
+++ b/frontend/components/diary/DiaryDeleteDialog.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useState } from "react"
+
 import {
     AlertDialog,
     AlertDialogAction,
@@ -20,6 +22,8 @@ interface DiaryDeleteDialogProps {
 }
 
 export function DiaryDeleteDialog({ summary, open, onOpenChange, onConfirm }: DiaryDeleteDialogProps) {
+    const [isDeleting, setIsDeleting] = useState(false)
+
     const dateLabel = summary
         ? new Date(summary.summary_date + "T00:00:00").toLocaleDateString("ja-JP", {
               year: "numeric",
@@ -30,8 +34,13 @@ export function DiaryDeleteDialog({ summary, open, onOpenChange, onConfirm }: Di
 
     const handleConfirm = async () => {
         if (!summary) return
-        await onConfirm(summary.summary_date)
-        onOpenChange(false)
+        setIsDeleting(true)
+        try {
+            await onConfirm(summary.summary_date)
+            onOpenChange(false)
+        } finally {
+            setIsDeleting(false)
+        }
     }
 
     return (
@@ -44,10 +53,11 @@ export function DiaryDeleteDialog({ summary, open, onOpenChange, onConfirm }: Di
                     </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                    <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                    <AlertDialogCancel disabled={isDeleting}>キャンセル</AlertDialogCancel>
                     <AlertDialogAction
                         onClick={handleConfirm}
                         className="bg-red-500 hover:bg-red-600"
+                        loading={isDeleting}
                     >
                         削除
                     </AlertDialogAction>

--- a/frontend/components/records/CommentItem.tsx
+++ b/frontend/components/records/CommentItem.tsx
@@ -122,10 +122,11 @@ export function CommentItem({ comment, currentUserId, onDelete, isDeleting }: Co
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>キャンセル</AlertDialogCancel>
+              <AlertDialogCancel disabled={isDeleting}>キャンセル</AlertDialogCancel>
               <AlertDialogAction
                 onClick={() => onDelete(comment.id)}
                 className="bg-red-500 hover:bg-red-600 focus-visible:ring-red-600"
+                loading={isDeleting}
               >
                 削除する
               </AlertDialogAction>

--- a/frontend/components/settings/InviteCodeCard.tsx
+++ b/frontend/components/settings/InviteCodeCard.tsx
@@ -82,10 +82,11 @@ export function InviteCodeCard({ inviteCode, isAdmin, onRegenerated }: Props) {
                             </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
-                            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                            <AlertDialogCancel disabled={regenerating}>キャンセル</AlertDialogCancel>
                             <AlertDialogAction
                                 onClick={handleRegenerate}
                                 className="bg-indigo-600 hover:bg-indigo-700"
+                                loading={regenerating}
                             >
                                 再生成する
                             </AlertDialogAction>

--- a/frontend/components/settings/MemberPasswordResetDialog.tsx
+++ b/frontend/components/settings/MemberPasswordResetDialog.tsx
@@ -122,7 +122,7 @@ export function MemberPasswordResetDialog({ member, open, onClose }: Props) {
                 </AlertDialogHeader>
                 {error && <p className="text-red-500 text-sm px-1">{error}</p>}
                 <AlertDialogFooter>
-                    <AlertDialogCancel onClick={handleClose}>キャンセル</AlertDialogCancel>
+                    <AlertDialogCancel onClick={handleClose} disabled={resetting}>キャンセル</AlertDialogCancel>
                     <AlertDialogAction
                         onClick={handleReset}
                         loading={resetting}

--- a/test_ui.sh
+++ b/test_ui.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-cd frontend
-files=$(find components -type f -name "*.tsx")
-for f in $files; do
-    # Find button-like elements without aria-pressed when acting as toggle
-    grep -E "onClick=.*selected" $f | grep -v aria-pressed
-done


### PR DESCRIPTION
💡 何を: 
非同期操作（削除、再生成など）を伴う複数の確認ダイアログにおいて、キャンセルボタンの無効化（`disabled={loading}`）およびアクションボタンへのローディングスピナー（`loading={loading}`）表示を追加しました。
対象ファイル:
- `DiaryDeleteDialog.tsx`
- `InviteCodeCard.tsx`
- `CommentItem.tsx`
- `MemberPasswordResetDialog.tsx`

🎯 なぜ: 
削除や再生成などの処理中に、ユーザーが誤ってダイアログを閉じたり、重複して送信アクションを実行したりするのを防ぐためです。これにより、フィードバックの欠如による不安を軽減し、スムーズなインタラクションを提供します。

📸 Before/After:
（今回はUI状態の細かな変更のため添付画像はありませんが、Playwrightのスクリーンショットで検証済みです）

♿ アクセシビリティ: 
処理中にボタンを無効化することで、スクリーンリーダーやキーボード操作においても「現在処理中である」状態が正しく伝わり、予期せぬ操作によるエラーを防ぐことができます。

---
*PR created automatically by Jules for task [12989447476896282291](https://jules.google.com/task/12989447476896282291) started by @eburairu*