### PR TITLE
🧹 Tidy: 型定義の共通化と未使用インポートの削除

### DIFF
--- a/frontend/__tests__/diaperPoopFields.test.ts
+++ b/frontend/__tests__/diaperPoopFields.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { POOP_COLORS, POOP_AMOUNTS, POOP_CONSISTENCIES } from "@/constants/diaper"
+import { POOP_CONSISTENCIES } from "@/constants/diaper"
 import { resolvePoopField } from "@/lib/diaperPoopUtils"
 
 describe("POOP_CONSISTENCIES定数", () => {

--- a/frontend/components/settings/BabyDeleteDialog.tsx
+++ b/frontend/components/settings/BabyDeleteDialog.tsx
@@ -11,11 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { api } from "@/lib/api"
 import { useAsyncAction } from "@/hooks/useAsyncAction"
-
-interface Baby {
-    id: number
-    name: string
-}
+import { Baby } from "@/types/baby"
 
 interface Props {
     baby: Baby | null


### PR DESCRIPTION
💡 何を
- `frontend/__tests__/diaperPoopFields.test.ts` で発生していたESLintの未使用インポートの警告 (`POOP_COLORS`, `POOP_AMOUNTS`) を削除しました。
- `frontend/components/settings/BabyDeleteDialog.tsx` 内でローカルに定義されていた `interface Baby` を削除し、リポジトリ共通の `@/types/baby` からインポートするように変更しました。

🎯 なぜ
- 未使用コードを削除することで、コードベースのノイズを減らし、クリーンな状態を保つためです（ボーイスカウトの規則）。
- 型定義の重複は技術的負債の原因となるため、DRY原則に従い、単一の真実の情報源 (Single Source of Truth) を利用するようにするためです。

🛡️ 安全性
- ロジックやUIの変更は一切含んでいません。
- `pnpm lint` を実行し、該当の警告が解消されたことを確認しました。
- `pnpm test --run` および `pnpm build` が正常に通過することを確認済みです。

---
*PR created automatically by Jules for task [2608843941624170714](https://jules.google.com/task/2608843941624170714) started by @eburairu*