### PR TITLE
feat: 赤ちゃんごとにInstagramユーザー名を設定しリンクを表示

### DIFF
--- a/alembic/versions/p1q2r3s4_add_instagram_username_to_babies.py
+++ b/alembic/versions/p1q2r3s4_add_instagram_username_to_babies.py
@@ -1,0 +1,22 @@
+"""add instagram_username to babies
+
+Revision ID: p1q2r3s4
+Revises: o1p2q3r4
+Create Date: 2026-04-05
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'p1q2r3s4'
+down_revision = 'o1p2q3r4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('babies', sa.Column('instagram_username', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('babies', 'instagram_username')

--- a/app/models/baby.py
+++ b/app/models/baby.py
@@ -16,6 +16,7 @@ class Baby(Base, SoftDeleteMixin):
     characteristics = Column(String, nullable=True)  # AIが生成・更新する「赤ちゃんの特徴・傾向」
     feeding_threshold_minutes = Column(Integer, nullable=True)
     diaper_threshold_minutes = Column(Integer, nullable=True)
+    instagram_username = Column(String, nullable=True)
 
     family = relationship("Family", backref="babies")
 

--- a/app/routers/baby.py
+++ b/app/routers/baby.py
@@ -110,6 +110,7 @@ def create_baby(baby_in: BabyCreate, db: Session = Depends(get_db), current_user
         characteristics=baby_in.characteristics,
         feeding_threshold_minutes=baby_in.feeding_threshold_minutes,
         diaper_threshold_minutes=baby_in.diaper_threshold_minutes,
+        instagram_username=baby_in.instagram_username,
     )
     db.add(new_baby)
     db.commit()

--- a/app/schemas/baby.py
+++ b/app/schemas/baby.py
@@ -12,6 +12,7 @@ class BabyBase(BaseModel):
     characteristics: Optional[str] = Field(None, max_length=1000)
     feeding_threshold_minutes: Optional[int] = None
     diaper_threshold_minutes: Optional[int] = None
+    instagram_username: Optional[str] = Field(None, max_length=30)
 
 
 class BabyCreate(BabyBase):
@@ -26,6 +27,7 @@ class BabyUpdate(BaseModel):
     characteristics: Optional[str] = Field(None, max_length=1000)
     feeding_threshold_minutes: Optional[int] = None
     diaper_threshold_minutes: Optional[int] = None
+    instagram_username: Optional[str] = Field(None, max_length=30)
 
     @field_validator('name')
     @classmethod

--- a/frontend/components/settings/AddBabyDialog.tsx
+++ b/frontend/components/settings/AddBabyDialog.tsx
@@ -33,6 +33,7 @@ export function AddBabyDialog({ open, onClose, onAdded }: Props) {
                     characteristics: data.characteristics || null,
                     feeding_threshold_minutes: data.feeding_threshold_minutes,
                     diaper_threshold_minutes: data.diaper_threshold_minutes,
+                    instagram_username: data.instagram_username || null,
                 })
                 onAdded()
                 handleClose()

--- a/frontend/components/settings/BabyCard.tsx
+++ b/frontend/components/settings/BabyCard.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { Button } from "@/components/ui/button"
-import { Baby as BabyIcon, Pencil, Trash2 } from "lucide-react"
+import { Baby as BabyIcon, Pencil, Trash2, ExternalLink } from "lucide-react"
 import { calcAge } from "@/lib/ageUtils"
 import { SettingsCard } from "./SettingsCard"
 
@@ -34,6 +34,17 @@ export function BabyCard({ baby, isAdmin, onEdit, onDelete }: Props) {
                     )}
                     {baby.due_date && (
                         <p className="text-xs text-gray-500 dark:text-zinc-500">予定日: {formatDate(baby.due_date)}</p>
+                    )}
+                    {baby.instagram_username && (
+                        <a
+                            href={`https://www.instagram.com/${baby.instagram_username}/`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-xs text-pink-500 dark:text-pink-400 hover:underline mt-1"
+                        >
+                            <ExternalLink className="w-3 h-3" />
+                            @{baby.instagram_username}
+                        </a>
                     )}
                     {baby.characteristics && (
                         <div className="mt-2 pt-2 border-t border-gray-100 dark:border-zinc-800">

--- a/frontend/components/settings/BabyEditDialog.tsx
+++ b/frontend/components/settings/BabyEditDialog.tsx
@@ -36,6 +36,7 @@ export function BabyEditDialog({ baby, open, onClose, onUpdated }: Props) {
                     characteristics: data.characteristics || null,
                     feeding_threshold_minutes: data.feeding_threshold_minutes,
                     diaper_threshold_minutes: data.diaper_threshold_minutes,
+                    instagram_username: data.instagram_username || null,
                 })
                 onUpdated()
                 handleClose()
@@ -56,6 +57,7 @@ export function BabyEditDialog({ baby, open, onClose, onUpdated }: Props) {
         characteristics: baby.characteristics ?? "",
         feeding_threshold_minutes: baby.feeding_threshold_minutes ?? null,
         diaper_threshold_minutes: baby.diaper_threshold_minutes ?? null,
+        instagram_username: baby.instagram_username ?? "",
     } : undefined
 
     return (

--- a/frontend/components/settings/BabyForm.tsx
+++ b/frontend/components/settings/BabyForm.tsx
@@ -27,6 +27,7 @@ const babySchema = z.object({
     characteristics: z.string().optional(),
     feeding_threshold_minutes: z.preprocess((val) => (val === "" ? null : val), z.coerce.number().min(0).nullable()).optional() as z.ZodType<number | null | undefined>,
     diaper_threshold_minutes: z.preprocess((val) => (val === "" ? null : val), z.coerce.number().min(0).nullable()).optional() as z.ZodType<number | null | undefined>,
+    instagram_username: z.string().max(30).optional(),
 })
 
 export type BabyFormData = z.infer<typeof babySchema>
@@ -58,6 +59,7 @@ export function BabyForm({
             characteristics: "",
             feeding_threshold_minutes: null,
             diaper_threshold_minutes: null,
+            instagram_username: "",
             ...defaultValues,
         },
         values: defaultValues ? {
@@ -68,6 +70,7 @@ export function BabyForm({
             characteristics: defaultValues.characteristics || "",
             feeding_threshold_minutes: defaultValues.feeding_threshold_minutes ?? null,
             diaper_threshold_minutes: defaultValues.diaper_threshold_minutes ?? null,
+            instagram_username: defaultValues.instagram_username || "",
         } : undefined,
     })
 
@@ -183,6 +186,26 @@ export function BabyForm({
                                     {...field}
                                 />
                             </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+
+                <FormField
+                    control={form.control}
+                    name="instagram_username"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Instagramアカウント名</FormLabel>
+                            <FormControl>
+                                <div className="flex items-center gap-1">
+                                    <span className="text-gray-400 text-sm select-none">@</span>
+                                    <Input placeholder="username" {...field} />
+                                </div>
+                            </FormControl>
+                            <FormDescription>
+                                設定するとプロフィールページにInstagramへのリンクが表示されます。
+                            </FormDescription>
                             <FormMessage />
                         </FormItem>
                     )}

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -441,6 +441,18 @@
               }
             ]
           },
+          "instagram_username": {
+            "anyOf": [
+              {
+                "maxLength": 30,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instagram Username"
+          },
           "name": {
             "maxLength": 100,
             "title": "Name",
@@ -599,6 +611,18 @@
             "title": "Id",
             "type": "integer"
           },
+          "instagram_username": {
+            "anyOf": [
+              {
+                "maxLength": 30,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instagram Username"
+          },
           "name": {
             "maxLength": 100,
             "title": "Name",
@@ -683,6 +707,18 @@
                 "type": "null"
               }
             ]
+          },
+          "instagram_username": {
+            "anyOf": [
+              {
+                "maxLength": 30,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instagram Username"
           },
           "name": {
             "anyOf": [

--- a/frontend/types/generated/api.d.ts
+++ b/frontend/types/generated/api.d.ts
@@ -1453,6 +1453,8 @@ export interface components {
             /** Feeding Threshold Minutes */
             feeding_threshold_minutes?: number | null;
             gender?: components["schemas"]["Gender"] | null;
+            /** Instagram Username */
+            instagram_username?: string | null;
             /** Name */
             name: string;
         };
@@ -1508,6 +1510,8 @@ export interface components {
             gender?: components["schemas"]["Gender"] | null;
             /** Id */
             id: number;
+            /** Instagram Username */
+            instagram_username?: string | null;
             /** Name */
             name: string;
         };
@@ -1524,6 +1528,8 @@ export interface components {
             /** Feeding Threshold Minutes */
             feeding_threshold_minutes?: number | null;
             gender?: components["schemas"]["Gender"] | null;
+            /** Instagram Username */
+            instagram_username?: string | null;
             /** Name */
             name?: string | null;
         };


### PR DESCRIPTION
## 概要

- 赤ちゃんごとにInstagramアカウント名（ユーザー名）を設定できるようにする
- 設定すると赤ちゃん管理画面のカードにInstagramプロフィールへのリンクが表示される

## 変更内容

- **DB**: `babies` テーブルに `instagram_username` カラム追加（マイグレーション `p1q2r3s4`）
- **Backend**: `BabyBase` / `BabyUpdate` スキーマ、`Baby` モデル、`create_baby` ルーターに `instagram_username` を追加
- **Frontend**: `BabyForm` にアカウント名入力フィールドを追加、`BabyCard` にプロフィールリンクを表示、`BabyEditDialog` / `AddBabyDialog` でフィールドを送受信

## テスト手順

- [ ] 赤ちゃん追加ダイアログで Instagram アカウント名を入力し保存できる
- [ ] 赤ちゃん編集ダイアログで変更・クリアができる
- [ ] 設定後、BabyCard に `@username` のリンクが表示される
- [ ] リンクをタップすると Instagram プロフィールが別タブで開く
- [ ] 未設定の場合リンクは表示されない