### PR TITLE
🛡️ Sentinel: [HIGH] Fix Authorization Bypass in Comments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Fix Authorization Bypass (IDOR) in Comments Endpoints
+**脆弱性:** コメントの作成および削除エンドポイント（`app/routers/comments.py`）において、ユーザーの権限（`UserRole.ADMIN`）を確認する際、`db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()` のように、`user_id` のみで検索していました。
+**学び:** ユーザーが複数のファミリーに所属可能なシステム設計において、コンテキスト（操作対象のレコードが属する `family_id`）を特定せずに `user_id` のみで権限レコードを引くと、偶然別のファミリーで保持している管理者権限が評価されてしまい、権限のないデータへの操作を許してしまう（認可バイパス/IDOR）という罠が存在しました。
+**予防:** 権限や所属を確認するクエリを発行する際は、必ず `user_id` だけでなく、その操作が実行されるコンテキストである対象リソースのID（この場合は `baby.family_id`）もクエリフィルタに含めるようにします。また、SQLAlchemyの `.filter()` に動的な条件を渡す際、条件結果が `None` になると `ArgumentError` になるため、クエリオブジェクトに対して `if` 文を用いて条件的にフィルタを追加するパターンを使用します。

--- a/app/routers/comments.py
+++ b/app/routers/comments.py
@@ -149,7 +149,10 @@ def create_record_comment(
             category="comment",
         )
 
-    family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
+    family_user_query = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id)
+    if baby:
+        family_user_query = family_user_query.filter(FamilyUser.family_id == baby.family_id)
+    family_user = family_user_query.first()
     return CommentResponse(
         id=new_comment.id,
         user_id=new_comment.user_id,
@@ -173,9 +176,12 @@ def delete_comment(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comment not found")
 
     # コメントに紐づく baby へのアクセス権を検証（ファミリー間の分離を保証）
-    verify_baby_access(db, comment.baby_id, current_user.id)
+    baby = verify_baby_access(db, comment.baby_id, current_user.id)
 
-    family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
+    family_user = db.query(FamilyUser).filter(
+        FamilyUser.user_id == current_user.id,
+        FamilyUser.family_id == baby.family_id
+    ).first()
     if comment.user_id != current_user.id and (family_user is None or family_user.role != UserRole.ADMIN):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to delete this comment")
 


### PR DESCRIPTION
🚨 深刻度: HIGH
💡 脆弱性: コメントの作成および削除エンドポイントにおいて、現在のユーザーの権限（`FamilyUser.role`）を確認する際に、対象のレコード（赤ちゃん）が属する特定の `family_id` での絞り込みが行われておらず、`user_id` のみで検索していました。
🎯 影響: ユーザーが複数のファミリーに所属している場合、別のファミリーで管理者（ADMIN）権限を持っていれば、その権限が誤って評価され、権限を持たないはずのファミリーのコメントを削除できてしまう（認可バイパス）危険性がありました。
🔧 修正: `FamilyUser` のクエリに対象レコードの `family_id` フィルタを追加し、コンテキストに沿った正しい権限チェックを行うように修正しました。
✅ 検証: 修正後のコードを構文チェックし、テストの実行によって変更がリグレッションを引き起こさないことを確認しました。また不要なテストスクリプトを削除しました。

---
*PR created automatically by Jules for task [9215826297825832910](https://jules.google.com/task/9215826297825832910) started by @eburairu*