### PR TITLE
🧹 Tidy: RecordCommentDialogのResponsiveModal共通化

### DIFF
--- a/frontend/components/records/RecordCommentDialog.tsx
+++ b/frontend/components/records/RecordCommentDialog.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { ResponsiveModal } from "@/components/ui/responsive-modal";
 import { CommentSection } from "./CommentSection";
 
 interface RecordCommentDialogProps {
@@ -24,41 +22,19 @@ export function RecordCommentDialog({
   currentUserId,
   onCommentChange,
 }: RecordCommentDialogProps) {
-  const isMobile = useIsMobile();
-
-  if (isMobile) {
-    return (
-      <Drawer open={open} onOpenChange={onOpenChange}>
-        <DrawerContent>
-          <DrawerHeader>
-            <DrawerTitle>{title}</DrawerTitle>
-          </DrawerHeader>
-          <div className="overflow-y-auto px-4 pb-6">
-            <CommentSection
-              recordType={recordType}
-              recordId={recordId}
-              currentUserId={currentUserId}
-              onCommentChange={onCommentChange}
-            />
-          </div>
-        </DrawerContent>
-      </Drawer>
-    );
-  }
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md dark:bg-zinc-900 dark:border-zinc-800 max-h-[85dvh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="text-base">{title}</DialogTitle>
-        </DialogHeader>
-        <CommentSection
-          recordType={recordType}
-          recordId={recordId}
-          currentUserId={currentUserId}
-          onCommentChange={onCommentChange}
-        />
-      </DialogContent>
-    </Dialog>
+    <ResponsiveModal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      contentClassName="pb-6"
+    >
+      <CommentSection
+        recordType={recordType}
+        recordId={recordId}
+        currentUserId={currentUserId}
+        onCommentChange={onCommentChange}
+      />
+    </ResponsiveModal>
   );
 }


### PR DESCRIPTION
💡 何を:
- `frontend/components/records/RecordCommentDialog.tsx` において、`useIsMobile` を用いた `Drawer` と `Dialog` の手動による条件分岐を削除し、共通コンポーネントである `ResponsiveModal` を使用するようにリファクタリングしました。

🎯 なぜ:
- メモリのガイドラインに従い、DRY原則を適用し、アプリ全体で一貫したレスポンシブなUIを保証するためです。コードの重複がなくなり、保守性が向上します。

🛡️ 安全性:
- `pnpm lint`, `pnpm test`, `pnpm build` を実行し、既存の機能が壊れていないことを確認しました。
- UIの構造自体は `ResponsiveModal` の内部で処理されるため、動作は変更されません。

---
*PR created automatically by Jules for task [469792865921595358](https://jules.google.com/task/469792865921595358) started by @eburairu*