### PR TITLE
🧹 Tidy: useBaseRecordFormを利用するコンポーネントから冗長なtry/catchを削除

### DIFF
--- a/frontend/components/diaper/DiaperForm.tsx
+++ b/frontend/components/diaper/DiaperForm.tsx
@@ -123,34 +123,29 @@ export function DiaperForm({ babyId, initialData, defaultDiaperType, onSuccess, 
     })
 
     const onSubmit = async (values: DiaperFormValues) => {
-        try {
-            await submitRecord<DiaperCreate, Diaper | undefined>(values, (vals) => ({
-                baby_id: Number(babyId),
-                diaper_type: vals.diaper_type,
-                change_time: new Date(vals.change_time).toISOString(),
-                notes: vals.notes?.trim() || null,
-                ...buildPoopPayload(vals),
-            }),
-            isEditing && initialData ? async (payload: DiaperCreate) => {
-                const updatePayload: DiaperUpdate = {
-                    diaper_type: payload.diaper_type,
-                    change_time: payload.change_time,
-                    notes: payload.notes,
-                    poop_color: payload.poop_color,
-                    poop_consistency: payload.poop_consistency,
-                    poop_amount: payload.poop_amount,
-                }
+        await submitRecord<DiaperCreate, Diaper | undefined>(values, (vals) => ({
+            baby_id: Number(babyId),
+            diaper_type: vals.diaper_type,
+            change_time: new Date(vals.change_time).toISOString(),
+            notes: vals.notes?.trim() || null,
+            ...buildPoopPayload(vals),
+        }),
+        isEditing && initialData ? async (payload: DiaperCreate) => {
+            const updatePayload: DiaperUpdate = {
+                diaper_type: payload.diaper_type,
+                change_time: payload.change_time,
+                notes: payload.notes,
+                poop_color: payload.poop_color,
+                poop_consistency: payload.poop_consistency,
+                poop_amount: payload.poop_amount,
+            }
 
-                if (onUpdate) {
-                    return await onUpdate(initialData.id, updatePayload)
-                } else {
-                    return await api.put<Diaper>(`/diapers/${initialData.id}`, updatePayload)
-                }
-            } : undefined)
-        } catch (e) {
-            // Error is handled by the hook
-            console.error(e)
-        }
+            if (onUpdate) {
+                return await onUpdate(initialData.id, updatePayload)
+            } else {
+                return await api.put<Diaper>(`/diapers/${initialData.id}`, updatePayload)
+            }
+        } : undefined)
     }
 
     return (

--- a/frontend/components/feeding/feeding-form.tsx
+++ b/frontend/components/feeding/feeding-form.tsx
@@ -137,53 +137,48 @@ export function FeedingForm({ babyId, onAdd, onUpdate, initialData, onSuccess, l
     })
 
     const onSubmit = useCallback(async (values: FeedingFormValues) => {
-        try {
-            if (isEditing && initialData && onUpdate) {
-                // Update case
-                await submitRecord(
-                    values,
-                    (vals) => buildFeedingPayload({
-                        babyId,
-                        values: vals,
-                        activeTab,
-                        feedingCompletion,
-                        bottleContentType: vals.bottle_content_type ?? null,
-                        burped
-                    }),
-                    (payload) => onUpdate(initialData.id, payload)
-                )
-            } else if (onAdd) {
-                // Create case with custom onAdd (needed for triggerFeedback etc)
-                await submitRecord(
-                    values,
-                    (vals) => buildFeedingPayload({
-                        babyId,
-                        values: vals,
-                        activeTab,
-                        feedingCompletion,
-                        bottleContentType: vals.bottle_content_type ?? null,
-                        burped,
-                        reset_timer: true
-                    }),
-                    onAdd
-                )
-            } else {
-                // Default create case (standard POST)
-                await submitRecord(values, (vals) => {
-                    return buildFeedingPayload({
-                        babyId,
-                        values: vals,
-                        activeTab,
-                        feedingCompletion,
-                        bottleContentType: vals.bottle_content_type ?? null,
-                        burped,
-                        reset_timer: true
-                    })
+        if (isEditing && initialData && onUpdate) {
+            // Update case
+            await submitRecord(
+                values,
+                (vals) => buildFeedingPayload({
+                    babyId,
+                    values: vals,
+                    activeTab,
+                    feedingCompletion,
+                    bottleContentType: vals.bottle_content_type ?? null,
+                    burped
+                }),
+                (payload) => onUpdate(initialData.id, payload)
+            )
+        } else if (onAdd) {
+            // Create case with custom onAdd (needed for triggerFeedback etc)
+            await submitRecord(
+                values,
+                (vals) => buildFeedingPayload({
+                    babyId,
+                    values: vals,
+                    activeTab,
+                    feedingCompletion,
+                    bottleContentType: vals.bottle_content_type ?? null,
+                    burped,
+                    reset_timer: true
+                }),
+                onAdd
+            )
+        } else {
+            // Default create case (standard POST)
+            await submitRecord(values, (vals) => {
+                return buildFeedingPayload({
+                    babyId,
+                    values: vals,
+                    activeTab,
+                    feedingCompletion,
+                    bottleContentType: vals.bottle_content_type ?? null,
+                    burped,
+                    reset_timer: true
                 })
-            }
-        } catch (error) {
-            console.error(error)
-            // Error handling is mostly done by the hook, but we catch to avoid unhandled rejections
+            })
         }
     }, [activeTab, babyId, burped, feedingCompletion, isEditing, initialData, onAdd, onUpdate, submitRecord])
 

--- a/frontend/components/temperature/TemperatureForm.tsx
+++ b/frontend/components/temperature/TemperatureForm.tsx
@@ -70,38 +70,34 @@ export function TemperatureForm({ babyId, initialData, onSuccess, onUpdate }: Pr
     })
 
     const onSubmit = async (values: TemperatureFormValues) => {
-        try {
-            await submitRecord<TemperatureCreate, Temperature | undefined>(
-                values,
-                (vals) => ({
-                    baby_id: Number(babyId),
-                    measured_at: new Date(vals.measured_at).toISOString(),
-                    temperature: parseFloat(vals.temperature),
-                    method: vals.method,
-                    notes: vals.notes?.trim() || null,
-                }),
-                isEditing && initialData
-                    ? async (payload: TemperatureCreate) => {
-                          const updatePayload: TemperatureUpdate = {
-                              measured_at: payload.measured_at,
-                              temperature: payload.temperature,
-                              method: payload.method,
-                              notes: payload.notes,
-                          }
-                          if (onUpdate) {
-                              return await onUpdate(initialData.id, updatePayload)
-                          } else {
-                              return await api.put<Temperature>(
-                                  `/temperatures/${initialData.id}`,
-                                  updatePayload
-                              )
-                          }
+        await submitRecord<TemperatureCreate, Temperature | undefined>(
+            values,
+            (vals) => ({
+                baby_id: Number(babyId),
+                measured_at: new Date(vals.measured_at).toISOString(),
+                temperature: parseFloat(vals.temperature),
+                method: vals.method,
+                notes: vals.notes?.trim() || null,
+            }),
+            isEditing && initialData
+                ? async (payload: TemperatureCreate) => {
+                      const updatePayload: TemperatureUpdate = {
+                          measured_at: payload.measured_at,
+                          temperature: payload.temperature,
+                          method: payload.method,
+                          notes: payload.notes,
                       }
-                    : undefined
-            )
-        } catch (e) {
-            console.error(e)
-        }
+                      if (onUpdate) {
+                          return await onUpdate(initialData.id, updatePayload)
+                      } else {
+                          return await api.put<Temperature>(
+                              `/temperatures/${initialData.id}`,
+                              updatePayload
+                          )
+                      }
+                  }
+                : undefined
+        )
     }
 
     return (


### PR DESCRIPTION
💡 何を:
`useBaseRecordForm` カスタムフックを利用してレコードを保存する以下のコンポーネントの `onSubmit` ハンドラから、冗長な `try/catch` ブロックを削除しました。
- `DiaperForm`
- `TemperatureForm`
- `FeedingForm` (feeding-form)

🎯 なぜ:
`useBaseRecordForm` 内の `submitRecord` は、既に内部で例外をキャッチし、適切にエラー状態（`error` state）の設定やトースト通知を行っています。
コンポーネント側で再度 `try/catch` を行うことは冗長であり、DRY（Don't Repeat Yourself）原則に反するため、削除して可読性を向上させました。

🛡️ 安全性:
- TypeScriptエラーやLintエラーが発生しないことを `pnpm lint` で確認しました。
- 既存のテストがパスすることを `pnpm test` で確認しました。
- 正常にビルドできることを `pnpm build` で確認しました。

---
*PR created automatically by Jules for task [3191846336222033005](https://jules.google.com/task/3191846336222033005) started by @eburairu*