### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in comments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-15 - [CRITICAL] Fix authorization bypass in comments routing
+**脆弱性:** `FamilyUser.role` を確認する際に `user_id` だけでフィルタリングしていたため、複数家族に所属するユーザーが別の家族の権限を流用できる状態になっていた。
+**学び:** 権限チェックは常に `user_id` と `family_id` の両方のコンテキストを組み合わせて検証する必要がある。また、SQLAlchemy の `filter` 内での条件式 `A == B if C else None` は演算子優先順位のバグ（`(A == B) if C else None`）を引き起こすため危険。
+**予防:** `family_id` に基づく認可を徹底する。また、SQLAlchemy に渡す変数はクエリ前に事前計算して格納するか、括弧で明示的に優先順位をつける。

--- a/app/routers/comments.py
+++ b/app/routers/comments.py
@@ -149,7 +149,11 @@ def create_record_comment(
             category="comment",
         )
 
-    family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
+    target_family_id = baby.family_id if baby else None
+    family_user = db.query(FamilyUser).filter(
+        FamilyUser.user_id == current_user.id,
+        FamilyUser.family_id == target_family_id
+    ).first()
     return CommentResponse(
         id=new_comment.id,
         user_id=new_comment.user_id,
@@ -175,7 +179,12 @@ def delete_comment(
     # コメントに紐づく baby へのアクセス権を検証（ファミリー間の分離を保証）
     verify_baby_access(db, comment.baby_id, current_user.id)
 
-    family_user = db.query(FamilyUser).filter(FamilyUser.user_id == current_user.id).first()
+    baby = db.query(Baby).filter(Baby.id == comment.baby_id).first()
+    target_family_id = baby.family_id if baby else None
+    family_user = db.query(FamilyUser).filter(
+        FamilyUser.user_id == current_user.id,
+        FamilyUser.family_id == target_family_id
+    ).first()
     if comment.user_id != current_user.id and (family_user is None or family_user.role != UserRole.ADMIN):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to delete this comment")
 


### PR DESCRIPTION
🚨 深刻度: HIGH
💡 脆弱性: コメントの作成と削除のエンドポイント（`create_record_comment`、`delete_comment`）において、`FamilyUser` のロールチェックが `user_id` のみで行われており、`family_id` のコンテキストが考慮されていませんでした。
🎯 影響: 複数の家族に所属しているユーザーが、別の家族での管理者権限を利用して、権限のない家族のコメントを削除したり、誤ったロール情報がレスポンスに含まれる可能性がありました。
🔧 修正: `FamilyUser` のクエリにおいて、対象のコメント（または記録）が属する `baby.family_id` も条件に含めるように修正しました。また、SQLAlchemy に渡す変数をクエリ前に事前計算して演算子優先順位のバグを回避しました。
✅ 検証: コードレビューおよび単体テストで修正を確認しました。

---
*PR created automatically by Jules for task [2564737645543110224](https://jules.google.com/task/2564737645543110224) started by @eburairu*