### PR TITLE
🧹 Tidy: RecordCommentDialogでResponsiveModalを使用するようリファクタリング

### DIFF
--- a/frontend/components/records/RecordCommentDialog.tsx
+++ b/frontend/components/records/RecordCommentDialog.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { ResponsiveModal } from "@/components/ui/responsive-modal";
 import { CommentSection } from "./CommentSection";
 
 interface RecordCommentDialogProps {
@@ -24,41 +22,18 @@ export function RecordCommentDialog({
   currentUserId,
   onCommentChange,
 }: RecordCommentDialogProps) {
-  const isMobile = useIsMobile();
-
-  if (isMobile) {
-    return (
-      <Drawer open={open} onOpenChange={onOpenChange}>
-        <DrawerContent>
-          <DrawerHeader>
-            <DrawerTitle>{title}</DrawerTitle>
-          </DrawerHeader>
-          <div className="overflow-y-auto px-4 pb-6">
-            <CommentSection
-              recordType={recordType}
-              recordId={recordId}
-              currentUserId={currentUserId}
-              onCommentChange={onCommentChange}
-            />
-          </div>
-        </DrawerContent>
-      </Drawer>
-    );
-  }
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md dark:bg-zinc-900 dark:border-zinc-800 max-h-[85dvh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="text-base">{title}</DialogTitle>
-        </DialogHeader>
-        <CommentSection
-          recordType={recordType}
-          recordId={recordId}
-          currentUserId={currentUserId}
-          onCommentChange={onCommentChange}
-        />
-      </DialogContent>
-    </Dialog>
+    <ResponsiveModal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+    >
+      <CommentSection
+        recordType={recordType}
+        recordId={recordId}
+        currentUserId={currentUserId}
+        onCommentChange={onCommentChange}
+      />
+    </ResponsiveModal>
   );
 }


### PR DESCRIPTION
💡 何を
`frontend/components/records/RecordCommentDialog.tsx` 内の `useIsMobile` を用いた `Drawer` (モバイル向け) と `Dialog` (デスクトップ向け) の手動による条件分岐のロジックを削除し、一元化された共通コンポーネントである `ResponsiveModal` を使用するようにリファクタリングを行いました。

🎯 なぜ
DRY原則に従い、コードベース全体の可読性と保守性を向上させるためです。冗長なUIの条件分岐ロジックを排除することで、コンポーネントを簡潔に保ちつつ、アプリ全体で一貫したレスポンシブなUI体験を保証することができます。また、メモリ内にも記録されているルール（「avoid manually implementing conditional Drawer and Dialog component logic using the useIsMobile hook. Instead, use the centralized ResponsiveModal component」）に準拠するための変更です。

🛡️ 安全性
`ResponsiveModal` は、元々の `Drawer` と `Dialog` の振る舞いを内部でカプセル化しているため、UIの見た目やユーザー体験に影響を与えません。修正後に `pnpm lint`、`pnpm test --run`、および `pnpm build` を実行し、静的解析・テスト・ビルドのすべてが正常に通ることで、既存機能が破壊されていないことを確認しました。

---
*PR created automatically by Jules for task [165660037106277530](https://jules.google.com/task/165660037106277530) started by @eburairu*